### PR TITLE
Add EIP-712 transactions support

### DIFF
--- a/docs/pages/core/actions/prepareSendTransaction.en-US.mdx
+++ b/docs/pages/core/actions/prepareSendTransaction.en-US.mdx
@@ -132,3 +132,60 @@ const request = await prepareSendTransaction({
   value: parseEther('1'),
 })
 ```
+
+### gasPerPubdata (optional)
+
+The amount of gas for publishing one byte of data on Ethereum. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  gasPerPubdata: 50000,
+})
+```
+
+### factoryDeps (optional)
+
+Contains bytecode of the deployed contract. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  factoryDeps: ['0xcde...'],
+})
+```
+
+### paymaster (optional)
+
+Address of the paymaster account that will pay the fees. The `paymasterInput` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### paymasterInput (optional)
+
+Input data to the paymaster. The `paymaster` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {4}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### customSignature (optional)
+
+Signature of the transaction, filled when user signs transaction. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  customSignature: '0x12abc',
+})
+```

--- a/docs/pages/core/actions/prepareWriteContract.en-US.mdx
+++ b/docs/pages/core/actions/prepareWriteContract.en-US.mdx
@@ -235,3 +235,60 @@ const { request } = await prepareWriteContract({
   value: parseGwei('2'),
 })
 ```
+
+### gasPerPubdata (optional)
+
+The amount of gas for publishing one byte of data on Ethereum. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  gasPerPubdata: 50000,
+})
+```
+
+### factoryDeps (optional)
+
+Contains bytecode of the deployed contract. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  factoryDeps: ['0xcde...'],
+})
+```
+
+### paymaster (optional)
+
+Address of the paymaster account that will pay the fees. The `paymasterInput` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### paymasterInput (optional)
+
+Input data to the paymaster. The `paymaster` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {4}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### customSignature (optional)
+
+Signature of the transaction, filled when user signs transaction. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  customSignature: '0x12abc',
+})
+```

--- a/docs/pages/core/actions/sendTransaction.en-US.mdx
+++ b/docs/pages/core/actions/sendTransaction.en-US.mdx
@@ -135,3 +135,60 @@ const { hash } = await sendTransaction({
   value: parseEther('1'),
 })
 ```
+
+### gasPerPubdata (optional)
+
+The amount of gas for publishing one byte of data on Ethereum. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  gasPerPubdata: 50000,
+})
+```
+
+### factoryDeps (optional)
+
+Contains bytecode of the deployed contract. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  factoryDeps: ['0xcde...'],
+})
+```
+
+### paymaster (optional)
+
+Address of the paymaster account that will pay the fees. The `paymasterInput` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### paymasterInput (optional)
+
+Input data to the paymaster. The `paymaster` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {4}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### customSignature (optional)
+
+Signature of the transaction, filled when user signs transaction. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  to: 'jxom.eth',
+  customSignature: '0x12abc',
+})
+```

