### PR TITLE
Update ethers.md to fix typo "getEthersSigner" to "useEthersSigner"

### DIFF
--- a/docs/react/guides/ethers.md
+++ b/docs/react/guides/ethers.md
@@ -219,12 +219,12 @@ export async function useEthersSigner({ chainId }: { chainId?: number } = {}) {
 
 ### Usage
 
-Now you can use the `getEthersSigner` function in your components:
+Now you can use the `useEthersSigner` function in your components:
 
 ::: code-group
 
 ```ts [example.ts]
-import { getEthersSigner } from './ethers'
+import { useEthersSigner } from './ethers'
 
 function example() {
   const signer = useEthersSigner()


### PR DESCRIPTION
## Description

fix typo "getEthersSigner" to "useEthersSigner"

## Additional Information

In the example it shows import { getEthersSigner } hook from './ethers' however there is no exported getEthersSigner from the ethers example file. It should be useEthersSigner