### PR TITLE
fix: provide correct block explorer URL to Coinbase connector

### DIFF
--- a/.changeset/plenty-mails-relate.md
+++ b/.changeset/plenty-mails-relate.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": patch
+"wagmi": patch
+"@wagmi/core": patch
+---
+
+fix: provide correct block explorer URL to Coinbase connector

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -174,7 +174,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
                   chainName: chain.name,
                   nativeCurrency: chain.nativeCurrency,
                   rpcUrls: [chain.rpcUrls.default?.http[0] ?? ''],
-                  blockExplorerUrls: [chain.blockExplorers?.default],
+                  blockExplorerUrls: [chain.blockExplorers?.default.url],
                 },
               ],
             })


### PR DESCRIPTION
## Description

Fixes similar to #3341 issue but with Coinbase connector when calling switchChain. We need to provide an actual block explorer URL instead of a block explorer object to an array of URLs.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
