### PR TITLE
add neonMainnet

### DIFF
--- a/docs/pages/core/chains.en-US.mdx
+++ b/docs/pages/core/chains.en-US.mdx
@@ -104,6 +104,7 @@ const { chains, publicClient } = configureChains(
 - `moonbeam`
 - `moonriver`
 - `neonDevnet`
+- `neonMainnet`
 - `nexilix`
 - `nexi`
 - `oasys`

--- a/docs/pages/react/chains.en-US.mdx
+++ b/docs/pages/react/chains.en-US.mdx
@@ -102,6 +102,7 @@ const { chains, publicClient } = configureChains(
 - `moonbeam`
 - `moonriver`
 - `neonDevnet`
+- `neonMainnet`
 - `nexilix`
 - `nexi`
 - `oasys`


### PR DESCRIPTION
## Description

This PR contains the adding of ```neonMainnet``` chain. For whatever reason in the [docs page](https://wagmi.sh/core/chains) ```neonMainnet``` was missing, but ```neonDevnet``` was added. This is the **[proof](https://github.com/wevm/viem/blob/main/src/chains/index.test.ts#L101)** of viem supporting both of them.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
