### PR TITLE
feat: restore ledger connector

### DIFF
--- a/.changeset/silver-timers-raise.md
+++ b/.changeset/silver-timers-raise.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": patch
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Restored ledger connector

--- a/docs/pages/core/connectors/_meta.en-US.json
+++ b/docs/pages/core/connectors/_meta.en-US.json
@@ -1,6 +1,7 @@
 {
   "injected": "Injected",
   "coinbaseWallet": "Coinbase Wallet",
+  "ledger": "Ledger",
   "metaMask": "MetaMask",
   "mock": "Mock",
   "safe": "Safe",

--- a/docs/pages/core/connectors/ledger.en-US.mdx
+++ b/docs/pages/core/connectors/ledger.en-US.mdx
@@ -1,0 +1,133 @@
+---
+title: 'Ledger Wallet'
+description: 'Official wagmi Connector for Ledger.'
+---
+
+# Ledger
+
+The `LedgerConnector` supports connecting with a Ledger device using the [Ledger Connect Kit](https://developers.ledger.com/docs/connect/introduction/).
+
+```ts
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+```
+
+## Usage 
+
+### WalletConnect v2
+
+To get started with Ledger + WalletConnect v2, you will need to retrieve a Project ID. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
+
+```ts
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+import { mainnet } from '@wagmi/core/chains'
+
+const connector = new LedgerConnector({
+  chains: [mainnet],
+  projectId: '...',
+})
+```
+
+Note: The above example is using chains from [`@wagmi/core/chains` entrypoint](/react/chains#wagmichains).
+
+### WalletConnect v1
+
+```ts
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+import { mainnet } from '@wagmi/core/chains'
+
+const connector = new LedgerConnector({
+  chains: [mainnet],
+})
+```
+
+## Configuration
+
+### chains (optional)
+
+Chains supported by app. Defaults to `defaultChains`.
+
+```ts {5}
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+import { mainnet } from '@wagmi/core/chains'
+
+const connector = new LedgerConnector({
+  chains: [mainnet],
+})
+```
+
+### options (WalletConnect v2)
+
+#### projectId
+
+WalletConnect Cloud Project ID. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
+
+```ts {5}
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    projectId: '...',
+  },
+})
+```
+
+#### enableDebugLogs
+
+Toggle debug logging for Ledger Connect Kit.
+
+```ts {6}
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    projectId: '...',
+    enableDebugLogs: true,
+  },
+})
+```
+
+### options (WalletConnect v1)
+
+#### chainId
+
+The Chain ID of the connecting chain.
+
+```ts {5}
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    chainId: 1,
+  },
+})
+```
+
+#### enableDebugLogs
+
+Toggle debug logging for Ledger Connect Kit.
+
+```ts {5}
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    enableDebugLogs: true,
+  },
+})
+```
+
+#### rpc
+
+A Chain ID (key) / RPC URL (value) map.
+
+```ts {5-7}
+import { LedgerConnector } from '@wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    rpc: {
+      1: 'https://eth-mainnet.alchemyapi.io/v2/yourAlchemyId',
+    },
+  },
+})
+```

--- a/docs/pages/react/connectors/_meta.en-US.json
+++ b/docs/pages/react/connectors/_meta.en-US.json
@@ -1,6 +1,7 @@
 {
   "injected": "Injected",
   "coinbaseWallet": "Coinbase Wallet",
+  "ledger": "Ledger",
   "metaMask": "MetaMask",
   "mock": "Mock",
   "safe": "Safe",

--- a/docs/pages/react/connectors/ledger.en-US.mdx
+++ b/docs/pages/react/connectors/ledger.en-US.mdx
@@ -1,0 +1,133 @@
+---
+title: 'Ledger Wallet'
+description: 'Official wagmi Connector for Ledger.'
+---
+
+# Ledger
+
+The `LedgerConnector` supports connecting with a Ledger device using the [Ledger Connect Kit](https://developers.ledger.com/docs/connect/introduction/).
+
+```ts
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+```
+
+## Usage 
+
+### WalletConnect v2
+
+To get started with Ledger + WalletConnect v2, you will need to retrieve a Project ID. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
+
+```ts
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+import { mainnet } from '@wagmi/core/chains'
+
+const connector = new LedgerConnector({
+  chains: [mainnet],
+  projectId: '...',
+})
+```
+
+Note: The above example is using chains from [`@wagmi/core/chains` entrypoint](/react/chains#wagmichains).
+
+### WalletConnect v1
+
+```ts
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+import { mainnet } from '@wagmi/core/chains'
+
+const connector = new LedgerConnector({
+  chains: [mainnet],
+})
+```
+
+## Configuration
+
+### chains (optional)
+
+Chains supported by app. Defaults to `defaultChains`.
+
+```ts {5}
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+import { mainnet } from '@wagmi/core/chains'
+
+const connector = new LedgerConnector({
+  chains: [mainnet],
+})
+```
+
+### options (WalletConnect v2)
+
+#### projectId
+
+WalletConnect Cloud Project ID. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
+
+```ts {5}
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    projectId: '...',
+  },
+})
+```
+
+#### enableDebugLogs
+
+Toggle debug logging for Ledger Connect Kit.
+
+```ts {6}
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    projectId: '...',
+    enableDebugLogs: true,
+  },
+})
+```
+
+### options (WalletConnect v1)
+
+#### chainId
+
+The Chain ID of the connecting chain.
+
+```ts {5}
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    chainId: 1,
+  },
+})
+```
+
+#### enableDebugLogs
+
+Toggle debug logging for Ledger Connect Kit.
+
+```ts {5}
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    enableDebugLogs: true,
+  },
+})
+```
+
+#### rpc
+
+A Chain ID (key) / RPC URL (value) map.
+
+```ts {5-7}
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+
+const connector = new LedgerConnector({
+  options: {
+    rpc: {
+      1: 'https://eth-mainnet.alchemyapi.io/v2/yourAlchemyId',
+    },
+  },
+})
+```

--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { avalanche, goerli, mainnet, optimism } from 'wagmi/chains'
 
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
+import { LedgerConnector } from 'wagmi/connectors/ledger'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { SafeConnector } from 'wagmi/connectors/safe'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
@@ -48,6 +49,12 @@ const config = createConfig({
       chains,
       options: {
         qrcode: true,
+      },
+    }),
+    new LedgerConnector({
+      chains,
+      options: {
+        projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? '',
       },
     }),
     new InjectedConnector({

--- a/packages/connectors/.gitignore
+++ b/packages/connectors/.gitignore
@@ -1,6 +1,7 @@
 # Generated file. Do not edit directly.
 coinbaseWallet/**
 injected/**
+ledger/**
 metaMask/**
 mock/**
 safe/**

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -35,6 +35,7 @@ const config = createConfig({
 
 - [`CoinbaseWalletConnector`](/packages/connectors/src/coinbaseWallet.ts)
 - [`InjectedConnector`](/packages/connectors/src/injected.ts)
+- [`LedgerConnector`](/packages/connectors/src/ledger.ts)
 - [`MetaMaskConnector`](/packages/connectors/src/metaMask.ts)
 - [`MockConnector`](/packages/connectors/src/mock.ts)
 - [`SafeConnector`](/packages/connectors/src/safe.ts)

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -18,13 +18,14 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.6.6",
-    "@ledgerhq/connect-kit-loader": "^1.1.0",
+    "@ledgerhq/connect-kit": "1.1.8",
+    "@ledgerhq/connect-kit-loader": "^1.1.8",
     "@safe-global/safe-apps-provider": "^0.18.1",
     "@safe-global/safe-apps-sdk": "^8.1.0",
     "@walletconnect/ethereum-provider": "2.11.0",
-    "@walletconnect/utils": "2.11.0",
     "@walletconnect/legacy-provider": "^2.0.0",
     "@walletconnect/modal": "2.6.2",
+    "@walletconnect/utils": "2.11.0",
     "abitype": "0.8.7",
     "eventemitter3": "^4.0.7"
   },

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.6.6",
     "@ledgerhq/connect-kit": "1.1.8",
-    "@ledgerhq/connect-kit-loader": "^1.1.8",
+    "@ledgerhq/connect-kit-loader": "1.1.8",
     "@safe-global/safe-apps-provider": "^0.18.1",
     "@safe-global/safe-apps-sdk": "^8.1.0",
     "@walletconnect/ethereum-provider": "2.11.0",

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.6.6",
+    "@ledgerhq/connect-kit-loader": "^1.1.0",
     "@safe-global/safe-apps-provider": "^0.18.1",
     "@safe-global/safe-apps-sdk": "^8.1.0",
     "@walletconnect/ethereum-provider": "2.11.0",
@@ -46,6 +47,10 @@
       "types": "./dist/injected.d.ts",
       "default": "./dist/injected.js"
     },
+    "./ledger": {
+      "types": "./dist/ledger.d.ts",
+      "default": "./dist/ledger.js"
+    },
     "./metaMask": {
       "types": "./dist/metaMask.d.ts",
       "default": "./dist/metaMask.js"
@@ -71,6 +76,7 @@
   "files": [
     "/coinbaseWallet",
     "/injected",
+    "/ledger",
     "/metaMask",
     "/mock",
     "/safe",

--- a/packages/connectors/src/ledger.test.ts
+++ b/packages/connectors/src/ledger.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { testChains } from '../test'
+import { LedgerConnector } from './ledger'
+
+/*
+ * To manually test the Ledger connector:
+ *
+ * - install the Ledger Live app, https://www.ledger.com/ledger-live
+ * - install the Ledger Connect extension, currently in beta, it should soon be
+ *   distributed with the Ledger Live app for iOS and macOS
+ * - run the wagmi playground app following the contributing docs on the main
+ *   wagmi repository
+ * - open the playground app in a web browser
+ * - press the "Ledger" button
+ * - see below for the Ledger Connect and Ledger Live flows
+ * - after the account is selected on the wallet the dapp state should reflect
+ *   the chosen account information
+ *
+ * Ledger Connect
+ *
+ * - if you are on a platform supported by the Ledger Connect extension
+ *   (currently Safari on iOS and macOS) but don't have it installed or enabled
+ *   you should see a modal explaining how you can do that
+ * - if you are on a platform supported by the Ledger Connect extension and
+ *   have it installed and enabled it should pop up allowing you to select an
+ *   account
+ *   - when pressing the "Disconnect" button on the dapp, the dapp shows as
+ *     disconnected but you are not actually disconnected until you press
+ *     the "Disconnect" button on Ledger Connect
+ *   - when pressing the "Disconnect" button on Ledger Connect (press the pill
+ *     shaped button with the Ledger logo, then "Disconnect" on the popup), the
+ *     dapp should also show as disconnected
+ *
+ * Testing Ledger Live
+ *
+ * - if you are on a platform not yet supported by the Connect extension you
+ *   should see a modal allowing you to use the Ledger Live app; pressing
+ *   "Use Ledger Live" or scanning the QR code should open the app and allow
+ *   you to choose an account
+ *   - when pressing the "Disconnect" button on the dapp, Ledger Live should
+ *     also show as disconnected
+ *   - when pressing the "Disconnect" button on Ledger Live, the dapp should
+ *     also show as disconnected
+ *   - when switching accounts on Ledger Live the dapp should reflect those
+ *     changes
+ */
+describe('LedgerConnector', () => {
+  it('inits', () => {
+    const connector = new LedgerConnector({
+      chains: testChains,
+      options: {},
+    })
+    expect(connector.name).toEqual('Ledger')
+  })
+
+  describe('behavior', () => {
+    it.todo('connects')
+
+    it.todo('disconnects via dapp (wagmi Connector)')
+
+    it.todo('disconnects via wallet (Ledger Live)')
+
+    it.todo('switch chains via dapp (wagmi Connector)')
+
+    it.todo('switch chains via wallet (Ledger Live)')
+
+    it.todo('switch accounts via wallet (Ledger Live)')
+
+    it.todo('sends a transaction')
+
+    it.todo('signs a message')
+  })
+})

--- a/packages/connectors/src/ledger.ts
+++ b/packages/connectors/src/ledger.ts
@@ -1,0 +1,310 @@
+import {
+  EthereumProvider,
+  SupportedProviders,
+  loadConnectKit,
+} from '@ledgerhq/connect-kit-loader'
+import { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
+import {
+  ProviderRpcError,
+  SwitchChainError,
+  UserRejectedRequestError,
+  createWalletClient,
+  custom,
+  getAddress,
+  numberToHex,
+} from 'viem'
+import type { Chain } from 'viem/chains'
+
+import { Connector } from './base'
+import type { WalletClient } from './types'
+import { normalizeChainId } from './utils/normalizeChainId'
+
+type LedgerConnectorWcV1Options = {
+  walletConnectVersion?: 1
+  bridge?: string
+  chainId?: number
+  projectId?: never
+  rpc?: { [chainId: number]: string }
+}
+
+type LedgerConnectorWcV2Options = {
+  walletConnectVersion?: 2
+  projectId?: EthereumProviderOptions['projectId']
+  requiredChains?: number[]
+  requiredMethods?: string[]
+  optionalMethods?: string[]
+  requiredEvents?: string[]
+  optionalEvents?: string[]
+}
+
+type LedgerConnectorOptions = {
+  enableDebugLogs?: boolean
+} & (LedgerConnectorWcV1Options | LedgerConnectorWcV2Options)
+
+type ConnectConfig = {
+  /** Target chain to connect to. */
+  chainId?: number
+}
+
+export class LedgerConnector extends Connector<
+  EthereumProvider,
+  LedgerConnectorOptions
+> {
+  readonly id = 'ledger'
+  readonly name = 'Ledger'
+  readonly ready = true
+
+  #provider?: EthereumProvider
+  #initProviderPromise?: Promise<void>
+  #isV1: boolean
+
+  get walletConnectVersion(): 1 | 2 {
+    if (this.options.walletConnectVersion)
+      return this.options.walletConnectVersion
+    else if ((this.options as LedgerConnectorWcV2Options).projectId) return 2
+    return 1
+  }
+
+  constructor(config: { chains?: Chain[]; options: LedgerConnectorOptions }) {
+    super({
+      ...config,
+      options: { ...config.options },
+    })
+
+    this.#isV1 = this.walletConnectVersion === 1
+  }
+
+  async connect({ chainId }: ConnectConfig = {}) {
+    try {
+      const provider = await this.getProvider({ create: true })
+      this.#setupListeners()
+
+      // Don't request accounts if we have a session, like when reloading with
+      // an active WC v2 session
+      if (!provider.session) {
+        this.emit('message', { type: 'connecting' })
+
+        await provider.request({
+          method: 'eth_requestAccounts',
+        })
+      }
+
+      const account = await this.getAccount()
+      let id = await this.getChainId()
+      let unsupported = this.isChainUnsupported(id)
+
+      if (chainId && id !== chainId) {
+        const chain = await this.switchChain(chainId)
+        id = chain.id
+        unsupported = this.isChainUnsupported(id)
+      }
+
+      return {
+        account,
+        chain: { id, unsupported },
+        provider,
+      }
+    } catch (error) {
+      if (/user rejected/i.test((error as ProviderRpcError)?.message)) {
+        throw new UserRejectedRequestError(error as Error)
+      }
+      throw error
+    }
+  }
+
+  async disconnect() {
+    const provider = await this.getProvider()
+    try {
+      if (provider?.disconnect) await provider.disconnect()
+    } catch (error) {
+      if (!/No matching key/i.test((error as Error).message)) throw error
+    } finally {
+      this.#removeListeners()
+
+      this.#isV1 &&
+        typeof localStorage !== 'undefined' &&
+        localStorage.removeItem('walletconnect')
+    }
+  }
+
+  async getAccount() {
+    const provider = await this.getProvider()
+    const accounts = (await provider.request({
+      method: 'eth_accounts',
+    })) as string[]
+    const account = getAddress(accounts[0] as string)
+
+    return account
+  }
+
+  async getChainId() {
+    const provider = await this.getProvider()
+    const chainId = (await provider.request({
+      method: 'eth_chainId',
+    })) as number
+
+    return normalizeChainId(chainId)
+  }
+
+  async getProvider(
+    { chainId, create }: { chainId?: number; create?: boolean } = {
+      create: false,
+    },
+  ) {
+    if (!this.#provider || (this.#isV1 && create)) {
+      await this.#createProvider()
+    }
+    if (chainId) await this.switchChain(chainId)
+    return this.#provider!
+  }
+
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
+    const [provider, account] = await Promise.all([
+      this.getProvider({ chainId }),
+      this.getAccount(),
+    ])
+    const chain = this.chains.find((x) => x.id === chainId)
+
+    if (!provider) throw new Error('provider is required.')
+    return createWalletClient({ account, chain, transport: custom(provider) })
+  }
+
+  async isAuthorized() {
+    try {
+      const account = await this.getAccount()
+
+      return !!account
+    } catch {
+      return false
+    }
+  }
+
+  async switchChain(chainId: number) {
+    const chain = this.chains.find((chain) => chain.id === chainId)
+    if (!chain)
+      throw new SwitchChainError(new Error('chain not found on connector.'))
+
+    try {
+      const provider = await this.getProvider()
+
+      await provider.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: numberToHex(chainId) }],
+      })
+
+      return chain
+    } catch (error) {
+      const message =
+        typeof error === 'string' ? error : (error as ProviderRpcError)?.message
+      if (/user rejected request/i.test(message)) {
+        throw new UserRejectedRequestError(error as Error)
+      }
+      throw new SwitchChainError(error as Error)
+    }
+  }
+
+  async #createProvider() {
+    if (!this.#initProviderPromise && typeof window !== 'undefined') {
+      this.#initProviderPromise = this.#initProvider()
+    }
+    return this.#initProviderPromise
+  }
+
+  async #initProvider() {
+    const connectKit = await loadConnectKit()
+
+    if (this.options.enableDebugLogs) {
+      connectKit.enableDebugLogs()
+    }
+
+    let checkSupportOptions
+
+    if (this.#isV1) {
+      const { chainId, bridge } = this.options as LedgerConnectorWcV1Options
+      checkSupportOptions = {
+        providerType: SupportedProviders.Ethereum,
+        walletConnectVersion: 1,
+        chainId,
+        bridge,
+        rpc: Object.fromEntries(
+          this.chains.map((chain) => [
+            chain.id,
+            chain.rpcUrls.default.http[0]!,
+          ]),
+        ),
+      }
+    } else {
+      const {
+        projectId,
+        requiredChains,
+        requiredMethods,
+        optionalMethods,
+        requiredEvents,
+        optionalEvents,
+      } = this.options as LedgerConnectorWcV2Options
+      const optionalChains = this.chains.map(({ id }) => id)
+
+      checkSupportOptions = {
+        providerType: SupportedProviders.Ethereum,
+        walletConnectVersion: 2,
+        projectId,
+        chains: requiredChains,
+        optionalChains,
+        methods: requiredMethods,
+        optionalMethods,
+        events: requiredEvents,
+        optionalEvents,
+        rpcMap: Object.fromEntries(
+          this.chains.map((chain) => [
+            chain.id,
+            chain.rpcUrls.default.http[0]!,
+          ]),
+        ),
+      }
+    }
+    connectKit.checkSupport(checkSupportOptions)
+
+    this.#provider =
+      (await connectKit.getProvider()) as unknown as EthereumProvider
+  }
+
+  #setupListeners() {
+    if (!this.#provider) return
+    this.#removeListeners()
+    this.#provider.on('accountsChanged', this.onAccountsChanged)
+    this.#provider.on('chainChanged', this.onChainChanged)
+    this.#provider.on('disconnect', this.onDisconnect)
+    this.#provider.on('session_delete', this.onDisconnect)
+    this.#provider.on('connect', this.onConnect)
+  }
+
+  #removeListeners() {
+    if (!this.#provider) return
+    this.#provider.removeListener('accountsChanged', this.onAccountsChanged)
+    this.#provider.removeListener('chainChanged', this.onChainChanged)
+    this.#provider.removeListener('disconnect', this.onDisconnect)
+    this.#provider.removeListener('session_delete', this.onDisconnect)
+    this.#provider.removeListener('connect', this.onConnect)
+  }
+
+  protected onAccountsChanged = (accounts: string[]) => {
+    if (accounts.length === 0) this.emit('disconnect')
+    else this.emit('change', { account: getAddress(accounts[0]!) })
+  }
+
+  protected onChainChanged = (chainId: number | string) => {
+    const id = normalizeChainId(chainId)
+    const unsupported = this.isChainUnsupported(id)
+    this.emit('change', { chain: { id, unsupported } })
+  }
+
+  protected onDisconnect = () => {
+    this.emit('disconnect')
+  }
+
+  protected onConnect = () => {
+    this.emit('connect', {})
+  }
+}

--- a/packages/connectors/src/ledger.ts
+++ b/packages/connectors/src/ledger.ts
@@ -1,7 +1,6 @@
 import {
   EthereumProvider,
   SupportedProviders,
-  loadConnectKit,
 } from '@ledgerhq/connect-kit-loader'
 import { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
 import {
@@ -213,7 +212,7 @@ export class LedgerConnector extends Connector<
   }
 
   async #initProvider() {
-    const connectKit = await loadConnectKit()
+    const connectKit = require('@ledgerhq/connect-kit')
 
     if (this.options.enableDebugLogs) {
       connectKit.enableDebugLogs()

--- a/packages/connectors/tsup.config.ts
+++ b/packages/connectors/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig(
       'src/index.ts',
       'src/coinbaseWallet.ts',
       'src/injected.ts',
+      'src/ledger.ts',
       'src/metaMask.ts',
       'src/mock/index.ts',
       'src/safe.ts',

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -3,6 +3,7 @@ chains/**
 connectors/**
 connectors/coinbaseWallet/**
 connectors/injected/**
+connectors/ledger/**
 connectors/metaMask/**
 connectors/mock/**
 connectors/safe/**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/connectors/injected.d.ts",
       "default": "./dist/connectors/injected.js"
     },
+    "./connectors/ledger": {
+      "types": "./dist/connectors/ledger.d.ts",
+      "default": "./dist/connectors/ledger.js"
+    },
     "./connectors/metaMask": {
       "types": "./dist/connectors/metaMask.d.ts",
       "default": "./dist/connectors/metaMask.js"

--- a/packages/core/src/connectors/ledger.ts
+++ b/packages/core/src/connectors/ledger.ts
@@ -1,0 +1,1 @@
+export { LedgerConnector } from '@wagmi/connectors/ledger'

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(
       'src/connectors/index.ts',
       'src/connectors/coinbaseWallet.ts',
       'src/connectors/injected.ts',
+      'src/connectors/ledger.ts',
       'src/connectors/metaMask.ts',
       'src/connectors/mock.ts',
       'src/connectors/safe.ts',

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -4,6 +4,7 @@ chains/**
 connectors/**
 connectors/coinbaseWallet/**
 connectors/injected/**
+connectors/ledger/**
 connectors/metaMask/**
 connectors/mock/**
 connectors/safe/**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/connectors/injected.d.ts",
       "default": "./dist/connectors/injected.js"
     },
+    "./connectors/ledger": {
+      "types": "./dist/connectors/ledger.d.ts",
+      "default": "./dist/connectors/ledger.js"
+    },
     "./connectors/metaMask": {
       "types": "./dist/connectors/metaMask.d.ts",
       "default": "./dist/connectors/metaMask.js"

--- a/packages/react/src/connectors/ledger.ts
+++ b/packages/react/src/connectors/ledger.ts
@@ -1,0 +1,1 @@
+export { LedgerConnector } from '@wagmi/core/connectors/ledger'

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(
       'src/connectors/index.ts',
       'src/connectors/coinbaseWallet.ts',
       'src/connectors/injected.ts',
+      'src/connectors/ledger.ts',
       'src/connectors/metaMask.ts',
       'src/connectors/mock.ts',
       'src/connectors/safe.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   abitype: 0.8.7
   esbuild: 0.15.13
@@ -299,9 +303,12 @@ importers:
       '@coinbase/wallet-sdk':
         specifier: ^3.6.6
         version: 3.6.6
+      '@ledgerhq/connect-kit':
+        specifier: 1.1.8
+        version: 1.1.8(rollup@3.20.2)
       '@ledgerhq/connect-kit-loader':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.8
+        version: 1.1.8
       '@safe-global/safe-apps-provider':
         specifier: ^0.18.1
         version: 0.18.1(typescript@5.0.4)
@@ -1440,6 +1447,10 @@ packages:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
     dev: true
 
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: false
+
   /@jridgewell/trace-mapping@0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
     dependencies:
@@ -1480,6 +1491,22 @@ packages:
     resolution: {integrity: sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg==}
     dev: false
 
+  /@ledgerhq/connect-kit-loader@1.1.8:
+    resolution: {integrity: sha512-mDJsOucVW8m3Lk2fdQst+P74SgiKebvq1iBk4sXLbADQOwhL9bWGaArvO+tW7jPJZwEfSPWBdHcHoYi11XAwZw==}
+    dev: false
+
+  /@ledgerhq/connect-kit@1.1.8(rollup@3.20.2):
+    resolution: {integrity: sha512-0jOA4AEmmK4nj3qW6+9ZoXLGDVg6mepx6O/lppxTOk7bkd8+wdn6fkjD5oHDL49ojBXHTP9upTBFVa5E6ZOR2Q==}
+    dependencies:
+      '@segment/analytics-next': 1.62.0
+      rollup-plugin-dotenv: 0.5.0(rollup@3.20.2)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+    dev: false
+
   /@lit-labs/ssr-dom-shim@1.1.0:
     resolution: {integrity: sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong==}
     dev: false
@@ -1488,6 +1515,18 @@ packages:
     resolution: {integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==}
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.1.0
+    dev: false
+
+  /@lukeed/csprng@1.1.0:
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@lukeed/uuid@2.0.1:
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@lukeed/csprng': 1.1.0
     dev: false
 
   /@manypkg/find-root@1.1.0:
@@ -2398,6 +2437,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -2516,6 +2556,35 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       tiny-warning: 1.0.3
       tslib: 2.5.0
+    dev: false
+
+  /@rollup/plugin-replace@5.0.5(rollup@3.20.2):
+    resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@3.20.2)
+      magic-string: 0.30.5
+      rollup: 3.20.2
+    dev: false
+
+  /@rollup/pluginutils@5.1.0(rollup@3.20.2):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.20.2
     dev: false
 
   /@rometools/cli-darwin-arm64@12.1.2:
@@ -2667,6 +2736,76 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
+
+  /@segment/analytics-core@1.4.0:
+    resolution: {integrity: sha512-rLUv5Se0iDccykxY8bWUuoZT4gg8fNW00zMPqkJN+ONfj5/P1eaGQgygq2EHlR9j20a7tNtp5Y9bZ4rLzViIXQ==}
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      '@segment/analytics-generic-utils': 1.1.0
+      dset: 3.1.3
+      tslib: 2.5.0
+    dev: false
+
+  /@segment/analytics-generic-utils@1.1.0:
+    resolution: {integrity: sha512-nOgmbfsKD0jFzH3df+PtjLq3qTspdcFpIy/F5ziho5qiE+QATM8wY9TpvCNBbcHr2f3OGzT6SgjJLFlmM5Yb+w==}
+    dev: false
+
+  /@segment/analytics-next@1.62.0:
+    resolution: {integrity: sha512-RuamvHQPVAkwO9/SSd/ioC/fT+4BaWvDlgkCKQi1DHXT4+5HG7bJROIUBgrHDmXEOVavnH7U97BIkZ1tgXEchw==}
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      '@segment/analytics-core': 1.4.0
+      '@segment/analytics-generic-utils': 1.1.0
+      '@segment/analytics.js-video-plugins': 0.2.1
+      '@segment/facade': 3.4.10
+      '@segment/tsub': 2.0.0
+      dset: 3.1.3
+      js-cookie: 3.0.1
+      node-fetch: 2.6.9
+      spark-md5: 3.0.2
+      tslib: 2.5.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@segment/analytics.js-video-plugins@0.2.1:
+    resolution: {integrity: sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==}
+    dependencies:
+      unfetch: 3.1.2
+    dev: false
+
+  /@segment/facade@3.4.10:
+    resolution: {integrity: sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==}
+    dependencies:
+      '@segment/isodate-traverse': 1.1.1
+      inherits: 2.0.4
+      new-date: 1.0.3
+      obj-case: 0.2.1
+    dev: false
+
+  /@segment/isodate-traverse@1.1.1:
+    resolution: {integrity: sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==}
+    dependencies:
+      '@segment/isodate': 1.0.3
+    dev: false
+
+  /@segment/isodate@1.0.3:
+    resolution: {integrity: sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==}
+    dev: false
+
+  /@segment/tsub@2.0.0:
+    resolution: {integrity: sha512-NzkBK8GwPsyQ74AceLjENbUoaFrObnzEKOX4ko2wZDuIyK+DnDm3B//8xZYI2LCKt+wUD55l6ygfjCoVs8RMWw==}
+    hasBin: true
+    dependencies:
+      '@stdlib/math-base-special-ldexp': 0.0.5
+      dlv: 1.1.3
+      dset: 3.1.3
+      tiny-hashes: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@sentry/core@5.30.0:
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -2891,6 +3030,1037 @@ packages:
       '@stablelib/keyagreement': 1.0.1
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stdlib/array-float32@0.0.6:
+    resolution: {integrity: sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-float32array-support': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/array-float64@0.0.6:
+    resolution: {integrity: sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-float64array-support': 0.0.8
+    dev: false
+
+  /@stdlib/array-uint16@0.0.6:
+    resolution: {integrity: sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-uint16array-support': 0.0.8
+    dev: false
+
+  /@stdlib/array-uint32@0.0.6:
+    resolution: {integrity: sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-uint32array-support': 0.0.8
+    dev: false
+
+  /@stdlib/array-uint8@0.0.7:
+    resolution: {integrity: sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-uint8array-support': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-float32array-support@0.0.8:
+    resolution: {integrity: sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-float32array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-float64-pinf': 0.0.8
+      '@stdlib/fs-read-file': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/assert-has-float64array-support@0.0.8:
+    resolution: {integrity: sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-float64array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-node-buffer-support@0.0.8:
+    resolution: {integrity: sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-buffer': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-own-property@0.0.7:
+    resolution: {integrity: sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/assert-has-symbol-support@0.0.8:
+    resolution: {integrity: sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-tostringtag-support@0.0.9:
+    resolution: {integrity: sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-has-symbol-support': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-uint16array-support@0.0.8:
+    resolution: {integrity: sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-uint16array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-uint16-max': 0.0.7
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-uint32array-support@0.0.8:
+    resolution: {integrity: sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-uint32array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-uint32-max': 0.0.7
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-uint8array-support@0.0.8:
+    resolution: {integrity: sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-uint8array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-uint8-max': 0.0.7
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-array@0.0.7:
+    resolution: {integrity: sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-big-endian@0.0.7:
+    resolution: {integrity: sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/array-uint16': 0.0.6
+      '@stdlib/array-uint8': 0.0.7
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-boolean@0.0.8:
+    resolution: {integrity: sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-buffer@0.0.8:
+    resolution: {integrity: sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-object-like': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-float32array@0.0.8:
+    resolution: {integrity: sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-float64array@0.0.8:
+    resolution: {integrity: sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-function@0.0.8:
+    resolution: {integrity: sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-type-of': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-little-endian@0.0.7:
+    resolution: {integrity: sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/array-uint16': 0.0.6
+      '@stdlib/array-uint8': 0.0.7
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-number@0.0.7:
+    resolution: {integrity: sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/number-ctor': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-object-like@0.0.8:
+    resolution: {integrity: sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-tools-array-function': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/assert-is-object@0.0.8:
+    resolution: {integrity: sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-array': 0.0.7
+    dev: false
+
+  /@stdlib/assert-is-plain-object@0.0.7:
+    resolution: {integrity: sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-object': 0.0.8
+      '@stdlib/utils-get-prototype-of': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-regexp-string@0.0.9:
+    resolution: {integrity: sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/regexp-eol': 0.0.7
+      '@stdlib/regexp-regexp': 0.0.8
+      '@stdlib/streams-node-stdin': 0.0.7
+    dev: false
+
+  /@stdlib/assert-is-regexp@0.0.7:
+    resolution: {integrity: sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-string@0.0.8:
+    resolution: {integrity: sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-uint16array@0.0.8:
+    resolution: {integrity: sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-uint32array@0.0.8:
+    resolution: {integrity: sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-uint8array@0.0.8:
+    resolution: {integrity: sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-tools-array-function@0.0.7:
+    resolution: {integrity: sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-array': 0.0.7
+    dev: false
+
+  /@stdlib/buffer-ctor@0.0.7:
+    resolution: {integrity: sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-node-buffer-support': 0.0.8
+    dev: false
+
+  /@stdlib/buffer-from-string@0.0.8:
+    resolution: {integrity: sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/buffer-ctor': 0.0.7
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/cli-ctor@0.0.3:
+    resolution: {integrity: sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-noop': 0.0.14
+      minimist: 1.2.8
+    dev: false
+
+  /@stdlib/complex-float32@0.0.7:
+    resolution: {integrity: sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-number': 0.0.7
+      '@stdlib/number-float64-base-to-float32': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-define-property': 0.0.9
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/complex-float64@0.0.8:
+    resolution: {integrity: sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-number': 0.0.7
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-define-property': 0.0.9
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/complex-reim@0.0.6:
+    resolution: {integrity: sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/complex-float64': 0.0.8
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/complex-reimf@0.0.1:
+    resolution: {integrity: sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float32': 0.0.6
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-exponent-bias@0.0.8:
+    resolution: {integrity: sha512-IzBJQw9hYgWCki7VoC/zJxEA76Nmf8hmY+VkOWnJ8IyfgTXClgY8tfDGS1cc4l/hCOEllxGp9FRvVdn24A5tKQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-high-word-abs-mask@0.0.1:
+    resolution: {integrity: sha512-1vy8SUyMHFBwqUUVaZFA7r4/E3cMMRKSwsaa/EZ15w7Kmc01W/ZmaaTLevRcIdACcNgK+8i8813c8H7LScXNcQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-high-word-exponent-mask@0.0.8:
+    resolution: {integrity: sha512-z28/EQERc0VG7N36bqdvtrRWjFc8600PKkwvl/nqx6TpKAzMXNw55BS1xT4C28Sa9Z7uBWeUj3UbIFedbkoyMw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-high-word-sign-mask@0.0.1:
+    resolution: {integrity: sha512-hmTr5caK1lh1m0eyaQqt2Vt3y+eEdAx57ndbADEbXhxC9qSGd0b4bLSzt/Xp4MYBYdQkHAE/BlkgUiRThswhCg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-max-base2-exponent-subnormal@0.0.8:
+    resolution: {integrity: sha512-YGBZykSiXFebznnJfWFDwhho2Q9xhUWOL+X0lZJ4ItfTTo40W6VHAyNYz98tT/gJECFype0seNzzo1nUxCE7jQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-max-base2-exponent@0.0.8:
+    resolution: {integrity: sha512-xBAOtso1eiy27GnTut2difuSdpsGxI8dJhXupw0UukGgvy/3CSsyNm+a1Suz/dhqK4tPOTe5QboIdNMw5IgXKQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-min-base2-exponent-subnormal@0.0.8:
+    resolution: {integrity: sha512-bt81nBus/91aEqGRQBenEFCyWNsf8uaxn4LN1NjgkvY92S1yVxXFlC65fJHsj9FTqvyZ+uj690/gdMKUDV3NjQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-ninf@0.0.8:
+    resolution: {integrity: sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/number-ctor': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-pinf@0.0.8:
+    resolution: {integrity: sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-smallest-normal@0.0.8:
+    resolution: {integrity: sha512-Qwxpn5NA3RXf+mQcffCWRcsHSPTUQkalsz0+JDpblDszuz2XROcXkOdDr5LKgTAUPIXsjOgZzTsuRONENhsSEg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-uint16-max@0.0.7:
+    resolution: {integrity: sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/constants-uint32-max@0.0.7:
+    resolution: {integrity: sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/constants-uint8-max@0.0.7:
+    resolution: {integrity: sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/fs-exists@0.0.8:
+    resolution: {integrity: sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-cwd': 0.0.8
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/fs-read-file@0.0.8:
+    resolution: {integrity: sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/fs-resolve-parent-path@0.0.8:
+    resolution: {integrity: sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-plain-object': 0.0.7
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-exists': 0.0.8
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-cwd': 0.0.8
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/math-base-assert-is-infinite@0.0.9:
+    resolution: {integrity: sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-ninf': 0.0.8
+      '@stdlib/constants-float64-pinf': 0.0.8
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-assert-is-nan@0.0.8:
+    resolution: {integrity: sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-napi-binary@0.0.8:
+    resolution: {integrity: sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/complex-float64': 0.0.8
+      '@stdlib/complex-reim': 0.0.6
+      '@stdlib/complex-reimf': 0.0.1
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-napi-unary@0.0.9:
+    resolution: {integrity: sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/complex-float64': 0.0.8
+      '@stdlib/complex-reim': 0.0.6
+      '@stdlib/complex-reimf': 0.0.1
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-special-abs@0.0.6:
+    resolution: {integrity: sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/math-base-napi-unary': 0.0.9
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-special-copysign@0.0.7:
+    resolution: {integrity: sha512-7Br7oeuVJSBKG8BiSk/AIRFTBd2sbvHdV3HaqRj8tTZHX8BQomZ3Vj4Qsiz3kPyO4d6PpBLBTYlGTkSDlGOZJA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-high-word-abs-mask': 0.0.1
+      '@stdlib/constants-float64-high-word-sign-mask': 0.0.1
+      '@stdlib/math-base-napi-binary': 0.0.8
+      '@stdlib/number-float64-base-from-words': 0.0.6
+      '@stdlib/number-float64-base-get-high-word': 0.0.6
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-special-ldexp@0.0.5:
+    resolution: {integrity: sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-exponent-bias': 0.0.8
+      '@stdlib/constants-float64-max-base2-exponent': 0.0.8
+      '@stdlib/constants-float64-max-base2-exponent-subnormal': 0.0.8
+      '@stdlib/constants-float64-min-base2-exponent-subnormal': 0.0.8
+      '@stdlib/constants-float64-ninf': 0.0.8
+      '@stdlib/constants-float64-pinf': 0.0.8
+      '@stdlib/math-base-assert-is-infinite': 0.0.9
+      '@stdlib/math-base-assert-is-nan': 0.0.8
+      '@stdlib/math-base-special-copysign': 0.0.7
+      '@stdlib/number-float64-base-exponent': 0.0.6
+      '@stdlib/number-float64-base-from-words': 0.0.6
+      '@stdlib/number-float64-base-normalize': 0.0.9
+      '@stdlib/number-float64-base-to-words': 0.0.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-ctor@0.0.7:
+    resolution: {integrity: sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/number-float64-base-exponent@0.0.6:
+    resolution: {integrity: sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-exponent-bias': 0.0.8
+      '@stdlib/constants-float64-high-word-exponent-mask': 0.0.8
+      '@stdlib/number-float64-base-get-high-word': 0.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-from-words@0.0.6:
+    resolution: {integrity: sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/array-uint32': 0.0.6
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-get-high-word@0.0.6:
+    resolution: {integrity: sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/array-uint32': 0.0.6
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-normalize@0.0.9:
+    resolution: {integrity: sha512-+rm7RQJEj8zHkqYFE2a6DgNQSB5oKE/IydHAajgZl40YB91BoYRYf/ozs5/tTwfy2Fc04+tIpSfFtzDr4ZY19Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-smallest-normal': 0.0.8
+      '@stdlib/math-base-assert-is-infinite': 0.0.9
+      '@stdlib/math-base-assert-is-nan': 0.0.8
+      '@stdlib/math-base-special-abs': 0.0.6
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-to-float32@0.0.7:
+    resolution: {integrity: sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float32': 0.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-to-words@0.0.7:
+    resolution: {integrity: sha512-7wsYuq+2MGp9rAkTnQ985rah7EJI9TfgHrYSSd4UIu4qIjoYmWIKEhIDgu7/69PfGrls18C3PxKg1pD/v7DQTg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/array-uint32': 0.0.6
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/os-byte-order': 0.0.7
+      '@stdlib/os-float-word-order': 0.0.7
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/os-byte-order@0.0.7:
+    resolution: {integrity: sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-big-endian': 0.0.7
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/os-float-word-order@0.0.7:
+    resolution: {integrity: sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/os-byte-order': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/process-cwd@0.0.8:
+    resolution: {integrity: sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/process-read-stdin@0.0.7:
+    resolution: {integrity: sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/buffer-ctor': 0.0.7
+      '@stdlib/buffer-from-string': 0.0.8
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/utils-next-tick': 0.0.8
+    dev: false
+
+  /@stdlib/regexp-eol@0.0.7:
+    resolution: {integrity: sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-is-boolean': 0.0.8
+      '@stdlib/assert-is-plain-object': 0.0.7
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/regexp-extended-length-path@0.0.7:
+    resolution: {integrity: sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/regexp-function-name@0.0.7:
+    resolution: {integrity: sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/regexp-regexp@0.0.8:
+    resolution: {integrity: sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/streams-node-stdin@0.0.7:
+    resolution: {integrity: sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/string-base-format-interpolate@0.0.4:
+    resolution: {integrity: sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/string-base-format-tokenize@0.0.4:
+    resolution: {integrity: sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/string-format@0.0.3:
+    resolution: {integrity: sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/string-base-format-interpolate': 0.0.4
+      '@stdlib/string-base-format-tokenize': 0.0.4
+    dev: false
+
+  /@stdlib/string-lowercase@0.0.9:
+    resolution: {integrity: sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/string-replace@0.0.11:
+    resolution: {integrity: sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-regexp': 0.0.7
+      '@stdlib/assert-is-regexp-string': 0.0.9
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/regexp-eol': 0.0.7
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/string-format': 0.0.3
+      '@stdlib/utils-escape-regexp-string': 0.0.9
+      '@stdlib/utils-regexp-from-string': 0.0.9
+    dev: false
+
+  /@stdlib/types@0.0.14:
+    resolution: {integrity: sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/utils-constructor-name@0.0.8:
+    resolution: {integrity: sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-buffer': 0.0.8
+      '@stdlib/regexp-function-name': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/utils-convert-path@0.0.8:
+    resolution: {integrity: sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/regexp-eol': 0.0.7
+      '@stdlib/regexp-extended-length-path': 0.0.7
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/string-lowercase': 0.0.9
+      '@stdlib/string-replace': 0.0.11
+    dev: false
+
+  /@stdlib/utils-define-nonenumerable-read-only-property@0.0.7:
+    resolution: {integrity: sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-define-property': 0.0.9
+    dev: false
+
+  /@stdlib/utils-define-property@0.0.9:
+    resolution: {integrity: sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/types': 0.0.14
+    dev: false
+
+  /@stdlib/utils-escape-regexp-string@0.0.9:
+    resolution: {integrity: sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/utils-get-prototype-of@0.0.7:
+    resolution: {integrity: sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/utils-global@0.0.7:
+    resolution: {integrity: sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-boolean': 0.0.8
+    dev: false
+
+  /@stdlib/utils-library-manifest@0.0.8:
+    resolution: {integrity: sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-resolve-parent-path': 0.0.8
+      '@stdlib/utils-convert-path': 0.0.8
+      debug: 2.6.9
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/utils-native-class@0.0.8:
+    resolution: {integrity: sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+    dev: false
+
+  /@stdlib/utils-next-tick@0.0.8:
+    resolution: {integrity: sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/utils-noop@0.0.14:
+    resolution: {integrity: sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/utils-regexp-from-string@0.0.9:
+    resolution: {integrity: sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/regexp-regexp': 0.0.8
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/utils-type-of@0.0.8:
+    resolution: {integrity: sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-constructor-name': 0.0.8
+      '@stdlib/utils-global': 0.0.7
     dev: false
 
   /@swc/helpers@0.4.11:
@@ -5401,6 +6571,17 @@ packages:
       time-zone: 1.0.0
     dev: true
 
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -5619,7 +6800,6 @@ packages:
 
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-    dev: true
 
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -5667,6 +6847,11 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
     dev: true
+
+  /dset@3.1.3:
+    resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
+    engines: {node: '>=4'}
+    dev: false
 
   /duplexify@4.1.2:
     resolution: {integrity: sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==}
@@ -6375,6 +7560,10 @@ packages:
     dependencies:
       '@types/estree-jsx': 1.0.0
       '@types/unist': 2.0.6
+    dev: false
+
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: false
 
   /estree-walker@3.0.3:
@@ -7632,7 +8821,6 @@ packages:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -7959,6 +9147,11 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
     dev: true
+
+  /js-cookie@3.0.1:
+    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -8447,6 +9640,13 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
+
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -9132,7 +10332,6 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /mixme@0.5.9:
     resolution: {integrity: sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==}
@@ -9216,6 +10415,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -9289,9 +10492,19 @@ packages:
     resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
     dev: false
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: false
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /new-date@1.0.3:
+    resolution: {integrity: sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==}
+    dependencies:
+      '@segment/isodate': 1.0.3
+    dev: false
 
   /next-seo@5.15.0(next@13.2.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==}
@@ -9571,6 +10784,10 @@ packages:
   /nwsapi@2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
     dev: true
+
+  /obj-case@0.2.1:
+    resolution: {integrity: sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==}
+    dev: false
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -10540,7 +11757,6 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /resolve@2.0.0-next.4:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
@@ -10603,13 +11819,23 @@ packages:
       bn.js: 5.2.1
     dev: false
 
+  /rollup-plugin-dotenv@0.5.0(rollup@3.20.2):
+    resolution: {integrity: sha512-M2gZqEZebtcKaA7OBdO4UF3WmkI02wVD6UVwoxFlRKoq4/n1Q9Cw6UV8dPvVZYpGQ+ug2JPoogrCLaydIKU96A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0
+    dependencies:
+      '@rollup/plugin-replace': 5.0.5(rollup@3.20.2)
+      dotenv: 16.0.3
+      rollup: 3.20.2
+    dev: false
+
   /rollup@3.20.2:
     resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /rome@12.1.2:
     resolution: {integrity: sha512-ObyDevKRU6k3R9fAK9hDvrX9FSPEJ0JWNv5i65enknV+epWjEIL0jnDuijPUX7MSVS6M/ngTiKUaeF3w63SJXw==}
@@ -10976,6 +12202,10 @@ packages:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
     dev: false
 
+  /spark-md5@3.0.2:
+    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
+    dev: false
+
   /spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
     dependencies:
@@ -11317,7 +12547,6 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -11419,6 +12648,10 @@ packages:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
     dev: true
+
+  /tiny-hashes@1.0.1:
+    resolution: {integrity: sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==}
+    dev: false
 
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
@@ -11729,6 +12962,10 @@ packages:
       pathe: 1.1.1
     dev: false
 
+  /unfetch@3.1.2:
+    resolution: {integrity: sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==}
+    dev: false
+
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
     dev: false
@@ -11989,6 +13226,11 @@ packages:
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: false
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
 
@@ -12661,7 +13903,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   abitype: 0.8.7
   esbuild: 0.15.13
@@ -307,7 +303,7 @@ importers:
         specifier: 1.1.8
         version: 1.1.8(rollup@3.20.2)
       '@ledgerhq/connect-kit-loader':
-        specifier: ^1.1.8
+        specifier: 1.1.8
         version: 1.1.8
       '@safe-global/safe-apps-provider':
         specifier: ^0.18.1
@@ -1485,10 +1481,6 @@ packages:
     dependencies:
       '@json-rpc-tools/types': 1.7.6
       '@pedrouid/environment': 1.0.1
-    dev: false
-
-  /@ledgerhq/connect-kit-loader@1.1.0:
-    resolution: {integrity: sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg==}
     dev: false
 
   /@ledgerhq/connect-kit-loader@1.1.8:
@@ -4680,7 +4672,7 @@ packages:
         optional: true
     dependencies:
       '@coinbase/wallet-sdk': 3.6.6
-      '@ledgerhq/connect-kit-loader': 1.1.0
+      '@ledgerhq/connect-kit-loader': 1.1.8
       '@safe-global/safe-apps-provider': 0.15.2
       '@safe-global/safe-apps-sdk': 7.10.0
       '@wagmi/chains': 0.2.22(typescript@5.0.4)
@@ -5975,7 +5967,7 @@ packages:
     resolution: {integrity: sha512-Of6l6JBAxiyQ5axFxUM6dYeP/W7X2Sozeo/4EYB9sJhL+dqL7TKjg+shwxp6jlu/6ZSERfsYtIpSJ1/x3XkAEA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: 0.15.13
+      esbuild: '>=0.13'
     dependencies:
       esbuild: 0.15.13
       load-tsconfig: 0.2.5
@@ -5985,7 +5977,7 @@ packages:
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: 0.15.13
+      esbuild: '>=0.17'
     dependencies:
       esbuild: 0.15.13
       load-tsconfig: 0.2.5
@@ -7150,7 +7142,7 @@ packages:
   /esbuild-register@3.4.2(esbuild@0.15.13):
     resolution: {integrity: sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==}
     peerDependencies:
-      esbuild: 0.15.13
+      esbuild: '>=0.12 <1'
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.15.13
@@ -13903,3 +13895,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       '@coinbase/wallet-sdk':
         specifier: ^3.6.6
         version: 3.6.6
+      '@ledgerhq/connect-kit-loader':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@safe-global/safe-apps-provider':
         specifier: ^0.18.1
         version: 0.18.1(typescript@5.0.4)
@@ -2395,7 +2398,6 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
-      napi-wasm: 1.1.0
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -9285,10 +9287,6 @@ packages:
 
   /napi-macros@2.0.0:
     resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
-    dev: false
-
-  /napi-wasm@1.1.0:
-    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
     dev: false
 
   /natural-compare@1.4.0:


### PR DESCRIPTION
## Description

This PR restores the Ledger connector. (reverting https://github.com/wevm/wagmi/commit/53ca1f7eb411d912e11fcce7e03bd61ed067959c). 

It now loads the [@ledgerhq/connect-kit](https://github.com/LedgerHQ/connect-kit?tab=readme-ov-file#-important-notice-) package without going through **@ledgerhq/connect-kit-loader**'s `loadConnectKit` function.  

**@ledgerhq/connect-kit** is thus added (with a fixed version, 1.1.8) in packages/connectors/package.json

## Additional Information

 **@ledgerhq/connect-kit-loader** is still required as we need types exported from this package. Future iterations of the **@ledgerhq/connect-kit** package will directly export those and requiring  **@ledgerhq/connect-kit-loader** will thus become unnecessary.
