### PR TITLE
docs: replace useContract hook by getContract action

### DIFF
--- a/docs/pages/react/hooks/useWalletClient.en-US.mdx
+++ b/docs/pages/react/hooks/useWalletClient.en-US.mdx
@@ -16,12 +16,13 @@ import { useWalletClient } from 'wagmi'
 The following examples use the [ENS Registry](https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e#code) contract.
 
 ```tsx {4, 9}
-import { useContract, useWalletClient } from 'wagmi'
+import { useWalletClient } from 'wagmi'
+import { getContract } from '@wagmi/core'
 
 function App() {
   const { data: walletClient, isError, isLoading } = useWalletClient()
 
-  const contract = useContract({
+  const contract = getContract({
     address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     abi: ensRegistryABI,
     walletClient,

--- a/docs/pages/react/hooks/useWalletClient.en-US.mdx
+++ b/docs/pages/react/hooks/useWalletClient.en-US.mdx
@@ -17,7 +17,7 @@ The following examples use the [ENS Registry](https://etherscan.io/address/0x000
 
 ```tsx {4, 9}
 import { useWalletClient } from 'wagmi'
-import { getContract } from '@wagmi/core'
+import { getContract } from 'wagmi/actions'
 
 function App() {
   const { data: walletClient, isError, isLoading } = useWalletClient()


### PR DESCRIPTION
## Description

Replaced the use of the `useContract` hook in favor of the action `getContract`, since this hook has been deprecated.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: arthxr.eth
