### PR TITLE
fix: use eventName instead of functionName

### DIFF
--- a/.changeset/lazy-lemons-act.md
+++ b/.changeset/lazy-lemons-act.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Fixed cli actions plugin using `functionName` instead of `eventName`

--- a/.changeset/lazy-lemons-act.md
+++ b/.changeset/lazy-lemons-act.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Fixed cli actions plugin using `functionName` instead of `eventName`
+Fixed actions plugin issue where `functionName` was used instead of `eventName` for generated contract event actions.

--- a/packages/cli/src/plugins/actions.ts
+++ b/packages/cli/src/plugins/actions.ts
@@ -233,7 +233,7 @@ export const ${actionName} = ${pure} ${functionName}({ ${innerContent} })`,
             })
             content.push(
               `${docString}
-export const ${actionName} = ${pure} ${functionName}({ ${innerContent}, functionName: '${item.name}' })`,
+export const ${actionName} = ${pure} ${functionName}({ ${innerContent}, eventName: '${item.name}' })`,
             )
           }
         }


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

use `eventName` instead of `functionName` when generating contract events code.
Closes: https://github.com/wevm/wagmi/issues/3409

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
