### PR TITLE
Fix CLI React Plugin bug to allow hook generation when there are two similar function names and one contains underscore

### DIFF
--- a/.changeset/few-icons-pump.md
+++ b/.changeset/few-icons-pump.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/cli': minor
+---
+
+Fixed react plugin bug which would throw error when there were identical function names - one starting with an underscore and one without

--- a/packages/cli/src/plugins/react.test.ts
+++ b/packages/cli/src/plugins/react.test.ts
@@ -98,5 +98,41 @@ describe('react', () => {
         format(`${imports}\n\n${content}`),
       ).resolves.toMatchSnapshot()
     })
+
+    it('throws when function names in a contract are non unique', async () => {
+      await expect(
+        react().run({
+          contracts: [
+            {
+              name: 'foo',
+              abi: [
+                {
+                  type: 'function',
+                  name: 'totalSupply',
+                  stateMutability: 'view',
+                  inputs: [],
+                  outputs: [{ type: 'uint256' }],
+                },
+                {
+                  type: 'function',
+                  name: '-totalSupply',
+                  stateMutability: 'view',
+                  inputs: [],
+                  outputs: [{ type: 'uint256' }],
+                },
+              ],
+              content: '',
+              meta: {
+                abiName: 'fooAbi',
+              },
+            },
+          ],
+          isTypeScript: true,
+          outputs: [],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Hook name \\"useFooTotalSupply\\" must be unique for contract \\"foo\\"."`,
+      )
+    })
   })
 })

--- a/packages/cli/src/plugins/react.ts
+++ b/packages/cli/src/plugins/react.ts
@@ -1,4 +1,4 @@
-import { pascalCase } from 'change-case'
+import { pascalCase as originalPascalCase } from 'change-case'
 import dedent from 'dedent'
 
 import type { Plugin } from '../config'
@@ -59,6 +59,9 @@ type ReactConfig = {
 type ReactResult = RequiredBy<Plugin, 'run'>
 
 export function react(config: ReactConfig = {}): ReactResult {
+  const pascalCase = (input: string) =>
+    originalPascalCase(input, { stripRegexp: /[^A-Z0-9_]/gi })
+
   const hooks = {
     useContractEvent: true,
     useContractItemEvent: true,


### PR DESCRIPTION
## Description

fixes #2297

cli react plugin currently fails to generate hooks when there are functions with the same name, but one begins with an underscore - eg totalSupply and _totalSupply.

The default behavior of the change-case package is to strip all non letters/numbers.

This PR extends the [default stripRegexp options](https://github.com/blakeembrey/change-case/blob/master/README.md#options) to ignore underscores.

Also included a test case to ensure it still throws if identical function names are found after pascal casing (this will only occur if function names are the same after stripping a symbol as [the loop already continues if there are two identical names](https://github.com/wagmi-dev/wagmi/blob/7b47ac330810d67be0215ae541951b1990d25ff0/packages/cli/src/plugins/react.ts#L211)). One function is named ``totalSupply`` and the other ``-totalSupply`` - although a real ABI will never contain a hyphen, this was required to demonstrate the test case.

## Additional Information

- [ x ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
