### PR TITLE
Fix: typo in the sample code in sign-message.en-US.mdx

### DIFF
--- a/docs/pages/examples/sign-message.en-US.mdx
+++ b/docs/pages/examples/sign-message.en-US.mdx
@@ -59,10 +59,10 @@ export function SignMessage() {
         {isLoading ? 'Check Wallet' : 'Sign Message'}
       </button>
 
-      {data && (
+      {signMessageData && (
         <div>
           <div>Recovered Address: {recoveredAddress.current}</div>
-          <div>Signature: {data}</div>
+          <div>Signature: {signMessageData}</div>
         </div>
       )}
 


### PR DESCRIPTION
The sample code in the 'Step 2: Add SignMessage Component' in the example of Sign Message https://wagmi.sh/examples/sign-message has a typo, the variable that is assigned as the return of `data` has been named as `signMessageData`

```
const { data: signMessageData, error, isLoading, signMessage, variables } = useSignMessage()
```

But in the return, it's still using `data` instead of `signMessageData`

```
{data && (
        <div>
          <div>Recovered Address: {recoveredAddress.current}</div>
          <div>Signature: {data}</div>
        </div>
      )}
```

This commit is to replace `data` above with `signMessageData`

## Description

Fix the typo in the example code in https://wagmi.sh/examples/sign-message

## Additional Information

- [ v ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
