### PR TITLE
export chain id type

### DIFF
--- a/packages/cli/src/exports/plugins.ts
+++ b/packages/cli/src/exports/plugins.ts
@@ -5,7 +5,11 @@ export {
   type BlockExplorerConfig,
 } from '../plugins/blockExplorer.js'
 
-export { etherscan, type EtherscanConfig } from '../plugins/etherscan.js'
+export { 
+  etherscan,
+  type EtherscanChainId,
+  type EtherscanConfig,
+} from '../plugins/etherscan.js'
 
 export { fetch, type FetchConfig } from '../plugins/fetch.js'
 

--- a/packages/cli/src/exports/plugins.ts
+++ b/packages/cli/src/exports/plugins.ts
@@ -5,7 +5,7 @@ export {
   type BlockExplorerConfig,
 } from '../plugins/blockExplorer.js'
 
-export { 
+export {
   etherscan,
   type EtherscanChainId,
   type EtherscanConfig,

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -32,7 +32,8 @@ const apiUrls = {
   [42220]: 'https://api.celoscan.io/api',
   [44787]: 'https://api-alfajores.celoscan.io/api',
 }
-type ChainId = keyof typeof apiUrls
+
+export type ChainId = keyof typeof apiUrls
 
 export type EtherscanConfig<chainId extends number> = {
   /**

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -33,7 +33,7 @@ const apiUrls = {
   [44787]: 'https://api-alfajores.celoscan.io/api',
 }
 
-export type ChainId = keyof typeof apiUrls
+export type EtherscanChainId = keyof typeof apiUrls
 
 export type EtherscanConfig<chainId extends number> = {
   /**

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -66,13 +66,13 @@ export type EtherscanConfig<chainId extends number> = {
   /**
    * Contracts to fetch ABIs for.
    */
-  contracts: Evaluate<Omit<ContractConfig<ChainId, chainId>, 'abi'>>[]
+  contracts: Evaluate<Omit<ContractConfig<EtherscanChainId, chainId>, 'abi'>>[]
 }
 
 /**
  * Fetches contract ABIs from Etherscan.
  */
-export function etherscan<chainId extends ChainId>(
+export function etherscan<chainId extends EtherscanChainId>(
   config: EtherscanConfig<chainId>,
 ) {
   const { apiKey, cacheDuration, chainId } = config
@@ -85,7 +85,7 @@ export function etherscan<chainId extends ChainId>(
 
   return blockExplorer({
     apiKey,
-    baseUrl: apiUrls[chainId as ChainId],
+    baseUrl: apiUrls[chainId as EtherscanChainId],
     cacheDuration,
     contracts,
     getAddress({ address }) {


### PR DESCRIPTION
## Description

I want to use the `EtherscanConfig` `ChainId` for a specific wagmi cli config at my org so I'm adding this pr to export it.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
esm.eth