### PR TITLE
docs: update example in migrate-from-v1-to-v2.md

### DIFF
--- a/docs/react/guides/migrate-from-v1-to-v2.md
+++ b/docs/react/guides/migrate-from-v1-to-v2.md
@@ -225,7 +225,7 @@ const { writeContract } = useWriteContract() // [!code ++]
   disabled={!Boolean(write)} // [!code --]
   onClick={() => write()} // [!code --]
   disabled={!Boolean(data?.request)} // [!code ++]
-  onClick={() => data?.request && writeContract(data.request)} // [!code ++]
+  onClick={() => writeContract(data!.request)} // [!code ++]
 >
   Write contract
 </button>

--- a/docs/react/guides/migrate-from-v1-to-v2.md
+++ b/docs/react/guides/migrate-from-v1-to-v2.md
@@ -225,7 +225,7 @@ const { writeContract } = useWriteContract() // [!code ++]
   disabled={!Boolean(write)} // [!code --]
   onClick={() => write()} // [!code --]
   disabled={!Boolean(data?.request)} // [!code ++]
-  onClick={() => writeContract(data?.request)} // [!code ++]
+  onClick={() => data?.request && writeContract(data.request)} // [!code ++]
 >
   Write contract
 </button>


### PR DESCRIPTION
## Description

A nitpicking as `writeContract` in the example won't accept an `undefined` type from what I can tell.

![CleanShot-0e3OwlDa@2x](https://github.com/wevm/wagmi/assets/126733611/0e9ca9c8-49ab-4408-83d6-9f3d98d2b763)


## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
