### PR TITLE
Fix: Remove chainId param from Viem readContract calls

### DIFF
--- a/.changeset/loud-cats-sing.md
+++ b/.changeset/loud-cats-sing.md
@@ -1,0 +1,8 @@
+---
+"@wagmi/connectors": patch 
+"create-wagmi": patch 
+"wagmi": patch 
+---
+
+Bumped dependencies.
+

--- a/.changeset/smelly-mouse-help.md
+++ b/.changeset/smelly-mouse-help.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch 
+---
+
+Fix param issue with readContract calls

--- a/.changeset/smelly-mouse-help.md
+++ b/.changeset/smelly-mouse-help.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch 
 ---
 
-Fix param issue with readContract calls
+Fixed invalid `chainId` parameter passed through actions to Viem.

--- a/packages/core/src/actions/getBlock.ts
+++ b/packages/core/src/actions/getBlock.ts
@@ -56,9 +56,9 @@ export async function getBlock<
     chainId
   > = {},
 ): Promise<GetBlockReturnType<includeTransactions, blockTag, config, chainId>> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  const block = await viem_getBlock(client, parameters)
+  const block = await viem_getBlock(client, rest)
   return {
     ...(block as GetBlockReturnType<
       includeTransactions,

--- a/packages/core/src/actions/getBlockNumber.ts
+++ b/packages/core/src/actions/getBlockNumber.ts
@@ -26,7 +26,7 @@ export function getBlockNumber<
   config: config,
   parameters: GetBlockNumberParameters<config, chainId> = {},
 ): Promise<GetBlockNumberReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getBlockNumber(client, parameters)
+  return viem_getBlockNumber(client, rest)
 }

--- a/packages/core/src/actions/getBlockTransactionCount.ts
+++ b/packages/core/src/actions/getBlockTransactionCount.ts
@@ -30,7 +30,7 @@ export function getBlockTransactionCount<
   config: config,
   parameters: GetBlockTransactionCountParameters<config, chainId> = {},
 ): Promise<GetBlockTransactionCountReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getBlockTransactionCount(client, parameters)
+  return viem_getBlockTransactionCount(client, rest)
 }

--- a/packages/core/src/actions/getEnsAddress.ts
+++ b/packages/core/src/actions/getEnsAddress.ts
@@ -22,7 +22,7 @@ export function getEnsAddress<config extends Config>(
   config: config,
   parameters: GetEnsAddressParameters<config>,
 ): Promise<GetEnsAddressReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getEnsAddress(client, parameters)
+  return viem_getEnsAddress(client, rest)
 }

--- a/packages/core/src/actions/getEnsAvatar.ts
+++ b/packages/core/src/actions/getEnsAvatar.ts
@@ -22,7 +22,7 @@ export function getEnsAvatar<config extends Config>(
   config: config,
   parameters: GetEnsAvatarParameters<config>,
 ): Promise<GetEnsAvatarReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getEnsAvatar(client, parameters)
+  return viem_getEnsAvatar(client, rest)
 }

--- a/packages/core/src/actions/getEnsName.ts
+++ b/packages/core/src/actions/getEnsName.ts
@@ -22,7 +22,7 @@ export function getEnsName<config extends Config>(
   config: config,
   parameters: GetEnsNameParameters<config>,
 ): Promise<GetEnsNameReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getEnsName(client, parameters)
+  return viem_getEnsName(client, rest)
 }

--- a/packages/core/src/actions/getEnsResolver.ts
+++ b/packages/core/src/actions/getEnsResolver.ts
@@ -22,7 +22,7 @@ export function getEnsResolver<config extends Config>(
   config: config,
   parameters: GetEnsResolverParameters<config>,
 ): Promise<GetEnsResolverReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getEnsResolver(client, parameters)
+  return viem_getEnsResolver(client, rest)
 }

--- a/packages/core/src/actions/getFeeHistory.ts
+++ b/packages/core/src/actions/getFeeHistory.ts
@@ -26,7 +26,7 @@ export function getFeeHistory<
   config: config,
   parameters: GetFeeHistoryParameters<config, chainId>,
 ): Promise<GetFeeHistoryReturnType> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getFeeHistory(client, parameters)
+  return viem_getFeeHistory(client, rest)
 }

--- a/packages/core/src/actions/getTransaction.ts
+++ b/packages/core/src/actions/getTransaction.ts
@@ -39,9 +39,9 @@ export function getTransaction<
   config: config,
   parameters: GetTransactionParameters<config, chainId>,
 ): Promise<GetTransactionReturnType<config, chainId>> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_getTransaction(client, parameters) as unknown as Promise<
+  return viem_getTransaction(client, rest) as unknown as Promise<
     GetTransactionReturnType<config, chainId>
   >
 }

--- a/packages/core/src/actions/readContract.ts
+++ b/packages/core/src/actions/readContract.ts
@@ -52,5 +52,5 @@ export function readContract<
 ): Promise<ReadContractReturnType<abi, functionName, args>> {
   const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_readContract(client, rest)
+  return viem_readContract(client, rest as any)
 }

--- a/packages/core/src/actions/readContract.ts
+++ b/packages/core/src/actions/readContract.ts
@@ -1,10 +1,10 @@
-import { type Abi } from 'viem'
 import type { ContractFunctionArgs, ContractFunctionName } from 'viem'
+import { type Abi } from 'viem'
 import {
+  readContract as viem_readContract,
   type ReadContractErrorType as viem_ReadContractErrorType,
   type ReadContractParameters as viem_ReadContractParameters,
   type ReadContractReturnType as viem_ReadContractReturnType,
-  readContract as viem_readContract,
 } from 'viem/actions'
 
 import { type Config } from '../createConfig.js'
@@ -50,7 +50,7 @@ export function readContract<
   config: config,
   parameters: ReadContractParameters<abi, functionName, args, config>,
 ): Promise<ReadContractReturnType<abi, functionName, args>> {
-  const { chainId } = parameters
+  const { chainId, ...rest } = parameters
   const client = config.getClient({ chainId })
-  return viem_readContract(client, parameters as any)
+  return viem_readContract(client, rest)
 }

--- a/packages/core/src/actions/readContract.ts
+++ b/packages/core/src/actions/readContract.ts
@@ -1,10 +1,10 @@
-import type { ContractFunctionArgs, ContractFunctionName } from 'viem'
 import { type Abi } from 'viem'
+import type { ContractFunctionArgs, ContractFunctionName } from 'viem'
 import {
-  readContract as viem_readContract,
   type ReadContractErrorType as viem_ReadContractErrorType,
   type ReadContractParameters as viem_ReadContractParameters,
   type ReadContractReturnType as viem_ReadContractReturnType,
+  readContract as viem_readContract,
 } from 'viem/actions'
 
 import { type Config } from '../createConfig.js'


### PR DESCRIPTION
## Description

Remove `chainId` parameter from `readContract` calls in wagmi core action
Fixes https://github.com/wevm/wagmi/issues/3442

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
