### PR TITLE
Fix switchChain not resolve when input chainId is the same as connected chainId

### DIFF
--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -205,15 +205,18 @@ export class InjectedConnector extends Connector<
     try {
       await Promise.all([
         provider.request({
-          method: 'wallet_switchEthereumChain',
+          method: "wallet_switchEthereumChain",
           params: [{ chainId: id }],
         }),
-        new Promise<void>((res) =>
-          this.on('change', ({ chain }) => {
-            if (chain?.id === chainId) res()
-          }),
-        ),
-      ])
+        new Promise<void>((res) => {
+          this.getChainId().then((currentChainId) => {
+            if (currentChainId === chainId) res();
+          });
+          this.on("change", ({ chain }) => {
+            if (chain?.id === chainId) res();
+          });
+        }),
+      ]);
       return (
         this.chains.find((x) => x.id === chainId) ?? {
           id: chainId,


### PR DESCRIPTION
## Description

The switchChain function won't resolve if the input chainId is the same as the connected chainId.

**Root cause**: the second `Promise` in`Promise.all` will only resolve on 'change' event, but if the chainId is the same as current chainId, the 'change' event won't trigger, so the promise keeps `pending` status
```js
await Promise.all([
  provider.request({
    method: "wallet_switchEthereumChain",
    params: [{ chainId: id }],
  }),
  new Promise<void>((res) =>
    this.on("change", ({ chain }) => { // 'change' event won't trigger when input chainId is the same as current chainId
      if (chain?.id === chainId) res();
    }),
  ),
]);
```
**Solution**:  check if the currentChainId is the same as input chainId at the same time

In a released product, it should not allow a user to call switchChain if the chainId does not change. But when developing, the unresolved promise may cause confusion and may be difficult to track.

## Additional Information

- [✅] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
