### PR TITLE
Add `getTransactionCount` and `useTransactionCount`

### DIFF
--- a/.changeset/happy-terms-stare.md
+++ b/.changeset/happy-terms-stare.md
@@ -1,0 +1,6 @@
+---
+"wagmi": minor
+"@wagmi/core": minor
+---
+
+Adds the core action getTransactionCount and the React hook useTransactionCount for the Viem action [getTransactionCount](https://viem.sh/docs/actions/public/getTransactionCount.html#gettransactioncount)

--- a/.changeset/happy-terms-stare.md
+++ b/.changeset/happy-terms-stare.md
@@ -1,6 +1,0 @@
----
-"wagmi": minor
-"@wagmi/core": minor
----
-
-Adds the core action getTransactionCount and the React hook useTransactionCount for the Viem action [getTransactionCount](https://viem.sh/docs/actions/public/getTransactionCount.html#gettransactioncount)

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -195,6 +195,10 @@ export function getSidebar() {
             link: '/react/api/hooks/useTransaction',
           },
           {
+            text: 'useTransactionCount',
+            link: '/react/api/hooks/useTransactionCount',
+          },
+          {
             text: 'useToken',
             link: '/react/api/hooks/useToken',
           },

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -398,6 +398,10 @@ export function getSidebar() {
             link: '/core/api/actions/getTransaction',
           },
           {
+            text: 'getTransactionCount',
+            link: '/core/api/actions/getTransactionCount',
+          },
+          {
             text: 'getWalletClient',
             link: '/core/api/actions/getWalletClient',
           },

--- a/docs/core/api/actions/getTransactionCount.md
+++ b/docs/core/api/actions/getTransactionCount.md
@@ -1,0 +1,138 @@
+<script setup>
+const packageName = '@wagmi/core'
+const actionName = 'getTransactionCount'
+const typeName = 'GetTransactionCount'
+</script>
+
+# getTransactionCount
+
+Action for fetching the number of transactions an Account has broadcast / sent.
+
+## Import
+
+```ts
+import { getTransactionCount } from '@wagmi/core'
+```
+
+## Usage
+
+::: code-group
+```ts [index.ts]
+import { getTransactionCount } from '@wagmi/core'
+import { config } from './config'
+
+const transactionCount = getTransactionCount(config, {
+  address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type GetTransactionCountParameters } from '@wagmi/core'
+```
+
+---
+### address
+
+`Address`
+
+The address of the account.
+
+::: code-group
+```ts [index.ts]
+import { getTransactionCount } from '@wagmi/core'
+import { config } from './config'
+
+const transactionCount = getTransactionCount(config, {
+  address: '0x4557B18E779944BFE9d78A672452331C186a9f48', // [!code focus]
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+---
+
+### blockNumber
+
+`bigint | undefined`
+
+Get the count at a block number.
+
+::: code-group
+```ts [index.ts]
+import { getTransactionCount } from '@wagmi/core'
+import { config } from './config'
+
+const transactionCount = getTransactionCount(config, {
+  address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+  blockNumber: 17829139n, // [!code focus]
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+### blockTag
+
+`'latest' | 'earliest' | 'pending' | 'safe' | 'finalized' | undefined`
+
+Get the count at a block tag.
+
+::: code-group
+```ts [index.ts]
+import { getTransactionCount } from '@wagmi/core'
+import { config } from './config'
+
+const transactionCount = getTransactionCount(config, {
+  address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+  blockTag: 'latest', // [!code focus]
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+---
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+::: code-group
+```ts [index.ts]
+import { getTransactionCount } from '@wagmi/core'
+import { config } from './config'
+
+const transactionCount = getTransactionCount(config, {
+  address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+  chainId: mainnet.id, // [!code focus]
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+
+## Return Type
+
+```ts
+import { type GetTransactionCountReturnType } from '@wagmi/core'
+```
+
+`number`
+
+The number of transactions an account has sent.
+
+## Error
+
+```ts
+import { type GetTransactionCountErrorType } from '@wagmi/core'
+```
+
+<!--@include: @shared/query-imports.md-->
+
+## Viem
+
+- [`getTransactionCount`](https://viem.sh/docs/actions/public/getTransactionCount.html)

--- a/docs/core/api/actions/getTransactionCount.md
+++ b/docs/core/api/actions/getTransactionCount.md
@@ -35,6 +35,7 @@ import { type GetTransactionCountParameters } from '@wagmi/core'
 ```
 
 ---
+
 ### address
 
 `Address`

--- a/docs/react/api/hooks/useTransactionCount.md
+++ b/docs/react/api/hooks/useTransactionCount.md
@@ -1,0 +1,185 @@
+---
+title: useTransactionCount
+description: Hook for fetching the number of transactions an Account has broadcast / sent.
+---
+
+<script setup>
+const packageName = 'wagmi'
+const actionName = 'getTransactionCount'
+const typeName = 'GetTransactionCount'
+const TData = 'number'
+const TError = 'GetTransactionCountErrorType'
+</script>
+
+# useTransactionCount
+
+Hook for fetching the number of transactions an Account has broadcast / sent.
+
+## Import
+
+```ts
+import { useTransactionCount } from 'wagmi'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionCount } from 'wagmi'
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type UseTransactionCountParameters } from 'wagmi'
+```
+
+### address
+
+`Address | undefined`
+
+Address to get the transaction count for. [`enabled`](#enabled) set to `false` if `address` is `undefined`.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionCount } from 'wagmi'
+import { mainnet } from 'wagmi/chains'
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48', // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+---
+
+### blockNumber
+
+`bigint | undefined`
+
+Block number to get the transaction count at.
+
+::: code-group
+```ts [index.ts]
+import { useTransactionCount } from 'wagmi'
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+    blockNumber: 17829139n, // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+### blockTag
+
+`'latest' | 'earliest' | 'pending' | 'safe' | 'finalized' | undefined`
+
+Block tag to get the transaction count at.
+
+::: code-group
+```ts [index.ts]
+import { useTransactionCount } from 'wagmi'
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+    blockTag: 'latest', // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+---
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionCount } from 'wagmi'
+import { mainnet } from 'wagmi/chains' // [!code focus]
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+    chainId: mainnet.id, // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+### config
+
+`Config | undefined`
+
+[`Config`](/react/api/createConfig#config) to use instead of retrieving from the from nearest [`WagmiProvider`](/react/WagmiProvider).
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionCount } from 'wagmi'
+import { config } from './config' // [!code focus]
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+    config, // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+### scopeKey
+
+`string | undefined`
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionCount } from 'wagmi'
+
+function App() {
+  const result = useTransactionCount({
+    address: '0x4557B18E779944BFE9d78A672452331C186a9f48',
+    scopeKey: 'foo', // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { type UseTransactionCountReturnType } from 'wagmi'
+```
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`getTransactionCount`](/core/api/actions/getTransactionCount)

--- a/packages/core/src/actions/getTransactionCount.test.ts
+++ b/packages/core/src/actions/getTransactionCount.test.ts
@@ -1,0 +1,66 @@
+import { accounts, chain, config, testClient } from '@wagmi/test'
+import { describe, expect, test } from 'vitest'
+
+import { getTransactionCount } from './getTransactionCount.js'
+
+const address = accounts[0]
+
+describe('getTransactionCount', () => {
+  test('default', async () => {
+    await expect(getTransactionCount(config, { address })).resolves.toBe(564)
+  })
+
+  test('parameters: chainId', async () => {
+    await testClient.mainnet2.setNonce({
+      address,
+      nonce: 6969,
+    })
+    await testClient.mainnet2.mine({ blocks: 1 })
+    await expect(
+      getTransactionCount(config, { address, chainId: chain.mainnet2.id }),
+    ).resolves.toBe(6969)
+  })
+
+  test('parameters: blockNumber', async () => {
+    await expect(
+      getTransactionCount(config, { address, blockNumber: 13677382n }),
+    ).resolves.toBe(82)
+  })
+
+  test('parameters: blockTag', async () => {
+    await expect(
+      getTransactionCount(config, {
+        address,
+        blockTag: 'earliest',
+      }),
+    ).resolves.toBe(0)
+
+    await expect(
+      getTransactionCount(config, {
+        address,
+        blockTag: 'finalized',
+      }),
+    ).resolves.toBe(564)
+
+    await expect(
+      getTransactionCount(config, {
+        address,
+        blockTag: 'latest',
+      }),
+    ).resolves.toBe(564)
+
+    await expect(
+      getTransactionCount(config, {
+        address,
+        blockTag: 'pending',
+      }),
+    ).resolves.toBe(564)
+
+    await expect(
+      getTransactionCount(config, {
+        address,
+        blockTag: 'safe',
+      }),
+    ).resolves.toBe(564)
+  })
+})

--- a/packages/core/src/actions/getTransactionCount.test.ts
+++ b/packages/core/src/actions/getTransactionCount.test.ts
@@ -1,66 +1,64 @@
 import { accounts, chain, config, testClient } from '@wagmi/test'
-import { describe, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { getTransactionCount } from './getTransactionCount.js'
 
 const address = accounts[0]
 
-describe('getTransactionCount', () => {
-  test('default', async () => {
-    await expect(getTransactionCount(config, { address })).resolves.toBe(564)
-  })
+test('default', async () => {
+  await expect(getTransactionCount(config, { address })).resolves.toBe(564)
+})
 
-  test('parameters: chainId', async () => {
-    await testClient.mainnet2.setNonce({
+test('parameters: chainId', async () => {
+  await testClient.mainnet2.setNonce({
+    address,
+    nonce: 6969,
+  })
+  await testClient.mainnet2.mine({ blocks: 1 })
+  await expect(
+    getTransactionCount(config, { address, chainId: chain.mainnet2.id }),
+  ).resolves.toBe(6969)
+})
+
+test('parameters: blockNumber', async () => {
+  await expect(
+    getTransactionCount(config, { address, blockNumber: 13677382n }),
+  ).resolves.toBe(82)
+})
+
+test('parameters: blockTag', async () => {
+  await expect(
+    getTransactionCount(config, {
       address,
-      nonce: 6969,
-    })
-    await testClient.mainnet2.mine({ blocks: 1 })
-    await expect(
-      getTransactionCount(config, { address, chainId: chain.mainnet2.id }),
-    ).resolves.toBe(6969)
-  })
+      blockTag: 'earliest',
+    }),
+  ).resolves.toBe(0)
 
-  test('parameters: blockNumber', async () => {
-    await expect(
-      getTransactionCount(config, { address, blockNumber: 13677382n }),
-    ).resolves.toBe(82)
-  })
+  await expect(
+    getTransactionCount(config, {
+      address,
+      blockTag: 'finalized',
+    }),
+  ).resolves.toBe(564)
 
-  test('parameters: blockTag', async () => {
-    await expect(
-      getTransactionCount(config, {
-        address,
-        blockTag: 'earliest',
-      }),
-    ).resolves.toBe(0)
+  await expect(
+    getTransactionCount(config, {
+      address,
+      blockTag: 'latest',
+    }),
+  ).resolves.toBe(564)
 
-    await expect(
-      getTransactionCount(config, {
-        address,
-        blockTag: 'finalized',
-      }),
-    ).resolves.toBe(564)
+  await expect(
+    getTransactionCount(config, {
+      address,
+      blockTag: 'pending',
+    }),
+  ).resolves.toBe(564)
 
-    await expect(
-      getTransactionCount(config, {
-        address,
-        blockTag: 'latest',
-      }),
-    ).resolves.toBe(564)
-
-    await expect(
-      getTransactionCount(config, {
-        address,
-        blockTag: 'pending',
-      }),
-    ).resolves.toBe(564)
-
-    await expect(
-      getTransactionCount(config, {
-        address,
-        blockTag: 'safe',
-      }),
-    ).resolves.toBe(564)
-  })
+  await expect(
+    getTransactionCount(config, {
+      address,
+      blockTag: 'safe',
+    }),
+  ).resolves.toBe(564)
 })

--- a/packages/core/src/actions/getTransactionCount.ts
+++ b/packages/core/src/actions/getTransactionCount.ts
@@ -1,8 +1,8 @@
 import {
-  getTransactionCount as viem_getTransactionCount,
   type GetTransactionCountErrorType as viem_GetTransactionCountErrorType,
   type GetTransactionCountParameters as viem_GetTransactionCountParameters,
   type GetTransactionCountReturnType as viem_GetTransactionCountReturnType,
+  getTransactionCount as viem_getTransactionCount,
 } from 'viem/actions'
 
 import { type Config } from '../createConfig.js'

--- a/packages/core/src/actions/getTransactionCount.ts
+++ b/packages/core/src/actions/getTransactionCount.ts
@@ -1,0 +1,31 @@
+import {
+  getTransactionCount as viem_getTransactionCount,
+  type GetTransactionCountErrorType as viem_GetTransactionCountErrorType,
+  type GetTransactionCountParameters as viem_GetTransactionCountParameters,
+  type GetTransactionCountReturnType as viem_GetTransactionCountReturnType,
+} from 'viem/actions'
+
+import { type Config } from '../createConfig.js'
+import { type ChainIdParameter } from '../types/properties.js'
+import { type Evaluate } from '../types/utils.js'
+
+export type GetTransactionCountParameters<config extends Config = Config> =
+  Evaluate<ChainIdParameter<config> & viem_GetTransactionCountParameters>
+
+export type GetTransactionCountReturnType = viem_GetTransactionCountReturnType
+
+export type GetTransactionCountErrorType = viem_GetTransactionCountErrorType
+
+/** https://beta.wagmi.sh/core/api/actions/getTransactionCount */
+export async function getTransactionCount<config extends Config>(
+  config: config,
+  parameters: GetTransactionCountParameters<config>,
+): Promise<GetTransactionCountReturnType> {
+  const { address, blockNumber, blockTag, chainId } = parameters
+
+  const client = config.getClient({ chainId })
+  return await viem_getTransactionCount(
+    client,
+    blockNumber ? { address, blockNumber } : { address, blockTag },
+  )
+}

--- a/packages/core/src/exports/actions.test.ts
+++ b/packages/core/src/exports/actions.test.ts
@@ -32,6 +32,7 @@ test('exports', () => {
       "getToken",
       "fetchToken",
       "getTransaction",
+      "getTransactionCount",
       "fetchTransaction",
       "getWalletClient",
       "multicall",

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -148,6 +148,13 @@ export {
 } from '../actions/getTransaction.js'
 
 export {
+  type GetTransactionCountErrorType,
+  type GetTransactionCountParameters,
+  type GetTransactionCountReturnType,
+  getTransactionCount,
+} from '../actions/getTransactionCount.js'
+
+export {
   type GetWalletClientErrorType,
   type GetWalletClientParameters,
   type GetWalletClientReturnType,

--- a/packages/core/src/exports/index.test.ts
+++ b/packages/core/src/exports/index.test.ts
@@ -36,6 +36,7 @@ test('exports', () => {
       "getToken",
       "fetchToken",
       "getTransaction",
+      "getTransactionCount",
       "fetchTransaction",
       "getWalletClient",
       "multicall",

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -159,6 +159,13 @@ export {
 } from '../actions/getTransaction.js'
 
 export {
+  type GetTransactionCountErrorType,
+  type GetTransactionCountParameters,
+  type GetTransactionCountReturnType,
+  getTransactionCount,
+} from '../actions/getTransactionCount.js'
+
+export {
   type GetWalletClientErrorType,
   type GetWalletClientParameters,
   type GetWalletClientReturnType,

--- a/packages/core/src/exports/query.test.ts
+++ b/packages/core/src/exports/query.test.ts
@@ -31,6 +31,8 @@ test('exports', () => {
       "getTokenQueryOptions",
       "getTransactionQueryKey",
       "getTransactionQueryOptions",
+      "getTransactionCountQueryKey",
+      "getTransactionCountQueryOptions",
       "getWalletClientQueryKey",
       "getWalletClientQueryOptions",
       "infiniteReadContractsQueryKey",

--- a/packages/core/src/exports/query.ts
+++ b/packages/core/src/exports/query.ts
@@ -126,6 +126,15 @@ export {
 } from '../query/getTransaction.js'
 
 export {
+  type GetTransactionCountData,
+  type GetTransactionCountOptions,
+  type GetTransactionCountQueryFnData,
+  type GetTransactionCountQueryKey,
+  getTransactionCountQueryKey,
+  getTransactionCountQueryOptions,
+} from '../query/getTransactionCount.js'
+
+export {
   type GetWalletClientData,
   type GetWalletClientOptions,
   type GetWalletClientQueryFnData,

--- a/packages/core/src/query/getTransactionCount.test.ts
+++ b/packages/core/src/query/getTransactionCount.test.ts
@@ -1,15 +1,14 @@
 import { accounts, chain, config } from '@wagmi/test'
-import { describe, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { getTransactionCountQueryOptions } from './getTransactionCount.js'
 
 const address = accounts[0]
 
-describe('getTransactionCountQueryOptions', () => {
-  test('default', () => {
-    expect(
-      getTransactionCountQueryOptions(config, { address }),
-    ).toMatchInlineSnapshot(`
+test('default', () => {
+  expect(
+    getTransactionCountQueryOptions(config, { address }),
+  ).toMatchInlineSnapshot(`
     {
       "queryFn": [Function],
       "queryKey": [
@@ -20,15 +19,15 @@ describe('getTransactionCountQueryOptions', () => {
       ],
     }
   `)
-  })
+})
 
-  test('parameters: chainId', () => {
-    expect(
-      getTransactionCountQueryOptions(config, {
-        address,
-        chainId: chain.mainnet.id,
-      }),
-    ).toMatchInlineSnapshot(`
+test('parameters: chainId', () => {
+  expect(
+    getTransactionCountQueryOptions(config, {
+      address,
+      chainId: chain.mainnet.id,
+    }),
+  ).toMatchInlineSnapshot(`
       {
         "queryFn": [Function],
         "queryKey": [
@@ -40,15 +39,15 @@ describe('getTransactionCountQueryOptions', () => {
         ],
       }
     `)
-  })
+})
 
-  test('parameters: blockNumber', () => {
-    expect(
-      getTransactionCountQueryOptions(config, {
-        address,
-        blockNumber: 13677382n,
-      }),
-    ).toMatchInlineSnapshot(`
+test('parameters: blockNumber', () => {
+  expect(
+    getTransactionCountQueryOptions(config, {
+      address,
+      blockNumber: 13677382n,
+    }),
+  ).toMatchInlineSnapshot(`
       {
         "queryFn": [Function],
         "queryKey": [
@@ -60,15 +59,15 @@ describe('getTransactionCountQueryOptions', () => {
         ],
       }
     `)
-  })
+})
 
-  test('parameters: blockTag', () => {
-    expect(
-      getTransactionCountQueryOptions(config, {
-        address,
-        blockTag: 'earliest',
-      }),
-    ).toMatchInlineSnapshot(`
+test('parameters: blockTag', () => {
+  expect(
+    getTransactionCountQueryOptions(config, {
+      address,
+      blockTag: 'earliest',
+    }),
+  ).toMatchInlineSnapshot(`
       {
         "queryFn": [Function],
         "queryKey": [
@@ -80,5 +79,4 @@ describe('getTransactionCountQueryOptions', () => {
         ],
       }
     `)
-  })
 })

--- a/packages/core/src/query/getTransactionCount.test.ts
+++ b/packages/core/src/query/getTransactionCount.test.ts
@@ -1,0 +1,84 @@
+import { accounts, chain, config } from '@wagmi/test'
+import { describe, expect, test } from 'vitest'
+
+import { getTransactionCountQueryOptions } from './getTransactionCount.js'
+
+const address = accounts[0]
+
+describe('getTransactionCountQueryOptions', () => {
+  test('default', () => {
+    expect(
+      getTransactionCountQueryOptions(config, { address }),
+    ).toMatchInlineSnapshot(`
+    {
+      "queryFn": [Function],
+      "queryKey": [
+        "transactionCount",
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        },
+      ],
+    }
+  `)
+  })
+
+  test('parameters: chainId', () => {
+    expect(
+      getTransactionCountQueryOptions(config, {
+        address,
+        chainId: chain.mainnet.id,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "queryFn": [Function],
+        "queryKey": [
+          "transactionCount",
+          {
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            "chainId": 1,
+          },
+        ],
+      }
+    `)
+  })
+
+  test('parameters: blockNumber', () => {
+    expect(
+      getTransactionCountQueryOptions(config, {
+        address,
+        blockNumber: 13677382n,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "queryFn": [Function],
+        "queryKey": [
+          "transactionCount",
+          {
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            "blockNumber": 13677382n,
+          },
+        ],
+      }
+    `)
+  })
+
+  test('parameters: blockTag', () => {
+    expect(
+      getTransactionCountQueryOptions(config, {
+        address,
+        blockTag: 'earliest',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "queryFn": [Function],
+        "queryKey": [
+          "transactionCount",
+          {
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            "blockTag": "earliest",
+          },
+        ],
+      }
+    `)
+  })
+})

--- a/packages/core/src/query/getTransactionCount.ts
+++ b/packages/core/src/query/getTransactionCount.ts
@@ -1,0 +1,55 @@
+import { type QueryOptions } from '@tanstack/query-core'
+
+import {
+  getTransactionCount,
+  type GetTransactionCountErrorType,
+  type GetTransactionCountParameters,
+  type GetTransactionCountReturnType,
+} from '../actions/getTransactionCount.js'
+import { type Config } from '../createConfig.js'
+import type { Evaluate, PartialBy } from '../types/utils.js'
+import type { ScopeKeyParameter } from './types.js'
+import { filterQueryOptions } from './utils.js'
+
+export type GetTransactionCountOptions<config extends Config> = Evaluate<
+  PartialBy<GetTransactionCountParameters<config>, 'address'> &
+    ScopeKeyParameter
+>
+
+export function getTransactionCountQueryOptions<config extends Config>(
+  config: config,
+  options: GetTransactionCountOptions<config> = {},
+) {
+  return {
+    async queryFn({ queryKey }) {
+      const { address, scopeKey: _, ...parameters } = queryKey[1]
+      if (!address) throw new Error('address is required')
+      const transactionCount = await getTransactionCount(config, {
+        ...(parameters as GetTransactionCountParameters),
+        address,
+      })
+      return transactionCount ?? null
+    },
+    queryKey: getTransactionCountQueryKey(options),
+  } as const satisfies QueryOptions<
+    GetTransactionCountQueryFnData,
+    GetTransactionCountErrorType,
+    GetTransactionCountData,
+    GetTransactionCountQueryKey<config>
+  >
+}
+
+export type GetTransactionCountQueryFnData =
+  Evaluate<GetTransactionCountReturnType>
+
+export type GetTransactionCountData = GetTransactionCountQueryFnData
+
+export function getTransactionCountQueryKey<config extends Config>(
+  options: GetTransactionCountOptions<config> = {},
+) {
+  return ['transactionCount', filterQueryOptions(options)] as const
+}
+
+export type GetTransactionCountQueryKey<config extends Config> = ReturnType<
+  typeof getTransactionCountQueryKey<config>
+>

--- a/packages/core/src/query/getTransactionCount.ts
+++ b/packages/core/src/query/getTransactionCount.ts
@@ -1,10 +1,10 @@
 import { type QueryOptions } from '@tanstack/query-core'
 
 import {
-  getTransactionCount,
   type GetTransactionCountErrorType,
   type GetTransactionCountParameters,
   type GetTransactionCountReturnType,
+  getTransactionCount,
 } from '../actions/getTransactionCount.js'
 import { type Config } from '../createConfig.js'
 import type { Evaluate, PartialBy } from '../types/utils.js'

--- a/packages/react/src/exports/index.test.ts
+++ b/packages/react/src/exports/index.test.ts
@@ -51,6 +51,7 @@ test('exports', () => {
       "useSwitchChain",
       "useToken",
       "useTransaction",
+      "useTransactionCount",
       "useWalletClient",
       "useWaitForTransactionReceipt",
       "useWatchBlocks",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -236,6 +236,12 @@ export {
 } from '../hooks/useTransaction.js'
 
 export {
+  type UseTransactionCountParameters,
+  type UseTransactionCountReturnType,
+  useTransactionCount,
+} from '../hooks/useTransactionCount.js'
+
+export {
   type UseWalletClientParameters,
   type UseWalletClientReturnType,
   useWalletClient,

--- a/packages/react/src/exports/query.test.ts
+++ b/packages/react/src/exports/query.test.ts
@@ -31,6 +31,8 @@ test('exports', () => {
       "getTokenQueryOptions",
       "getTransactionQueryKey",
       "getTransactionQueryOptions",
+      "getTransactionCountQueryKey",
+      "getTransactionCountQueryOptions",
       "getWalletClientQueryKey",
       "getWalletClientQueryOptions",
       "infiniteReadContractsQueryKey",

--- a/packages/react/src/hooks/useTransactionCount.test-d.ts
+++ b/packages/react/src/hooks/useTransactionCount.test-d.ts
@@ -1,0 +1,14 @@
+import { expectTypeOf, test } from 'vitest'
+
+import { useTransactionCount } from './useTransactionCount.js'
+
+test('select data', async () => {
+  const result = useTransactionCount({
+    query: {
+      select(data) {
+        return data
+      },
+    },
+  })
+  expectTypeOf(result.data).toEqualTypeOf<number | undefined>()
+})

--- a/packages/react/src/hooks/useTransactionCount.test.ts
+++ b/packages/react/src/hooks/useTransactionCount.test.ts
@@ -1,19 +1,18 @@
 import { accounts, chain, wait } from '@wagmi/test'
 import { renderHook, waitFor } from '@wagmi/test/react'
 import type { Address } from 'viem'
-import { describe, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { useTransactionCount } from './useTransactionCount.js'
 
 const address = accounts[0]
 
-describe('useTransactionCount', () => {
-  test('default', async () => {
-    const { result } = renderHook(() => useTransactionCount({ address }))
+test('default', async () => {
+  const { result } = renderHook(() => useTransactionCount({ address }))
 
-    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
 
-    expect(result.current).toMatchInlineSnapshot(`
+  expect(result.current).toMatchInlineSnapshot(`
     {
       "data": 564,
       "dataUpdatedAt": 1675209600000,
@@ -48,16 +47,16 @@ describe('useTransactionCount', () => {
       "status": "success",
     }
   `)
-  })
+})
 
-  test('parameters: chainId', async () => {
-    const { result } = renderHook(() =>
-      useTransactionCount({ address, chainId: chain.mainnet2.id }),
-    )
+test('parameters: chainId', async () => {
+  const { result } = renderHook(() =>
+    useTransactionCount({ address, chainId: chain.mainnet2.id }),
+  )
 
-    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
 
-    expect(result.current).toMatchInlineSnapshot(`
+  expect(result.current).toMatchInlineSnapshot(`
     {
       "data": 564,
       "dataUpdatedAt": 1675209600000,
@@ -92,16 +91,16 @@ describe('useTransactionCount', () => {
       "status": "success",
     }
   `)
-  })
+})
 
-  test('parameters: blockNumber', async () => {
-    const { result } = renderHook(() =>
-      useTransactionCount({ address, blockNumber: 13677382n }),
-    )
+test('parameters: blockNumber', async () => {
+  const { result } = renderHook(() =>
+    useTransactionCount({ address, blockNumber: 13677382n }),
+  )
 
-    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
 
-    expect(result.current).toMatchInlineSnapshot(`
+  expect(result.current).toMatchInlineSnapshot(`
     {
       "data": 82,
       "dataUpdatedAt": 1675209600000,
@@ -137,16 +136,16 @@ describe('useTransactionCount', () => {
       "status": "success",
     }
   `)
-  })
+})
 
-  test('behavior: address: undefined -> defined', async () => {
-    let address: Address | undefined = undefined
+test('behavior: address: undefined -> defined', async () => {
+  let address: Address | undefined = undefined
 
-    const { result, rerender } = renderHook(() =>
-      useTransactionCount({ address }),
-    )
+  const { result, rerender } = renderHook(() =>
+    useTransactionCount({ address }),
+  )
 
-    expect(result.current).toMatchInlineSnapshot(`
+  expect(result.current).toMatchInlineSnapshot(`
     {
       "data": undefined,
       "dataUpdatedAt": 0,
@@ -182,12 +181,12 @@ describe('useTransactionCount', () => {
     }
   `)
 
-    address = accounts[0]
-    rerender()
+  address = accounts[0]
+  rerender()
 
-    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
 
-    expect(result.current).toMatchInlineSnapshot(`
+  expect(result.current).toMatchInlineSnapshot(`
     {
       "data": 564,
       "dataUpdatedAt": 1675209600000,
@@ -222,12 +221,11 @@ describe('useTransactionCount', () => {
       "status": "success",
     }
   `)
-  })
+})
 
-  test('behavior: disabled when properties missing', async () => {
-    const { result } = renderHook(() => useTransactionCount())
+test('behavior: disabled when properties missing', async () => {
+  const { result } = renderHook(() => useTransactionCount())
 
-    await wait(100)
-    await waitFor(() => expect(result.current.isPending).toBeTruthy())
-  })
+  await wait(100)
+  await waitFor(() => expect(result.current.isPending).toBeTruthy())
 })

--- a/packages/react/src/hooks/useTransactionCount.test.ts
+++ b/packages/react/src/hooks/useTransactionCount.test.ts
@@ -1,0 +1,233 @@
+import { accounts, chain, wait } from '@wagmi/test'
+import { renderHook, waitFor } from '@wagmi/test/react'
+import type { Address } from 'viem'
+import { describe, expect, test } from 'vitest'
+
+import { useTransactionCount } from './useTransactionCount.js'
+
+const address = accounts[0]
+
+describe('useTransactionCount', () => {
+  test('default', async () => {
+    const { result } = renderHook(() => useTransactionCount({ address }))
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": 564,
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "transactionCount",
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "chainId": 1,
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+  })
+
+  test('parameters: chainId', async () => {
+    const { result } = renderHook(() =>
+      useTransactionCount({ address, chainId: chain.mainnet2.id }),
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": 564,
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "transactionCount",
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "chainId": 456,
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+  })
+
+  test('parameters: blockNumber', async () => {
+    const { result } = renderHook(() =>
+      useTransactionCount({ address, blockNumber: 13677382n }),
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": 82,
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "transactionCount",
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "blockNumber": 13677382n,
+          "chainId": 1,
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+  })
+
+  test('behavior: address: undefined -> defined', async () => {
+    let address: Address | undefined = undefined
+
+    const { result, rerender } = renderHook(() =>
+      useTransactionCount({ address }),
+    )
+
+    expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": undefined,
+      "dataUpdatedAt": 0,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": false,
+      "isFetchedAfterMount": false,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": true,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": false,
+      "queryKey": [
+        "transactionCount",
+        {
+          "address": undefined,
+          "chainId": 1,
+        },
+      ],
+      "refetch": [Function],
+      "status": "pending",
+    }
+  `)
+
+    address = accounts[0]
+    rerender()
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": 564,
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "transactionCount",
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "chainId": 1,
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+  })
+
+  test('behavior: disabled when properties missing', async () => {
+    const { result } = renderHook(() => useTransactionCount())
+
+    await wait(100)
+    await waitFor(() => expect(result.current.isPending).toBeTruthy())
+  })
+})

--- a/packages/react/src/hooks/useTransactionCount.ts
+++ b/packages/react/src/hooks/useTransactionCount.ts
@@ -1,0 +1,59 @@
+'use client'
+
+import {
+  type Config,
+  type GetTransactionCountErrorType,
+  type ResolvedRegister,
+} from '@wagmi/core'
+import type { Evaluate } from '@wagmi/core/internal'
+import type { GetTransactionCountQueryFnData } from '@wagmi/core/query'
+import {
+  getTransactionCountQueryOptions,
+  type GetTransactionCountData,
+  type GetTransactionCountOptions,
+  type GetTransactionCountQueryKey,
+} from '@wagmi/core/query'
+
+import type { ConfigParameter, QueryParameter } from '../types/properties.js'
+import { useQuery, type UseQueryReturnType } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+export type UseTransactionCountParameters<
+  config extends Config = Config,
+  selectData = GetTransactionCountData,
+> = Evaluate<
+  GetTransactionCountOptions<config> &
+    ConfigParameter<config> &
+    QueryParameter<
+      GetTransactionCountQueryFnData,
+      GetTransactionCountErrorType,
+      selectData,
+      GetTransactionCountQueryKey<config>
+    >
+>
+
+export type UseTransactionCountReturnType<
+  selectData = GetTransactionCountData,
+> = UseQueryReturnType<selectData, GetTransactionCountErrorType>
+
+/** https://beta.wagmi.sh/react/api/hooks/useTransactionCount */
+export function useTransactionCount<
+  config extends Config = ResolvedRegister['config'],
+  selectData = GetTransactionCountData,
+>(
+  parameters: UseTransactionCountParameters<config, selectData> = {},
+): UseTransactionCountReturnType<selectData> {
+  const { address, query = {} } = parameters
+
+  const config = useConfig(parameters)
+  const chainId = useChainId()
+
+  const options = getTransactionCountQueryOptions(config, {
+    ...parameters,
+    chainId: parameters.chainId ?? chainId,
+  })
+  const enabled = Boolean(address && (query.enabled ?? true))
+
+  return useQuery({ ...query, ...options, enabled })
+}

--- a/packages/react/src/hooks/useTransactionCount.ts
+++ b/packages/react/src/hooks/useTransactionCount.ts
@@ -8,14 +8,14 @@ import {
 import type { Evaluate } from '@wagmi/core/internal'
 import type { GetTransactionCountQueryFnData } from '@wagmi/core/query'
 import {
-  getTransactionCountQueryOptions,
   type GetTransactionCountData,
   type GetTransactionCountOptions,
   type GetTransactionCountQueryKey,
+  getTransactionCountQueryOptions,
 } from '@wagmi/core/query'
 
 import type { ConfigParameter, QueryParameter } from '../types/properties.js'
-import { useQuery, type UseQueryReturnType } from '../utils/query.js'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
 import { useChainId } from './useChainId.js'
 import { useConfig } from './useConfig.js'
 


### PR DESCRIPTION
## Description

This PR Adds the core action `getTransactionCount` and the React hook `useTransactionCount ` for the Viem action [getTransactionCount ](https://viem.sh/docs/actions/public/getTransactionCount.html#gettransactioncount).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
vitormarthendal.eth