--- a/docs/pages/core/actions/writeContract.en-US.mdx
+++ b/docs/pages/core/actions/writeContract.en-US.mdx
@@ -235,3 +235,60 @@ const { hash } = await writeContract({
   value: parseGwei('2'),
 })
 ```
+
+### gasPerPubdata (optional)
+
+The amount of gas for publishing one byte of data on Ethereum. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  gasPerPubdata: 50000,
+})
+```
+
+### factoryDeps (optional)
+
+Contains bytecode of the deployed contract. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  factoryDeps: ['0xcde...'],
+})
+```
+
+### paymaster (optional)
+
+Address of the paymaster account that will pay the fees. The `paymasterInput` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### paymasterInput (optional)
+
+Input data to the paymaster. The `paymaster` field is required with this one. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {4}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+  paymasterInput: '0x8c5a...',
+})
+```
+
+### customSignature (optional)
+
+Signature of the transaction, filled when user signs transaction. Only applies to [EIP-712 Transactions](https://era.zksync.io/docs/api/js/features.html)
+
+```ts {3}
+const hash = await writeContract({
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  customSignature: '0x12abc',
+})
+```

--- a/packages/core/src/actions/contracts/prepareWriteContract.ts
+++ b/packages/core/src/actions/contracts/prepareWriteContract.ts
@@ -83,6 +83,11 @@ export async function prepareWriteContract<
     maxPriorityFeePerGas,
     nonce,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   } = getCallParameters(config)
 
   const { result, request } = await publicClient.simulateContract({
@@ -101,6 +106,11 @@ export async function prepareWriteContract<
     maxPriorityFeePerGas,
     nonce,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   } as SimulateContractParameters)
 
   const minimizedAbi = (abi as Abi).filter(

--- a/packages/core/src/actions/transactions/prepareSendTransaction.ts
+++ b/packages/core/src/actions/transactions/prepareSendTransaction.ts
@@ -55,6 +55,11 @@ export async function prepareSendTransaction({
   to: to_,
   value,
   walletClient: walletClient_,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
 }: PrepareSendTransactionArgs): Promise<PrepareSendTransactionResult> {
   const publicClient = getPublicClient({ chainId })
   const walletClient = walletClient_ ?? (await getWalletClient({ chainId }))
@@ -80,6 +85,11 @@ export async function prepareSendTransaction({
           nonce,
           to,
           value,
+          gasPerPubdata,
+          paymaster,
+          paymasterInput,
+          factoryDeps,
+          customSignature,
         })
       : gas_ || undefined
 
@@ -95,6 +105,11 @@ export async function prepareSendTransaction({
     nonce,
     to: to!,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
     ...(chainId ? { chainId } : {}),
   }
 }

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -50,6 +50,11 @@ export async function sendTransaction({
   nonce,
   to,
   value,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
 }: SendTransactionArgs): Promise<SendTransactionResult> {
   /********************************************************************/
   /** START: iOS App Link cautious code.                              */
@@ -79,6 +84,11 @@ export async function sendTransaction({
       nonce,
       to: to as Address,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     }
   } else {
     args = await prepareSendTransaction({
@@ -93,6 +103,11 @@ export async function sendTransaction({
       nonce,
       to,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     })
   }
 

--- a/packages/core/src/utils/getParameters.ts
+++ b/packages/core/src/utils/getParameters.ts
@@ -18,6 +18,11 @@ export function getCallParameters(
     nonce: args.nonce,
     to: args.to,
     value: args.value,
+    gasPerPubdata: args.gasPerPubdata,
+    factoryDeps: args.factoryDeps,
+    paymaster: args.paymaster,
+    paymasterInput: args.paymasterInput,
+    customSignature: args.customSignature,
   } as CallParameters
 }
 
@@ -35,5 +40,10 @@ export function getSendTransactionParameters(
     nonce: args.nonce,
     to: args.to,
     value: args.value,
+    gasPerPubdata: args.gasPerPubdata,
+    factoryDeps: args.factoryDeps,
+    paymaster: args.paymaster,
+    paymasterInput: args.paymasterInput,
+    customSignature: args.customSignature,
   }
 }

--- a/packages/react/src/hooks/contracts/useContractWrite.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.ts
@@ -33,6 +33,11 @@ type UseContractWritePreparedArgs<
   maxPriorityFeePerGas?: never
   nonce?: never
   value?: never
+  gasPerPubdata?: never
+  paymaster?: never
+  paymasterInput?: never
+  factoryDeps?: never
+  customSignature?: never
 }
 
 type UseContractWriteUnpreparedArgs<
@@ -83,6 +88,11 @@ function mutationKey({
     nonce,
     request,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   } = config
   return [
     {
@@ -101,6 +111,11 @@ function mutationKey({
       nonce,
       request,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     },
   ] as const
 }
@@ -135,6 +150,11 @@ function mutationFn(
     maxPriorityFeePerGas: config.maxPriorityFeePerGas,
     nonce: config.nonce,
     value: config.value,
+    gasPerPubdata: config.gasPerPubdata,
+    paymaster: config.paymaster,
+    paymasterInput: config.paymasterInput,
+    factoryDeps: config.factoryDeps,
+    customSignature: config.customSignature,
   })
 }
 
@@ -179,6 +199,11 @@ export function useContractWrite<
     maxPriorityFeePerGas,
     nonce,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   } = getSendTransactionParameters(config)
 
   const {
@@ -211,6 +236,11 @@ export function useContractWrite<
       nonce,
       request: request,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     } as UseContractWriteArgs),
     mutationFn,
     {
@@ -248,6 +278,11 @@ export function useContractWrite<
         maxPriorityFeePerGas,
         nonce,
         value,
+        gasPerPubdata,
+        paymaster,
+        paymasterInput,
+        factoryDeps,
+        customSignature,
         ...overrideConfig,
       } as UseContractWriteArgs)
   }, [
@@ -270,6 +305,11 @@ export function useContractWrite<
     nonce,
     request,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   ]) as MutationFn<TMode, TAbi, TFunctionName, void>
 
   const writeAsync = React.useMemo(() => {
@@ -298,6 +338,11 @@ export function useContractWrite<
         maxPriorityFeePerGas,
         nonce,
         value,
+        gasPerPubdata,
+        paymaster,
+        paymasterInput,
+        factoryDeps,
+        customSignature,
         ...overrideConfig,
       } as UseContractWriteArgs)
   }, [
@@ -319,6 +364,11 @@ export function useContractWrite<
     nonce,
     request,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   ]) as MutationFn<TMode, TAbi, TFunctionName, Promise<WriteContractResult>>
 
   return {

--- a/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
+++ b/packages/react/src/hooks/contracts/usePrepareContractWrite.ts
@@ -54,6 +54,11 @@ function queryKey({
   scopeKey,
   walletClientAddress,
   value,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
@@ -76,6 +81,11 @@ function queryKey({
       scopeKey,
       walletClientAddress,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     },
   ] as const
 }
@@ -105,6 +115,11 @@ function queryFn({
         maxPriorityFeePerGas,
         nonce,
         value,
+        gasPerPubdata,
+        paymaster,
+        paymasterInput,
+        factoryDeps,
+        customSignature,
       },
     ],
   }: QueryFunctionArgs<typeof queryKey>) => {
@@ -130,6 +145,11 @@ function queryFn({
       nonce,
       walletClient,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     })
   }
 }
