### PR TITLE
fix: viem import path in migration docs

### DIFF
--- a/docs/react/guides/migrate-from-v1-to-v2.md
+++ b/docs/react/guides/migrate-from-v1-to-v2.md
@@ -425,7 +425,7 @@ Before v2, Wagmi handled ENS name normalization internally for `useEnsAddress`, 
 
 ```ts
 import { useEnsAddress } from 'wagmi'
-import { normalize } from 'viem' // [!code ++]
+import { normalize } from 'viem/ens' // [!code ++]
 
 const result = useEnsAddress({
   name: 'wevm.eth', // [!code --]


### PR DESCRIPTION
fixes incorrect documentation of importing `normalize` from viem