### PR TITLE
fix: allow excessive hydration to fix hanging `isReconnecting` state

### DIFF
--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { type ResolvedRegister, type State, hydrate } from '@wagmi/core'
-import { type ReactElement, useEffect, useRef } from 'react'
+import { type ReactElement, useEffect } from 'react'
 
 export type HydrateProps = {
   config: ResolvedRegister['config']

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -25,9 +25,6 @@ export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
   useEffect(() => {
     if (!config._internal.ssr) return
     onMount()
-    return () => {
-      active.current = false
-    }
   }, [onMount])
 
   return children as ReactElement

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -21,16 +21,14 @@ export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
   if (!config._internal.ssr) onMount()
 
   // Hydrate for SSR
-  const active = useRef(true)
   // biome-ignore lint/nursery/useExhaustiveDependencies:
   useEffect(() => {
-    if (!active.current) return
     if (!config._internal.ssr) return
     onMount()
     return () => {
       active.current = false
     }
-  }, [])
+  }, [onMount])
 
   return children as ReactElement
 }


### PR DESCRIPTION
As far as I've understood, the `const active = useRef(true)` was there to really make sure the effect is run just once as React doesn't guarantee that an effect won't be re-run once again, and for the same reason the dependencies were empty to minimize the redundant effect calls.

However, I think the effect still has to be run as during hot-reload component might get remounted with all connectors hanging in `isReconnecting: true` state.

Using this as a workaround for now.

Might fix #3490, yet also prune to excessive re-connects that might cause UI regressions, idk.

## Description

What changes are made in this PR? Is it a feature or a bug fix?

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
