### PR TITLE
fix: connector reconnect

### DIFF
--- a/.changeset/kind-adults-tan.md
+++ b/.changeset/kind-adults-tan.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Fixed an issue where connectors that share the same provider instance could reconnect when they have never been connected before.

--- a/packages/core/src/actions/reconnect.ts
+++ b/packages/core/src/actions/reconnect.ts
@@ -60,17 +60,16 @@ export async function reconnect(
   // Iterate through each connector and try to connect
   let connected = false
   const connections: Connection[] = []
+  const providers: unknown[] = []
   for (const connector of sorted) {
+    const provider_ = await connector.getProvider()
+    if (!provider_) continue
+
     // If we already have an instance of this connector's provider,
     // then we have already checked it (ie. injected connectors can
     // share the same `window.ethereum` instance, so we don't want to
     // connect to it again).
-    const checked = connections.some(
-      async (connection) =>
-        (await connection.connector.getProvider()) ===
-        (await connector.getProvider()),
-    )
-    if (checked) continue
+    if (providers.some((provider) => provider === provider_)) continue
 
     const isAuthorized = await connector.isAuthorized()
     if (!isAuthorized) continue
@@ -100,6 +99,7 @@ export async function reconnect(
       chainId: data.chainId,
       connector,
     })
+    providers.push(provider_)
     connected = true
   }
 

--- a/packages/core/src/actions/reconnect.ts
+++ b/packages/core/src/actions/reconnect.ts
@@ -59,8 +59,19 @@ export async function reconnect(
 
   // Iterate through each connector and try to connect
   let connected = false
-  const connections = []
+  const connections: Connection[] = []
   for (const connector of sorted) {
+    // If we already have an instance of this connector's provider,
+    // then we have already checked it (ie. injected connectors can
+    // share the same `window.ethereum` instance, so we don't want to
+    // connect to it again).
+    const checked = connections.some(
+      async (connection) =>
+        (await connection.connector.getProvider()) ===
+        (await connector.getProvider()),
+    )
+    if (checked) continue
+
     const isAuthorized = await connector.isAuthorized()
     if (!isAuthorized) continue
 


### PR DESCRIPTION
## Description

Fixed an issue where connectors that share the same provider instance could reconnect when they have never been connected before.
