### PR TITLE
fix: prelude gas estimation

### DIFF
--- a/.changeset/three-spoons-drum.md
+++ b/.changeset/three-spoons-drum.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Added a prelude gas estimate check to `sendTransaction`/`useSendTransaction`.

--- a/docs/core/api/actions/sendTransaction.md
+++ b/docs/core/api/actions/sendTransaction.md
@@ -149,9 +149,9 @@ const result = await sendTransaction(config, {
 
 ### gas
 
-`bigint | undefined`
+`bigint | undefined | null`
 
-Gas provided for transaction execution.
+Gas provided for transaction execution, or `null` to skip the prelude gas estimation.
 
 ::: code-group
 ```ts [index.ts]

--- a/packages/core/src/actions/sendTransaction.test.ts
+++ b/packages/core/src/actions/sendTransaction.test.ts
@@ -74,6 +74,7 @@ test('behavior: value exceeds balance', async () => {
       from:   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
       to:     0xd2135CfB216b74109775236E36d4b433F1DF507B
       value:  99999 ETH
+      gas:    21000
 
     Details: Insufficient funds for gas * price + value
     Version: viem@2.0.0"

--- a/packages/core/src/actions/sendTransaction.test.ts
+++ b/packages/core/src/actions/sendTransaction.test.ts
@@ -50,3 +50,33 @@ test('behavior: account does not exist on connector', async () => {
   `)
   await disconnect(config, { connector })
 })
+
+test('behavior: value exceeds balance', async () => {
+  await connect(config, { connector })
+  await expect(
+    sendTransaction(config, {
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('99999'),
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    "The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.
+
+    This error could arise when the account does not have enough funds to:
+     - pay for the total gas fee,
+     - pay for the value to send.
+     
+    The cost of the transaction is calculated as \`gas * gas fee + value\`, where:
+     - \`gas\` is the amount of gas needed for transaction to execute,
+     - \`gas fee\` is the gas fee,
+     - \`value\` is the amount of ether to send to the recipient.
+     
+    Request Arguments:
+      from:   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+      to:     0xd2135CfB216b74109775236E36d4b433F1DF507B
+      value:  99999 ETH
+
+    Details: Insufficient funds for gas * price + value
+    Version: viem@2.0.0"
+  `)
+  await disconnect(config, { connector })
+})


### PR DESCRIPTION
## Description

Noticed that we didn't have the preluding gas estimate check in `sendTransaction`. Adding it means we reach parity with `writeContract` (w/ `simulateContract` being the prelude check), and consumers will be less surprised when unexpected errors happen upon tx execution.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
