### PR TITLE
feat: account chain typing

### DIFF
--- a/.changeset/silly-oranges-relax.md
+++ b/.changeset/silly-oranges-relax.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": patch
+"create-wagmi": patch
+---
+
+Bumped dependencies.
+

--- a/.changeset/smart-grapes-join.md
+++ b/.changeset/smart-grapes-join.md
@@ -1,0 +1,6 @@
+---
+"wagmi": patch
+"@wagmi/core": patch
+---
+
+Fixed account typing.

--- a/packages/core/src/actions/getAccount.test-d.ts
+++ b/packages/core/src/actions/getAccount.test-d.ts
@@ -12,6 +12,7 @@ test('states', () => {
     case 'reconnecting': {
       expectTypeOf(result).toMatchTypeOf<{
         address: Address | undefined
+        chain: typeof config['chains'][number] | undefined
         chainId: number | undefined
         connector: Connector | undefined
         isConnected: boolean
@@ -25,6 +26,7 @@ test('states', () => {
     case 'connecting': {
       expectTypeOf(result).toMatchTypeOf<{
         address: Address | undefined
+        chain: typeof config['chains'][number] | undefined
         chainId: number | undefined
         connector: Connector | undefined
         isConnected: false
@@ -38,6 +40,7 @@ test('states', () => {
     case 'connected': {
       expectTypeOf(result).toMatchTypeOf<{
         address: Address
+        chain: typeof config['chains'][number] | undefined
         chainId: number
         connector: Connector
         isConnected: true
@@ -51,6 +54,7 @@ test('states', () => {
     case 'disconnected': {
       expectTypeOf(result).toMatchTypeOf<{
         address: undefined
+        chain: undefined
         chainId: undefined
         connector: undefined
         isConnected: false

--- a/packages/core/src/actions/getAccount.ts
+++ b/packages/core/src/actions/getAccount.ts
@@ -2,11 +2,15 @@ import { type Address, type Chain } from 'viem'
 
 import { type Config, type Connector } from '../createConfig.js'
 
-export type GetAccountReturnType =
+export type GetAccountReturnType<
+  config extends Config = Config,
+  ///
+  chain = Config extends config ? Chain : config['chains'][number],
+> =
   | {
       address: Address
       addresses: readonly [Address, ...Address[]]
-      chain: Chain | undefined
+      chain: chain | undefined
       chainId: number
       connector: Connector
       isConnected: true
@@ -18,7 +22,7 @@ export type GetAccountReturnType =
   | {
       address: Address | undefined
       addresses: readonly Address[] | undefined
-      chain: Chain | undefined
+      chain: chain | undefined
       chainId: number | undefined
       connector: Connector | undefined
       isConnected: boolean
@@ -30,7 +34,7 @@ export type GetAccountReturnType =
   | {
       address: Address | undefined
       addresses: readonly Address[] | undefined
-      chain: Chain | undefined
+      chain: chain | undefined
       chainId: number | undefined
       connector: Connector | undefined
       isConnected: false
@@ -42,7 +46,7 @@ export type GetAccountReturnType =
   | {
       address: undefined
       addresses: undefined
-      chain: Chain | undefined
+      chain: undefined
       chainId: undefined
       connector: undefined
       isConnected: false
@@ -53,12 +57,16 @@ export type GetAccountReturnType =
     }
 
 /** https://wagmi.sh/core/api/actions/getAccount */
-export function getAccount(config: Config): GetAccountReturnType {
+export function getAccount<config extends Config>(
+  config: config,
+): GetAccountReturnType<config> {
   const uid = config.state.current!
   const connection = config.state.connections.get(uid)
   const addresses = connection?.accounts
   const address = addresses?.[0]
-  const chain = config.chains.find((chain) => chain.id === connection?.chainId)
+  const chain = config.chains.find(
+    (chain) => chain.id === connection?.chainId,
+  ) as GetAccountReturnType<config>['chain']
   const status = config.state.status
 
   switch (status) {
@@ -105,7 +113,7 @@ export function getAccount(config: Config): GetAccountReturnType {
       return {
         address: undefined,
         addresses: undefined,
-        chain,
+        chain: undefined,
         chainId: undefined,
         connector: undefined,
         isConnected: false,

--- a/packages/react/src/hooks/useAccount.test-d.ts
+++ b/packages/react/src/hooks/useAccount.test-d.ts
@@ -1,5 +1,5 @@
 import { type Connector } from '@wagmi/core'
-import type { Address } from 'viem'
+import { type Address, type Chain } from 'viem'
 import { expectTypeOf, test } from 'vitest'
 
 import { useAccount } from './useAccount.js'
@@ -11,6 +11,7 @@ test('states', () => {
     case 'reconnecting': {
       expectTypeOf(result).toMatchTypeOf<{
         address: Address | undefined
+        chain: Chain | undefined
         chainId: number | undefined
         connector: Connector | undefined
         isConnected: boolean
@@ -24,6 +25,7 @@ test('states', () => {
     case 'connecting': {
       expectTypeOf(result).toMatchTypeOf<{
         address: Address | undefined
+        chain: Chain | undefined
         chainId: number | undefined
         connector: Connector | undefined
         isConnected: false
@@ -37,6 +39,7 @@ test('states', () => {
     case 'connected': {
       expectTypeOf(result).toMatchTypeOf<{
         address: Address
+        chain: Chain | undefined
         chainId: number
         connector: Connector
         isConnected: true
@@ -50,6 +53,7 @@ test('states', () => {
     case 'disconnected': {
       expectTypeOf(result).toMatchTypeOf<{
         address: undefined
+        chain: undefined
         chainId: undefined
         connector: undefined
         isConnected: false

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -1,7 +1,9 @@
 'use client'
 
 import {
+  type Config,
   type GetAccountReturnType,
+  type ResolvedRegister,
   getAccount,
   watchAccount,
 } from '@wagmi/core'
@@ -10,14 +12,16 @@ import type { ConfigParameter } from '../types/properties.js'
 import { useConfig } from './useConfig.js'
 import { useSyncExternalStoreWithTracked } from './useSyncExternalStoreWithTracked.js'
 
-export type UseAccountParameters = ConfigParameter
+export type UseAccountParameters<config extends Config = Config> =
+  ConfigParameter<config>
 
-export type UseAccountReturnType = GetAccountReturnType
+export type UseAccountReturnType<config extends Config = Config> =
+  GetAccountReturnType<config>
 
 /** https://wagmi.sh/react/api/hooks/useAccount */
-export function useAccount(
-  parameters: UseAccountParameters = {},
-): UseAccountReturnType {
+export function useAccount<config extends Config = ResolvedRegister['config']>(
+  parameters: UseAccountParameters<config> = {},
+): UseAccountReturnType<config> {
   const config = useConfig(parameters)
 
   return useSyncExternalStoreWithTracked(

--- a/packages/register-tests/react/src/useAccount.test-d.ts
+++ b/packages/register-tests/react/src/useAccount.test-d.ts
@@ -1,0 +1,15 @@
+import { config } from '@wagmi/test'
+import { expectTypeOf, test } from 'vitest'
+import { useAccount } from 'wagmi'
+
+import { type ChainId } from './config.js'
+
+test('default', () => {
+  const result = useAccount()
+  if (result.chain) expectTypeOf(result.chain.id).toEqualTypeOf<ChainId>()
+})
+
+test('parameters: config', async () => {
+  const result = useAccount({ config })
+  if (result.chain) expectTypeOf(result.chain.id).toEqualTypeOf<1 | 10 | 456>()
+})


### PR DESCRIPTION
## Description

Closes #3445

Previously, if you wanted to use the connected account's `chainId` (via `getAccount` and `useAccount`) with other actions/hooks `chainId` property, the type wasn't specific enough.

```ts
const config = createConfig({
  chains: [mainnet, goerli],
  transports: {
    [mainnet.id]: http(),
    [goerli.id]: http(),
  },
})

const account = getAccount(config)
const ensName = await getEnsName({
  address: '0x...',
  chainId: account.chainId,
  // Type 'number | undefined' is not assignable to type '1 | 5 | undefined'.
})
```

This is because `getAccount`/`useAccount` `chainId` doesn't need to adhere to the `config`, e.g. user switches wallet to an unsupported chain.

This PR updates types for `getAccount` and `useAccount` so that `chain` is either equal to a configured chain or `undefined`.

```ts
const account = getAccount(config)
const ensName = await getEnsName({
  address: '0x...',
  chainId: account.chain?.id,
  //                      ^? (property) id: 1 | 5 | undefined
})
```

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
