### PR TITLE
fix: use rpcUrls.default when requesting wallet_addEthereumChain

### DIFF
--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -171,7 +171,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
                   chainId: chainId_,
                   chainName: chain.name,
                   nativeCurrency: chain.nativeCurrency,
-                  rpcUrls: [chain.rpcUrls.public?.http[0] ?? ''],
+                  rpcUrls: [chain.rpcUrls.default?.http[0] ?? ''],
                   blockExplorerUrls: [chain.blockExplorers?.default],
                 },
               ],

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -236,7 +236,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
                   chainId: numberToHex(chainId),
                   chainName: chain.name,
                   nativeCurrency: chain.nativeCurrency,
-                  rpcUrls: [chain.rpcUrls.public?.http[0] ?? ''],
+                  rpcUrls: [chain.rpcUrls.default?.http[0] ?? ''],
                   blockExplorerUrls,
                 },
               ],

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -359,7 +359,7 @@ export function injected(parameters: InjectedParameters = {}) {
                   chainId: numberToHex(chainId),
                   chainName: chain.name,
                   nativeCurrency: chain.nativeCurrency,
-                  rpcUrls: [chain.rpcUrls.public?.http[0] ?? ''],
+                  rpcUrls: [chain.rpcUrls.default?.http[0] ?? ''],
                   blockExplorerUrls,
                 },
               ],


### PR DESCRIPTION
## Description

* fixes a bug where `switchChain` fails when user does not already have the chain configured with their wallet
* use `rpcUrls.default` when requesting `wallet_addEthereumChain`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: aquatik.eth
