### PR TITLE
docs: Update migrate-from-v1-to-v2.md

### DIFF
--- a/docs/react/guides/migrate-from-v1-to-v2.md
+++ b/docs/react/guides/migrate-from-v1-to-v2.md
@@ -485,6 +485,24 @@ const transport = http('https://mainnet.example.com')
 - Removed `config.setLastUsedConnector`. Use `config.storage?.setItem('recentConnectorId', connectorId)` instead.
 - Removed `getConfig`. `config` should be passed explicitly to actions instead of using global `config`.
 
+### Moved TanStack Query parameters to `query` object
+
+TanStack Query parameters like `enabled`, `staleTime` are now moved to `query` object:
+
+```tsx
+useContractRead({ // [!code --]
+  enabled: false, // [!code --]
+  staleTime: 1000, // [!code --]
+}); // [!code --]
+
+useReadContract({ // [!code ++]
+  query: { // [!code ++]
+    enabled: false, // [!code ++]
+    staleTime: 1000, // [!code ++]
+  } // [!code ++]
+}); // [!code ++]
+```
+
 ## Deprecations
 
 ### Renamed `WagmiConfig`

--- a/docs/react/guides/migrate-from-v1-to-v2.md
+++ b/docs/react/guides/migrate-from-v1-to-v2.md
@@ -107,6 +107,21 @@ const { signMessage } = useSignMessage() // [!code ++]
 </button>
 ```
 
+### Moved TanStack Query parameters to `query` property
+
+Previously, you could pass TanStack Query parameters, like `enabled` and `staleTime`, directly to hooks. In Wagmi v2, TanStack Query parameters are now moved to the `query` property. This allows Wagmi to better support TanStack Query type inference, control for future breaking changes since [TanStack Query is now a peer dependency](#moved-tanstack-query-to-peer-dependencies), and expose Wagmi-related hook property at the top-level of editor features, like autocomplete.
+
+```tsx
+useReadContract({
+  enabled: false, // [!code --]
+  staleTime: 1_000, // [!code --]
+  query: { // [!code ++]
+    enabled: false, // [!code ++]
+    staleTime: 1_000, // [!code ++]
+  }, // [!code ++]
+})
+```
+
 ### Removed watch property
 
 The `watch` property was removed from all hooks besides [`useBlock`](/react/api/hooks/useBlock) and [`useBlockNumber`](/react/api/hooks/useBlockNumber). This property allowed hooks to internally listen for block changes and automatically refresh their data. In Wagmi v2, you can compose `useBlock` or `useBlockNumber` along with [`React.useEffect`](https://react.dev/reference/react/useEffect) to achieve the same behavior. Two different approaches are outlined for `useBalance` below.
@@ -484,24 +499,6 @@ const transport = http('https://mainnet.example.com')
 - Renamed `config.setConnectors`. Use `config._internal.setConnectors` instead.
 - Removed `config.setLastUsedConnector`. Use `config.storage?.setItem('recentConnectorId', connectorId)` instead.
 - Removed `getConfig`. `config` should be passed explicitly to actions instead of using global `config`.
-
-### Moved TanStack Query parameters to `query` object
-
-TanStack Query parameters like `enabled`, `staleTime` are now moved to `query` object:
-
-```tsx
-useContractRead({ // [!code --]
-  enabled: false, // [!code --]
-  staleTime: 1000, // [!code --]
-}); // [!code --]
-
-useReadContract({ // [!code ++]
-  query: { // [!code ++]
-    enabled: false, // [!code ++]
-    staleTime: 1000, // [!code ++]
-  } // [!code ++]
-}); // [!code ++]
-```
 
 ## Deprecations
 


### PR DESCRIPTION
`enabled` etc. are moved under `query`, thought it worths a mention in the migrate docs.

## Description

What changes are made in this PR? Is it a feature or a bug fix?

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
