### PR TITLE
Add Conflux eSpace to chain list

### DIFF
--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -57,6 +57,8 @@ const { chains, publicClient } = configureChains(
 - `celo`
 - `celoAlfajores`
 - `classic`
+- `confluxESpace`
+- `confluxESpaceTestnet`
 - `chronos`
 - `chronosTestnet`
 - `crossbell`


### PR DESCRIPTION
## Description

`confluxESpace` is already added to the view chains but not listed in the document. This PR adds the `confluxESpace` to the chain list as well as `confluxESpaceTestnet`. 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