@@ -187,6 +207,11 @@ export function usePrepareContractWrite<
     maxPriorityFeePerGas,
     nonce,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   } = getCallParameters(config)
 
   const prepareContractWriteQuery = useQuery(
@@ -209,6 +234,11 @@ export function usePrepareContractWrite<
       scopeKey,
       walletClientAddress: walletClient?.account.address,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     } as QueryKeyArgs & QueryKeyConfig),
     queryFn({
       // TODO: Remove cast and still support `Narrow<TAbi>`

--- a/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/usePrepareSendTransaction.ts
@@ -35,6 +35,11 @@ function queryKey({
   value,
   scopeKey,
   walletClientAddress,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
 }: QueryKeyArgs & QueryKeyConfig) {
   return [
     {
@@ -53,6 +58,11 @@ function queryKey({
       value,
       scopeKey,
       walletClientAddress,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     },
   ] as const
 }
@@ -72,6 +82,11 @@ function queryFn({ walletClient }: { walletClient?: GetWalletClientResult }) {
         nonce,
         to,
         value,
+        gasPerPubdata,
+        paymaster,
+        paymasterInput,
+        factoryDeps,
+        customSignature,
       },
     ],
   }: QueryFunctionArgs<typeof queryKey>) => {
@@ -89,6 +104,11 @@ function queryFn({ walletClient }: { walletClient?: GetWalletClientResult }) {
       to,
       value,
       walletClient,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     })
   }
 }
@@ -124,6 +144,11 @@ export function usePrepareSendTransaction({
   suspense,
   to,
   value,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
   onError,
   onSettled,
   onSuccess,
@@ -147,6 +172,11 @@ export function usePrepareSendTransaction({
       to,
       value,
       walletClientAddress: walletClient?.account.address,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     }),
     queryFn({ walletClient }),
     {

--- a/packages/react/src/hooks/transactions/useSendTransaction.ts
+++ b/packages/react/src/hooks/transactions/useSendTransaction.ts
@@ -41,6 +41,11 @@ const mutationFn = ({
   nonce,
   to,
   value,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
 }: UseSendTransactionArgs) => {
   if (!to) throw new Error('to is required.')
   return sendTransaction({
@@ -56,6 +61,11 @@ const mutationFn = ({
     nonce,
     to,
     value,
+    gasPerPubdata,
+    paymaster,
+    paymasterInput,
+    factoryDeps,
+    customSignature,
   })
 }
 
@@ -91,6 +101,11 @@ export function useSendTransaction<
   nonce,
   to,
   value,
+  gasPerPubdata,
+  paymaster,
+  paymasterInput,
+  factoryDeps,
+  customSignature,
   onError,
   onMutate,
   onSettled,
@@ -122,6 +137,11 @@ export function useSendTransaction<
       nonce,
       to,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     }),
     mutationFn,
     {
@@ -150,6 +170,11 @@ export function useSendTransaction<
           nonce,
           value,
           to,
+          gasPerPubdata,
+          paymaster,
+          paymasterInput,
+          factoryDeps,
+          customSignature,
         }),
       }),
     [
@@ -166,6 +191,11 @@ export function useSendTransaction<
       nonce,
       to,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     ],
   )
 
@@ -187,6 +217,11 @@ export function useSendTransaction<
           nonce,
           value,
           to,
+          gasPerPubdata,
+          paymaster,
+          paymasterInput,
+          factoryDeps,
+          customSignature,
         }),
       }),
     [
@@ -203,6 +238,11 @@ export function useSendTransaction<
       nonce,
       to,
       value,
+      gasPerPubdata,
+      paymaster,
+      paymasterInput,
+      factoryDeps,
+      customSignature,
     ],
   )
 


### PR DESCRIPTION
## Description

This PR adds needed updates for proper handling of EIP-712 transactions. 

_Important note_ - this PR is related to [this viem PR](https://github.com/wevm/viem/pull/1461) which adds EIP-712 transactions support into viem. It should be merged **after** the viem PR is merged, otherwise wagmi build will fail.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
