### PR TITLE
fix: storage in private browsing mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -5,7 +5,7 @@ import { createStore } from 'zustand/vanilla'
 import type { Connector, ConnectorData } from './connectors'
 import { InjectedConnector } from './connectors'
 import type { ClientStorage } from './storage'
-import { createStorage, noopStorage } from './storage'
+import { createStorage, selectStorage } from './storage'
 import type { PublicClient, WebSocketPublicClient } from './types'
 
 export type CreateConfigParameters<
@@ -82,8 +82,7 @@ export class Config<
     connectors = [new InjectedConnector()],
     publicClient,
     storage = createStorage({
-      storage:
-        typeof window !== 'undefined' ? window.localStorage : noopStorage,
+      storage: selectStorage(),
     }),
     logger = {
       warn: console.warn,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -136,7 +136,7 @@ export {
   SwitchChainNotSupportedError,
 } from './errors'
 
-export { createStorage, noopStorage } from './storage'
+export { createStorage, noopStorage, selectStorage } from './storage'
 export type { ClientStorage as Storage } from './storage'
 
 export type {

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -14,6 +14,16 @@ export const noopStorage: BaseStorage = {
   removeItem: (_key) => null,
 }
 
+export function selectStorage(): BaseStorage {
+  try {
+    return typeof window !== 'undefined' && window.localStorage
+      ? window.localStorage
+      : noopStorage
+  } catch {
+    return noopStorage
+  }
+}
+
 export function createStorage({
   deserialize = deserialize_,
   key: prefix = 'wagmi',

--- a/packages/react/src/config.ts
+++ b/packages/react/src/config.ts
@@ -14,7 +14,7 @@ import type {
 import {
   createConfig as createCoreConfig,
   createStorage,
-  noopStorage,
+  selectStorage,
 } from '@wagmi/core'
 
 export type CreateConfigParameters<
@@ -43,10 +43,7 @@ export function createConfig<
     },
   }),
   storage = createStorage({
-    storage:
-      typeof window !== 'undefined' && window.localStorage
-        ? window.localStorage
-        : noopStorage,
+    storage: selectStorage(),
   }),
   persister = typeof window !== 'undefined'
     ? createSyncStoragePersister({


### PR DESCRIPTION
## Description

Browsing in incognito mode `SecurityError` exception can be thrown when accessing window.localStorage. This is causing `createClient` function to fail.
Here is the links about this error:

- [https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/)](https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/)
- [https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni](https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni)

This patch will fix this issue. 

## Additional Information

- [ ✅] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
