### PR TITLE
fix: Proposal to repair refresh/reconnect problem

### DIFF
--- a/.changeset/strange-goats-act.md
+++ b/.changeset/strange-goats-act.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Repair re-connect for generic injected wallet.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -147,7 +147,7 @@ export function injected(parameters: InjectedParameters = {}) {
       if (!provider) throw new ProviderNotFoundError()
 
       let accounts: readonly Address[] | null = null
-      if (!isReconnecting) {
+      if (isReconnecting) {
         accounts = await this.getAccounts().catch(() => null)
         const isAuthorized = !!accounts?.length
         if (isAuthorized)


### PR DESCRIPTION
## Description

When refreshing the page or tag the code runs autoConnect. Currently the providers are not being passed the desired chainId
and address making it not possible for the provider to check whether they are already connected and not prompting the user.
Adding these two fields during the "reconnecting" state and then implementing the code in the injected provider to check
if it's connected to the correct thing.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:


A lot of these changes are stale since they are in files which have been deleted.