### PR TITLE
Feat: add `getTransactionReceipt` and `useTransactionReceipt`

### DIFF
--- a/.changeset/short-dolphins-serve.md
+++ b/.changeset/short-dolphins-serve.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": minor
+---
+
+Added `getTransactionReceipt` action.

--- a/.changeset/tidy-dingos-confess.md
+++ b/.changeset/tidy-dingos-confess.md
@@ -1,0 +1,5 @@
+---
+"wagmi": minor
+---
+
+Added `useTransactionReceipt` hook.

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -251,6 +251,10 @@ export function getSidebar() {
             link: '/react/api/hooks/useTransactionCount',
           },
           {
+            text: 'useTransactionReceipt',
+            link: '/react/api/hooks/useTransactionReceipt',
+          },
+          {
             text: 'useToken',
             link: '/react/api/hooks/useToken',
           },
@@ -507,6 +511,10 @@ export function getSidebar() {
           {
             text: 'getTransactionCount',
             link: '/core/api/actions/getTransactionCount',
+          },
+          {
+            text: 'getTransactionReceipt',
+            link: '/core/api/actions/getTransactionReceipt',
           },
           {
             text: 'getWalletClient',

--- a/docs/core/api/actions/getTransactionReceipt.md
+++ b/docs/core/api/actions/getTransactionReceipt.md
@@ -1,0 +1,95 @@
+<script setup>
+const packageName = '@wagmi/core'
+const actionName = 'getTransactionReceipt'
+const typeName = 'getTransactionReceipt'
+</script>
+
+# getTransactionReceipt
+
+Action for return the [Transaction Receipt](https://viem.sh/docs/glossary/terms.html#transaction-receipt) given a [Transaction](https://viem.sh/docs/glossary/terms.html#transaction) hash.
+
+## Import
+
+```ts
+import { getTransactionReceipt } from '@wagmi/core'
+```
+
+## Usage
+
+::: code-group
+```ts [index.ts]
+import { getTransactionReceipt } from '@wagmi/core'
+import { config } from './config'
+
+await getTransactionReceipt(config, {
+  hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type GetTransactionReceiptParameters } from '@wagmi/core'
+```
+
+### hash
+
+`` `0x${string}` ``
+
+A transaction hash.
+
+::: code-group
+```ts [index.ts]
+import { getTransactionReceipt } from '@wagmi/core'
+import { config } from './config'
+
+await getTransactionReceipt(config, {
+  hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d', // [!code focus]
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+The ID of chain to return the transaction receipt from.
+
+::: code-group
+```ts [index.ts]
+import { getTransactionReceipt } from '@wagmi/core'
+import { mainnet } from '@wagmi/core/chains'
+import { config } from './config'
+
+await getTransactionReceipt(config, {
+  chainId: mainnet.id, // [!code focus]
+  hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+})
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
+## Return Type
+
+```ts
+import { type GetTransactionReceiptReturnType } from '@wagmi/core'
+```
+
+[`TransactionReceipt`](https://viem.sh/docs/glossary/types.html#transactionreceipt)
+
+The transaction receipt.
+
+## Error
+
+```ts
+import { type GetTransactionReceiptErrorType } from '@wagmi/core'
+```
+
+<!--@include: @shared/query-imports.md-->
+
+## Viem
+
+- [`getTransactionReceipt`](https://viem.sh/docs/actions/public/getTransactionReceipt.html)

--- a/docs/react/api/hooks/useTransactionReceipt.md
+++ b/docs/react/api/hooks/useTransactionReceipt.md
@@ -44,7 +44,7 @@ import { type UseTransactionReceiptParameters } from 'wagmi'
 
 ### hash
 
-`` `0x${string}` ``
+`` `0x${string}` | undefined ``
 
 A transaction hash.
 

--- a/docs/react/api/hooks/useTransactionReceipt.md
+++ b/docs/react/api/hooks/useTransactionReceipt.md
@@ -1,0 +1,142 @@
+---
+title: useTransactionReceipt
+description: Hook for return the Transaction Receipt given a Transaction hash.
+---
+
+<script setup>
+const packageName = 'wagmi'
+const actionName = 'getTransactionReceipt'
+const typeName = 'GetTransactionReceipt'
+const TData = 'GetTransactionReceiptData'
+const TError = 'GetTransactionReceiptErrorType'
+</script>
+
+# useTransactionReceipt
+
+Hook for return the [Transaction Receipt](https://viem.sh/docs/glossary/terms.html#transaction-receipt) given a [Transaction](https://viem.sh/docs/glossary/terms.html#transaction) hash.
+
+## Import
+
+```ts
+import { useTransactionReceipt } from 'wagmi'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from 'wagmi'
+
+function App() {
+  const result = useTransactionReceipt({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type UseTransactionReceiptParameters } from 'wagmi'
+```
+
+### hash
+
+`` `0x${string}` ``
+
+A transaction hash.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from 'wagmi'
+
+function App() {
+  const result = useTransactionReceipt({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d', // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+The ID of chain to return the transaction receipt from.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from 'wagmi'
+import { mainnet } from 'wagmi/chains'
+
+
+function App() {
+  const result = useTransactionReceipt({
+    chainId: mainnet.id, // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+### config
+
+`Config | undefined`
+
+[`Config`](/react/api/createConfig#config) to use instead of retrieving from the from nearest [`WagmiProvider`](/react/api/WagmiProvider).
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from 'wagmi'
+import { config } from './config' // [!code focus]
+
+function App() {
+  const result = useTransactionReceipt({
+    config, // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+### scopeKey
+
+`string | undefined`
+
+Scopes the cache to a given context. Hooks that have identical context will share the same cache.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from 'wagmi'
+import { config } from './config'
+
+function App() {
+  const result = useTransactionReceipt({
+    scopeKey: 'foo' // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  })
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { type UseTransactionReceiptReturnType } from 'wagmi'
+```
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`getTransactionReceipt`](/core/api/actions/getTransactionReceipt)

--- a/packages/core/src/actions/getTransactionReceipt.test.ts
+++ b/packages/core/src/actions/getTransactionReceipt.test.ts
@@ -1,0 +1,35 @@
+import { config } from '@wagmi/test'
+import { expect, test } from 'vitest'
+
+import { getTransaction } from './getTransaction.js'
+import { getTransactionReceipt } from './getTransactionReceipt.js'
+
+test('default', async () => {
+  const transaction = await getTransaction(config, {
+    blockNumber: 16280769n,
+    index: 0,
+  })
+
+  await expect(
+    getTransactionReceipt(config, {
+      hash: transaction.hash,
+    }),
+  ).resolves.toMatchInlineSnapshot(`
+    {
+      "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+      "blockNumber": 16280769n,
+      "contractAddress": null,
+      "cumulativeGasUsed": 21000n,
+      "effectiveGasPrice": 33427926161n,
+      "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+      "gasUsed": 21000n,
+      "logs": [],
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "status": "success",
+      "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+      "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+      "transactionIndex": 0,
+      "type": "legacy",
+    }
+  `)
+})

--- a/packages/core/src/actions/getTransactionReceipt.ts
+++ b/packages/core/src/actions/getTransactionReceipt.ts
@@ -1,0 +1,28 @@
+import {
+  type GetTransactionReceiptErrorType as viem_GetTransactionReceiptErrorType,
+  type GetTransactionReceiptParameters as viem_GetTransactionReceiptParameters,
+  type GetTransactionReceiptReturnType as viem_GetTransactionReceiptReturnType,
+  getTransactionReceipt as viem_getTransactionReceipt,
+} from 'viem/actions'
+
+import { type Config } from '../createConfig.js'
+import { type ChainIdParameter } from '../types/properties.js'
+import { type Evaluate } from '../types/utils.js'
+
+export type GetTransactionReceiptParameters<config extends Config = Config> =
+  Evaluate<viem_GetTransactionReceiptParameters & ChainIdParameter<config>>
+
+export type GetTransactionReceiptReturnType =
+  viem_GetTransactionReceiptReturnType
+
+export type GetTransactionReceiptErrorType = viem_GetTransactionReceiptErrorType
+
+/** https://wagmi.sh/core/api/actions/getTransactionReceipt */
+export async function getTransactionReceipt<config extends Config>(
+  config: config,
+  parameters: GetTransactionReceiptParameters<config>,
+): Promise<GetTransactionReceiptReturnType> {
+  const { chainId, ...rest } = parameters
+  const client = config.getClient({ chainId })
+  return viem_getTransactionReceipt(client, rest)
+}

--- a/packages/core/src/exports/actions.test.ts
+++ b/packages/core/src/exports/actions.test.ts
@@ -39,6 +39,7 @@ test('exports', () => {
       "getTransaction",
       "fetchTransaction",
       "getTransactionCount",
+      "getTransactionReceipt",
       "getWalletClient",
       "multicall",
       "readContract",

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -191,6 +191,13 @@ export {
 } from '../actions/getTransactionCount.js'
 
 export {
+  type GetTransactionReceiptErrorType,
+  type GetTransactionReceiptParameters,
+  type GetTransactionReceiptReturnType,
+  getTransactionReceipt,
+} from '../actions/getTransactionReceipt.js'
+
+export {
   type GetWalletClientErrorType,
   type GetWalletClientParameters,
   type GetWalletClientReturnType,

--- a/packages/core/src/exports/index.test.ts
+++ b/packages/core/src/exports/index.test.ts
@@ -39,6 +39,7 @@ test('exports', () => {
       "getTransaction",
       "fetchTransaction",
       "getTransactionCount",
+      "getTransactionReceipt",
       "getWalletClient",
       "multicall",
       "readContract",

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -191,6 +191,13 @@ export {
 } from '../actions/getTransactionCount.js'
 
 export {
+  type GetTransactionReceiptErrorType,
+  type GetTransactionReceiptParameters,
+  type GetTransactionReceiptReturnType,
+  getTransactionReceipt,
+} from '../actions/getTransactionReceipt.js'
+
+export {
   type GetWalletClientErrorType,
   type GetWalletClientParameters,
   type GetWalletClientReturnType,

--- a/packages/core/src/exports/query.test.ts
+++ b/packages/core/src/exports/query.test.ts
@@ -43,6 +43,8 @@ test('exports', () => {
       "getTransactionQueryOptions",
       "getTransactionCountQueryKey",
       "getTransactionCountQueryOptions",
+      "getTransactionReceiptQueryKey",
+      "getTransactionReceiptQueryOptions",
       "getWalletClientQueryKey",
       "getWalletClientQueryOptions",
       "infiniteReadContractsQueryKey",

--- a/packages/core/src/exports/query.ts
+++ b/packages/core/src/exports/query.ts
@@ -181,6 +181,15 @@ export {
 } from '../query/getTransactionCount.js'
 
 export {
+  type GetTransactionReceiptData,
+  type GetTransactionReceiptOptions,
+  type GetTransactionReceiptQueryFnData,
+  type GetTransactionReceiptQueryKey,
+  getTransactionReceiptQueryKey,
+  getTransactionReceiptQueryOptions,
+} from '../query/getTransactionReceipt.js'
+
+export {
   type GetWalletClientData,
   type GetWalletClientOptions,
   type GetWalletClientQueryFnData,

--- a/packages/core/src/query/getTransactionReceipt.test.ts
+++ b/packages/core/src/query/getTransactionReceipt.test.ts
@@ -1,0 +1,42 @@
+import { chain, config } from '@wagmi/test'
+import { expect, test } from 'vitest'
+
+import { getTransactionReceiptQueryOptions } from './getTransactionReceipt.js'
+
+test('default', () => {
+  expect(
+    getTransactionReceiptQueryOptions(config, {
+      hash: '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871',
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "queryFn": [Function],
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+    }
+  `)
+})
+
+test('parameters: chainId', () => {
+  expect(
+    getTransactionReceiptQueryOptions(config, {
+      chainId: chain.mainnet2.id,
+      hash: '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871',
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "queryFn": [Function],
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 456,
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+    }
+  `)
+})

--- a/packages/core/src/query/getTransactionReceipt.ts
+++ b/packages/core/src/query/getTransactionReceipt.ts
@@ -1,0 +1,55 @@
+import { type QueryOptions } from '@tanstack/query-core'
+
+import {
+  type GetTransactionReceiptErrorType,
+  type GetTransactionReceiptParameters,
+  type GetTransactionReceiptReturnType,
+  getTransactionReceipt,
+} from '../actions/getTransactionReceipt.js'
+import { type Config } from '../createConfig.js'
+import type { ScopeKeyParameter } from '../types/properties.js'
+import type { Evaluate, ExactPartial } from '../types/utils.js'
+import { filterQueryOptions } from './utils.js'
+
+export type GetTransactionReceiptOptions<config extends Config> = Evaluate<
+  ExactPartial<GetTransactionReceiptParameters<config>> & ScopeKeyParameter
+>
+
+export function getTransactionReceiptQueryOptions<config extends Config>(
+  config: config,
+  options: GetTransactionReceiptOptions<config> = {},
+) {
+  return {
+    async queryFn({ queryKey }) {
+      const { hash } = queryKey[1]
+      if (!hash) throw new Error('hash is required')
+
+      const { scopeKey: _, ...parameters } = queryKey[1]
+
+      const transactionReceipt = await getTransactionReceipt(
+        config,
+        parameters as GetTransactionReceiptParameters,
+      )
+      return transactionReceipt ?? null
+    },
+    queryKey: getTransactionReceiptQueryKey(options),
+  } as const satisfies QueryOptions<
+    GetTransactionReceiptQueryFnData,
+    GetTransactionReceiptErrorType,
+    GetTransactionReceiptData,
+    GetTransactionReceiptQueryKey
+  >
+}
+export type GetTransactionReceiptQueryFnData = GetTransactionReceiptReturnType
+
+export type GetTransactionReceiptData = GetTransactionReceiptQueryFnData
+
+export function getTransactionReceiptQueryKey<config extends Config>(
+  options: GetTransactionReceiptOptions<config>,
+) {
+  return ['getTransactionReceipt', filterQueryOptions(options)] as const
+}
+
+export type GetTransactionReceiptQueryKey = ReturnType<
+  typeof getTransactionReceiptQueryKey
+>

--- a/packages/core/src/query/getTransactionReceipt.ts
+++ b/packages/core/src/query/getTransactionReceipt.ts
@@ -7,8 +7,8 @@ import {
   getTransactionReceipt,
 } from '../actions/getTransactionReceipt.js'
 import { type Config } from '../createConfig.js'
-import type { ScopeKeyParameter } from '../types/properties.js'
-import type { Evaluate, ExactPartial } from '../types/utils.js'
+import { type ScopeKeyParameter } from '../types/properties.js'
+import { type Evaluate, type ExactPartial } from '../types/utils.js'
 import { filterQueryOptions } from './utils.js'
 
 export type GetTransactionReceiptOptions<config extends Config> = Evaluate<
@@ -21,16 +21,9 @@ export function getTransactionReceiptQueryOptions<config extends Config>(
 ) {
   return {
     async queryFn({ queryKey }) {
-      const { hash } = queryKey[1]
+      const { hash, scopeKey: _, ...parameters } = queryKey[1]
       if (!hash) throw new Error('hash is required')
-
-      const { scopeKey: _, ...parameters } = queryKey[1]
-
-      const transactionReceipt = await getTransactionReceipt(
-        config,
-        parameters as GetTransactionReceiptParameters,
-      )
-      return transactionReceipt ?? null
+      return getTransactionReceipt(config, { ...parameters, hash })
     },
     queryKey: getTransactionReceiptQueryKey(options),
   } as const satisfies QueryOptions<

--- a/packages/react/src/exports/actions.test.ts
+++ b/packages/react/src/exports/actions.test.ts
@@ -39,6 +39,7 @@ test('exports', () => {
       "getTransaction",
       "fetchTransaction",
       "getTransactionCount",
+      "getTransactionReceipt",
       "getWalletClient",
       "multicall",
       "readContract",

--- a/packages/react/src/exports/index.test.ts
+++ b/packages/react/src/exports/index.test.ts
@@ -53,6 +53,7 @@ test('exports', () => {
       "useToken",
       "useTransaction",
       "useTransactionCount",
+      "useTransactionReceipt",
       "useVerifyMessage",
       "useVerifyTypedData",
       "useWalletClient",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -264,6 +264,12 @@ export {
 } from '../hooks/useTransactionCount.js'
 
 export {
+  type UseTransactionReceiptParameters,
+  type UseTransactionReceiptReturnType,
+  useTransactionReceipt,
+} from '../hooks/useTransactionReceipt.js'
+
+export {
   type UseVerifyMessageParameters,
   type UseVerifyMessageReturnType,
   useVerifyMessage,

--- a/packages/react/src/exports/query.test.ts
+++ b/packages/react/src/exports/query.test.ts
@@ -43,6 +43,8 @@ test('exports', () => {
       "getTransactionQueryOptions",
       "getTransactionCountQueryKey",
       "getTransactionCountQueryOptions",
+      "getTransactionReceiptQueryKey",
+      "getTransactionReceiptQueryOptions",
       "getWalletClientQueryKey",
       "getWalletClientQueryOptions",
       "infiniteReadContractsQueryKey",

--- a/packages/react/src/hooks/useTransactionReceipt.test-d.ts
+++ b/packages/react/src/hooks/useTransactionReceipt.test-d.ts
@@ -1,0 +1,15 @@
+import { type TransactionReceipt } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+
+import { useTransactionReceipt } from './useTransactionReceipt.js'
+
+test('select data', async () => {
+  const result = useTransactionReceipt({
+    query: {
+      select(data) {
+        return data
+      },
+    },
+  })
+  expectTypeOf(result.data).toEqualTypeOf<TransactionReceipt | undefined>()
+})

--- a/packages/react/src/hooks/useTransactionReceipt.test.ts
+++ b/packages/react/src/hooks/useTransactionReceipt.test.ts
@@ -1,0 +1,237 @@
+import { chain, wait } from '@wagmi/test'
+import { renderHook, waitFor } from '@wagmi/test/react'
+import { type Hash } from 'viem'
+import { expect, test } from 'vitest'
+import { useTransactionReceipt } from './useTransactionReceipt.js'
+
+test('default', async () => {
+  const { result } = renderHook(() =>
+    useTransactionReceipt({
+      hash: '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871',
+    }),
+  )
+
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+  expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+        "blockNumber": 16280769n,
+        "contractAddress": null,
+        "cumulativeGasUsed": 21000n,
+        "effectiveGasPrice": 33427926161n,
+        "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+        "gasUsed": 21000n,
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "success",
+        "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+        "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        "transactionIndex": 0,
+        "type": "legacy",
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('parameters: chainId', async () => {
+  const { result } = renderHook(() =>
+    useTransactionReceipt({
+      chainId: chain.mainnet2.id,
+      hash: '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871',
+    }),
+  )
+
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+  expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+        "blockNumber": 16280769n,
+        "contractAddress": null,
+        "cumulativeGasUsed": 21000n,
+        "effectiveGasPrice": 33427926161n,
+        "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+        "gasUsed": 21000n,
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "success",
+        "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+        "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        "transactionIndex": 0,
+        "type": "legacy",
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 456,
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('behavior: hash: undefined -> defined', async () => {
+  let hash: Hash | undefined = undefined
+
+  const { result, rerender } = renderHook(() =>
+    useTransactionReceipt({
+      hash,
+    }),
+  )
+
+  expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": undefined,
+      "dataUpdatedAt": 0,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": false,
+      "isFetchedAfterMount": false,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": true,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": false,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": undefined,
+        },
+      ],
+      "refetch": [Function],
+      "status": "pending",
+    }
+  `)
+
+  hash = '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871'
+  rerender()
+
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+  expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+        "blockNumber": 16280769n,
+        "contractAddress": null,
+        "cumulativeGasUsed": 21000n,
+        "effectiveGasPrice": 33427926161n,
+        "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+        "gasUsed": 21000n,
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "success",
+        "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+        "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        "transactionIndex": 0,
+        "type": "legacy",
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('behavior: disabled when properties missing', async () => {
+  const { result } = renderHook(() => useTransactionReceipt())
+
+  await wait(100)
+  await waitFor(() => expect(result.current.isPending).toBeTruthy())
+})

--- a/packages/react/src/hooks/useTransactionReceipt.ts
+++ b/packages/react/src/hooks/useTransactionReceipt.ts
@@ -5,15 +5,18 @@ import {
   type GetTransactionReceiptErrorType,
   type ResolvedRegister,
 } from '@wagmi/core'
-import type { Evaluate } from '@wagmi/core/internal'
+import { type Evaluate } from '@wagmi/core/internal'
 import {
   type GetTransactionReceiptData,
   type GetTransactionReceiptOptions,
   type GetTransactionReceiptQueryKey,
   getTransactionReceiptQueryOptions,
 } from '@wagmi/core/query'
-import type { GetTransactionReceiptQueryFnData } from '@wagmi/core/query'
-import type { ConfigParameter, QueryParameter } from '../types/properties.js'
+import { type GetTransactionReceiptQueryFnData } from '@wagmi/core/query'
+import {
+  type ConfigParameter,
+  type QueryParameter,
+} from '../types/properties.js'
 import { type UseQueryReturnType, useQuery } from '../utils/query.js'
 import { useChainId } from './useChainId.js'
 import { useConfig } from './useConfig.js'

--- a/packages/react/src/hooks/useTransactionReceipt.ts
+++ b/packages/react/src/hooks/useTransactionReceipt.ts
@@ -1,0 +1,58 @@
+'use client'
+
+import {
+  type Config,
+  type GetTransactionReceiptErrorType,
+  type ResolvedRegister,
+} from '@wagmi/core'
+import type { Evaluate } from '@wagmi/core/internal'
+import {
+  type GetTransactionReceiptData,
+  type GetTransactionReceiptOptions,
+  type GetTransactionReceiptQueryKey,
+  getTransactionReceiptQueryOptions,
+} from '@wagmi/core/query'
+import type { GetTransactionReceiptQueryFnData } from '@wagmi/core/query'
+import type { ConfigParameter, QueryParameter } from '../types/properties.js'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+export type UseTransactionReceiptParameters<
+  config extends Config = Config,
+  selectData = GetTransactionReceiptData,
+> = Evaluate<
+  GetTransactionReceiptOptions<config> &
+    ConfigParameter<config> &
+    QueryParameter<
+      GetTransactionReceiptQueryFnData,
+      GetTransactionReceiptErrorType,
+      selectData,
+      GetTransactionReceiptQueryKey
+    >
+>
+
+export type UseTransactionReceiptReturnType<
+  selectData = GetTransactionReceiptData,
+> = UseQueryReturnType<selectData, GetTransactionReceiptErrorType>
+
+/** https://wagmi.sh/react/api/hooks/useTransactionReceipt */
+export function useTransactionReceipt<
+  config extends Config = ResolvedRegister['config'],
+  selectData = GetTransactionReceiptData,
+>(
+  parameters: UseTransactionReceiptParameters<config, selectData> = {},
+): UseTransactionReceiptReturnType<selectData> {
+  const { hash, query = {} } = parameters
+
+  const config = useConfig(parameters)
+  const chainId = useChainId()
+
+  const options = getTransactionReceiptQueryOptions(config, {
+    ...parameters,
+    chainId: parameters.chainId ?? chainId,
+  })
+  const enabled = Boolean(hash && (query.enabled ?? true))
+
+  return useQuery({ ...query, ...options, enabled })
+}


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?
- Added the `getTransactionReceipt` action.
- Added the `useTransactionReceipt` hook.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
