### PR TITLE
fix: provide correct block explorer URL to WalletConnect

### DIFF
--- a/.changeset/pink-spoons-relate.md
+++ b/.changeset/pink-spoons-relate.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": patch
+"wagmi": patch
+"@wagmi/core": patch
+---
+
+fix: provide correct block explorer URL to WalletConnect [#3340](https://github.com/wevm/wagmi/issues/3340)

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -263,7 +263,7 @@ export function walletConnect(parameters: WalletConnectParameters) {
             params: [
               {
                 chainId: numberToHex(chain.id),
-                blockExplorerUrls: [chain.blockExplorers?.default],
+                blockExplorerUrls: [chain.blockExplorers?.default.url],
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
                 rpcUrls: [...chain.rpcUrls.default.http],


### PR DESCRIPTION
## Description

Fixes the WalletConnect connector issue #3340 when calling `switchChain` for a chain that is not approved during initialization. We need to provide an actual block explorer URL instead of a block explorer object to an array of URLs.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
