### PR TITLE
Docs: replace account with address in getting-started

### DIFF
--- a/docs/pages/core/getting-started.en-US.mdx
+++ b/docs/pages/core/getting-started.en-US.mdx
@@ -88,10 +88,10 @@ Use actions! You can now import and use actions throughout your app.
 import { connect, fetchEnsName } from '@wagmi/core'
 import { InjectedConnector } from '@wagmi/core/connectors/injected'
 
-const { address } = await connect({
+const { account } = await connect({
   connector: new InjectedConnector(),
 })
-const ensName = await fetchEnsName({ address })
+const ensName = await fetchEnsName({ address: account })
 ```
 
 Want to learn more? Continue on reading the documentation.


### PR DESCRIPTION
## Description
Example shows `address` destructured from `connect`, but the variable in `connect's` return object is `account`

---
- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)