### PR TITLE
fix: only persist critical properties

### DIFF
--- a/.changeset/modern-crews-whisper.md
+++ b/.changeset/modern-crews-whisper.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Modified persist strategy to only store "critical" properties that are needed before hydration.

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -185,8 +185,23 @@ export function createConfig<
         ? persist(() => initialState, {
             name: 'store',
             partialize(state) {
+              // Only persist "critical" store properties to preserve storage size.
               return {
-                connections: state.connections,
+                connections: {
+                  __type: 'Map',
+                  value: Array.from(state.connections.entries()).map(
+                    ([key, connection]) => {
+                      const { id, name, type, uid } = connection.connector
+                      return [
+                        key,
+                        {
+                          ...connection,
+                          connector: { id, name, type, uid },
+                        },
+                      ]
+                    },
+                  ),
+                } as unknown as PartializedState['connections'],
                 chainId: state.chainId,
                 current: state.current,
               } satisfies PartializedState

--- a/playgrounds/next/src/app/layout.tsx
+++ b/playgrounds/next/src/app/layout.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { headers } from 'next/headers'
 import { type ReactNode } from 'react'
+import { cookieToInitialState } from 'wagmi'
 import './globals.css'
 
+import { config } from '../wagmi'
 import { Providers } from './providers'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -13,10 +16,11 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout(props: { children: ReactNode }) {
+  const initialState = cookieToInitialState(config, headers().get('cookie'))
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Providers>{props.children}</Providers>
+        <Providers initialState={initialState}>{props.children}</Providers>
       </body>
     </html>
   )

--- a/playgrounds/next/src/app/providers.tsx
+++ b/playgrounds/next/src/app/providers.tsx
@@ -2,15 +2,18 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { type ReactNode, useState } from 'react'
-import { WagmiProvider } from 'wagmi'
+import { State, WagmiProvider } from 'wagmi'
 
 import { config } from '../wagmi'
 
-export function Providers(props: { children: ReactNode }) {
+export function Providers(props: {
+  children: ReactNode
+  initialState?: State
+}) {
   const [queryClient] = useState(() => new QueryClient())
 
   return (
-    <WagmiProvider config={config}>
+    <WagmiProvider config={config} initialState={props.initialState}>
       <QueryClientProvider client={queryClient}>
         {props.children}
       </QueryClientProvider>

--- a/playgrounds/next/src/wagmi.ts
+++ b/playgrounds/next/src/wagmi.ts
@@ -1,14 +1,19 @@
-import { http, createConfig } from 'wagmi'
+import { http, cookieStorage, createConfig, createStorage } from 'wagmi'
 import { mainnet, sepolia } from 'wagmi/chains'
-import { coinbaseWallet, injected, walletConnect } from 'wagmi/connectors'
+import { injected, walletConnect } from 'wagmi/connectors'
 
 export const config = createConfig({
   chains: [mainnet, sepolia],
   connectors: [
     injected(),
-    coinbaseWallet({ appName: 'Create Wagmi' }),
-    walletConnect({ projectId: process.env.NEXT_PUBLIC_WC_PROJECT_ID! }),
+    walletConnect({
+      projectId: 'bd4997ce3ede37c95770ba10a3804dad',
+      showQrModal: false,
+    }),
   ],
+  storage: createStorage({
+    storage: cookieStorage,
+  }),
   ssr: true,
   transports: {
     [mainnet.id]: http(),


### PR DESCRIPTION
## Description

Connectors have really long base 64 SVG `icon` strings. This ends up consuming cookie storage really fast.

In this PR, I have modified our persist strategy to only store "critical" connector properties that are needed before hydration (omitting `icon`). 

