### PR TITLE
Fix prop name when generating contract event watch hooks

### DIFF
--- a/.changeset/lazy-kiwis-run.md
+++ b/.changeset/lazy-kiwis-run.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Fix prop name when generating contract event watch hooks

--- a/.changeset/lazy-kiwis-run.md
+++ b/.changeset/lazy-kiwis-run.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Fix prop name when generating contract event watch hooks
+Fixed prop name when generating contract event watch hooks

--- a/packages/cli/src/plugins/react.test.ts
+++ b/packages/cli/src/plugins/react.test.ts
@@ -107,12 +107,12 @@ test('default', async () => {
     /**
      * Wraps __{@link useWatchContractEvent}__ with \`abi\` set to __{@link erc20Abi}__ and \`eventName\` set to \`\\"Approval\\"\`
      */
-    export const useWatchErc20ApprovalEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, functionName: 'Approval' })
+    export const useWatchErc20ApprovalEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, eventName: 'Approval' })
 
     /**
      * Wraps __{@link useWatchContractEvent}__ with \`abi\` set to __{@link erc20Abi}__ and \`eventName\` set to \`\\"Transfer\\"\`
      */
-    export const useWatchErc20TransferEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, functionName: 'Transfer' })"
+    export const useWatchErc20TransferEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, eventName: 'Transfer' })"
   `)
 })
 
@@ -217,12 +217,12 @@ test('address', async () => {
     /**
      * Wraps __{@link useWatchContractEvent}__ with \`abi\` set to __{@link erc20Abi}__ and \`eventName\` set to \`\\"Approval\\"\`
      */
-    export const useWatchErc20ApprovalEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, functionName: 'Approval' })
+    export const useWatchErc20ApprovalEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, eventName: 'Approval' })
 
     /**
      * Wraps __{@link useWatchContractEvent}__ with \`abi\` set to __{@link erc20Abi}__ and \`eventName\` set to \`\\"Transfer\\"\`
      */
-    export const useWatchErc20TransferEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, functionName: 'Transfer' })"
+    export const useWatchErc20TransferEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, eventName: 'Transfer' })"
   `)
 })
 
@@ -327,11 +327,11 @@ test('legacy hook names', async () => {
     /**
      * Wraps __{@link useWatchContractEvent}__ with \`abi\` set to __{@link erc20Abi}__ and \`eventName\` set to \`\\"Approval\\"\`
      */
-    export const useErc20ApprovalEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, functionName: 'Approval' })
+    export const useErc20ApprovalEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, eventName: 'Approval' })
 
     /**
      * Wraps __{@link useWatchContractEvent}__ with \`abi\` set to __{@link erc20Abi}__ and \`eventName\` set to \`\\"Transfer\\"\`
      */
-    export const useErc20TransferEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, functionName: 'Transfer' })"
+    export const useErc20TransferEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: erc20Abi, address: erc20Address, eventName: 'Transfer' })"
   `)
 })

--- a/packages/cli/src/plugins/react.ts
+++ b/packages/cli/src/plugins/react.ts
@@ -226,7 +226,7 @@ export const ${hookName} = ${pure} ${functionName}({ ${innerContent} })`,
             })
             content.push(
               `${docString}
-export const ${hookName} = ${pure} ${functionName}({ ${innerContent}, functionName: '${item.name}' })`,
+export const ${hookName} = ${pure} ${functionName}({ ${innerContent}, eventName: '${item.name}' })`,
             )
           }
         }


### PR DESCRIPTION
## Description

Replace `functionName` for `eventName` when generating event watch hooks through the `useWatchContractEvent` function in the CLI's react plugin as the prop does not exist in that function.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [X] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [X] Added or updated tests (and snapshots) related to the changes made.
