### PR TITLE
introduce ledger connector

### DIFF
--- a/.changeset/fuzzy-pugs-tan.md
+++ b/.changeset/fuzzy-pugs-tan.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/connectors": patch
+"wagmi": patch
+---
+
+Restored ledger connector

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 @tmm @jxom
 
+/packages/connectors/src/ledger @Wozacosta @ComradeAERGO @RamyEB @Justkant
 /packages/connectors/src/safe @DaniSomoza @dasanra @mikhailxyz @yagopv
 /packages/connectors/src/walletConnect @ganchoradkov @0xAsimetriq

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -87,6 +87,10 @@ export function getSidebar() {
               },
               { text: 'injected', link: '/react/api/connectors/injected' },
               {
+                text: 'ledger',
+                link: '/react/api/connectors/ledger',
+              },
+              {
                 text: 'metaMask',
                 link: '/react/api/connectors/metaMask',
               },

--- a/docs/core/api/connectors/ledger.md
+++ b/docs/core/api/connectors/ledger.md
@@ -1,0 +1,6 @@
+<script setup>
+const packageName = '@wagmi/core'
+const connectorsPackageName = '@wagmi/connectors'
+</script>
+
+<!-- @include: @shared/connectors/ledger.md -->

--- a/docs/react/api/connectors/ledger.md
+++ b/docs/react/api/connectors/ledger.md
@@ -1,0 +1,6 @@
+<script setup>
+const packageName = 'wagmi'
+const connectorsPackageName = 'wagmi/connectors'
+</script>
+
+<!-- @include: @shared/connectors/ledger.md -->

--- a/docs/react/guides/migrate-from-v1-to-v2.md
+++ b/docs/react/guides/migrate-from-v1-to-v2.md
@@ -369,6 +369,7 @@ In Wagmi v1, connectors were classes you needed to instantiate. In Wagmi v2, con
 
 - `CoinbaseWalletConnector` is now [`coinbaseWallet`](/react/api/connectors/coinbaseWallet).
 - `InjectedConnector` is now [`injected`](/react/api/connectors/injected).
+- `LedgerConnector` is now [`ledger`](/react/api/connectors/ledger).
 - `SafeConnector` is now [`safe`](/react/api/connectors/safe).
 - `WalletConnectConnector` is now [`walletConnect`](/react/api/connectors/walletConnect).
 

--- a/docs/shared/connectors/ledger.md
+++ b/docs/shared/connectors/ledger.md
@@ -1,0 +1,78 @@
+<!-- <script setup>
+const packageName = 'wagmi'
+const connectorsPackageName = 'wagmi/connectors'
+</script> -->
+
+# ledger
+
+Connector for connecting with a Ledger device using the [Ledger Connect Kit](https://developers.ledger.com/docs/connect/introduction/).
+
+## Import
+
+```ts
+import { LedgerConnector } from 'wagmi/connectors/ledger'
+```
+
+## Usage
+
+To get started with Ledger + WalletConnect v2, you will need to retrieve a Project ID. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
+
+```ts{3,8-10}
+import { createConfig, http } from '{{packageName}}'
+import { mainnet, sepolia } from '{{packageName}}/chains'
+import { ledger } from '{{connectorsPackageName}}'
+
+export const config = createConfig({
+  chains: [mainnet, sepolia],
+  connectors: [
+    ledger({
+      projectId: '...',
+    }),
+  ],
+  transports: {
+    [mainnet.id]: http(),
+    [sepolia.id]: http(),
+  },
+})
+```
+
+## Parameters
+
+```ts
+import { type LedgerParameters } from '{{connectorsPackageName}}'
+```
+
+Check out the [Coinbase Wallet SDK docs](https://github.com/coinbase/coinbase-wallet-sdk) for more info.
+
+### projectId
+
+WalletConnect Cloud Project ID. You can find your Project ID [here](https://cloud.walletconnect.com/sign-in).
+
+```ts {5}
+export const config = createConfig({
+  // ...
+  connectors: [
+    ledger({
+      projectId: '...',
+    }),
+  ],
+  // ...
+})
+```
+
+### enableDebugLogs (optional)
+
+Toggle debug logging for Ledger Connect Kit.
+
+```ts {6}
+export const config = createConfig({
+  // ...
+  connectors: [
+    ledger({
+      projectId: '...',
+      enableDebugLogs: true,
+    }),
+  ],
+  // ...
+})
+```

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "3.9.1",
-    "@ledgerhq/connect-kit": "1.1.10",
+    "@ledgerhq/connect-kit": "1.1.12",
     "@metamask/sdk": "0.14.1",
     "@safe-global/safe-apps-provider": "0.18.1",
     "@safe-global/safe-apps-sdk": "8.1.0",

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "3.9.1",
+    "@ledgerhq/connect-kit": "1.1.10",
     "@metamask/sdk": "0.14.1",
     "@safe-global/safe-apps-provider": "0.18.1",
     "@safe-global/safe-apps-sdk": "8.1.0",

--- a/packages/connectors/src/exports/index.test.ts
+++ b/packages/connectors/src/exports/index.test.ts
@@ -8,6 +8,7 @@ test('exports', () => {
       "injected",
       "mock",
       "coinbaseWallet",
+      "ledger",
       "metaMask",
       "safe",
       "walletConnect",

--- a/packages/connectors/src/exports/index.ts
+++ b/packages/connectors/src/exports/index.ts
@@ -10,6 +10,8 @@ export {
   coinbaseWallet,
 } from '../coinbaseWallet.js'
 
+export { type LedgerParameters, ledger } from '../ledger.js'
+
 export { type MetaMaskParameters, metaMask } from '../metaMask.js'
 
 export { type SafeParameters, safe } from '../safe.js'

--- a/packages/connectors/src/ledger.test.ts
+++ b/packages/connectors/src/ledger.test.ts
@@ -1,0 +1,10 @@
+import { config } from '@wagmi/test'
+import { expect, test } from 'vitest'
+
+import { ledger } from './ledger.js'
+
+test('setup', () => {
+  const connectorFn = ledger({})
+  const connector = config._internal.connectors.setup(connectorFn)
+  expect(connector.name).toEqual('Ledger')
+})

--- a/packages/connectors/src/ledger.ts
+++ b/packages/connectors/src/ledger.ts
@@ -1,0 +1,243 @@
+import type { EthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.d.ts'
+import { type EthereumProviderOptions } from '@walletconnect/ethereum-provider'
+
+import { createConnector, normalizeChainId } from '@wagmi/core'
+import type { Evaluate } from '@wagmi/core/internal'
+import {
+  type ProviderRpcError,
+  SwitchChainError,
+  UserRejectedRequestError,
+  getAddress,
+  numberToHex,
+} from 'viem'
+
+type LedgerConnectorWcV2Options = {
+  enableDebugLogs?: boolean
+  walletConnectVersion?: 2
+  projectId?: EthereumProviderOptions['projectId']
+  requiredChains?: number[]
+  requiredMethods?: string[]
+  optionalMethods?: string[]
+  requiredEvents?: string[]
+  optionalEvents?: string[]
+}
+
+export type LedgerParameters = Evaluate<
+  LedgerConnectorWcV2Options & {
+    enableDebugLogs?: boolean
+    /**
+     Target chain to connect to.
+     */
+    chainId?: number | undefined
+  }
+>
+
+ledger.type = 'ledger' as const
+export function ledger(parameters: LedgerParameters) {
+  type Provider = EthereumProvider
+  type Properties = {
+    createProvider: any
+    initProvider: any
+    setupListeners: any
+    removeListeners: any
+  }
+
+  let provider_: Provider | undefined
+  let initProviderPromise: Promise<void>
+  const enableDebugLogs = parameters.enableDebugLogs ?? false
+
+  return createConnector<Provider, Properties>((config) => ({
+    id: 'ledger',
+    name: 'Ledger',
+    type: ledger.type,
+    async connect({ chainId }: { chainId?: number } = {}) {
+      try {
+        const provider = await this.getProvider()
+        this.setupListeners()
+
+        // Don't request accounts if we have a session, like when reloading with
+        // an active WC v2 session
+        if (!provider.session) {
+          config.emitter.emit('message', { type: 'connecting' })
+
+          await provider.request({
+            method: 'eth_requestAccounts',
+          })
+        }
+
+        const accounts = await this.getAccounts()
+        let id = await this.getChainId()
+
+        if (chainId && id !== chainId) {
+          const chain = await this.switchChain!({ chainId }).catch(() => ({
+            id,
+          }))
+          id = chain.id
+        }
+
+        return {
+          accounts,
+          chainId: id,
+          provider,
+        }
+      } catch (error) {
+        console.error(error)
+        if (/user rejected/i.test((error as ProviderRpcError)?.message)) {
+          throw new UserRejectedRequestError(error as Error)
+        }
+        throw error
+      }
+    },
+
+    async disconnect() {
+      const provider = await this.getProvider()
+      try {
+        if (provider?.disconnect) await provider.disconnect()
+      } catch (error) {
+        if (!/No matching key/i.test((error as Error).message)) throw error
+      } finally {
+        this.removeListeners()
+      }
+    },
+
+    async getAccounts() {
+      const provider = await this.getProvider()
+      const accounts = (await provider.request({
+        method: 'eth_accounts',
+      })) as string[]
+      return accounts.map(getAddress)
+    },
+
+    async getChainId() {
+      const provider = await this.getProvider()
+      const chainId = (await provider.request({
+        method: 'eth_chainId',
+      })) as number
+
+      return normalizeChainId(chainId)
+    },
+
+    async getProvider({ chainId } = {}) {
+      if (!provider_) {
+        await this.createProvider()
+      }
+
+      if (chainId) await this.switchChain?.({ chainId })
+      return provider_!
+    },
+
+    async isAuthorized() {
+      try {
+        const accounts = await this.getAccounts()
+
+        return !!accounts.length
+      } catch {
+        return false
+      }
+    },
+
+    async switchChain({ chainId }) {
+      const chain = config.chains.find((chain) => chain.id === chainId)
+      if (!chain)
+        throw new SwitchChainError(new Error('chain not found on connector.'))
+
+      try {
+        const provider = await this.getProvider()
+
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: numberToHex(chainId) }],
+        })
+
+        return chain
+      } catch (error) {
+        const message =
+          typeof error === 'string'
+            ? error
+            : (error as ProviderRpcError)?.message
+        if (/user rejected request/i.test(message)) {
+          throw new UserRejectedRequestError(error as Error)
+        }
+        throw new SwitchChainError(error as Error)
+      }
+    },
+    async createProvider() {
+      if (!initProviderPromise && typeof window !== 'undefined') {
+        initProviderPromise = this.initProvider()
+      }
+      return initProviderPromise
+    },
+    async initProvider() {
+      const connectKit = await import('@ledgerhq/connect-kit/dist/umd')
+
+      if (enableDebugLogs) {
+        connectKit.enableDebugLogs()
+      }
+
+      const {
+        projectId,
+        requiredChains,
+        requiredMethods,
+        optionalMethods,
+        requiredEvents,
+        optionalEvents,
+      } = parameters as LedgerConnectorWcV2Options
+      const optionalChains = config.chains.map(({ id }) => id)
+
+      const checkSupportOptions = {
+        providerType: connectKit.SupportedProviders.Ethereum,
+        walletConnectVersion: 2,
+        projectId,
+        chains: requiredChains,
+        optionalChains,
+        methods: requiredMethods,
+        optionalMethods,
+        events: requiredEvents,
+        optionalEvents,
+        rpcMap: Object.fromEntries(
+          config.chains.map((chain) => [
+            chain.id,
+            chain.rpcUrls.default.http[0]!,
+          ]),
+        ),
+      }
+      connectKit.checkSupport(checkSupportOptions)
+
+      provider_ =
+        (await connectKit.getProvider()) as unknown as EthereumProvider
+    },
+    setupListeners() {
+      if (!provider_) return
+      this.removeListeners()
+      provider_.on('accountsChanged', this.onAccountsChanged)
+      provider_.on('chainChanged', this.onChainChanged)
+      provider_.on('disconnect', this.onDisconnect)
+      provider_.on('session_delete', this.onDisconnect)
+      provider_.on('connect', this.onConnect?.bind(this))
+    },
+    removeListeners() {
+      if (!provider_) return
+      provider_.removeListener('accountsChanged', this.onAccountsChanged)
+      provider_.removeListener('chainChanged', this.onChainChanged)
+      provider_.removeListener('disconnect', this.onDisconnect)
+      provider_.removeListener('session_delete', this.onDisconnect)
+      provider_.removeListener('connect', this.onConnect?.bind(this))
+    },
+    onAccountsChanged(accounts: string[]) {
+      if (accounts.length === 0) config.emitter.emit('disconnect')
+      else config.emitter.emit('change', { accounts: accounts.map(getAddress) })
+    },
+    onChainChanged(chainId: number | string) {
+      const id = normalizeChainId(chainId)
+      config.emitter.emit('change', { chainId: id })
+    },
+    onDisconnect() {
+      config.emitter.emit('disconnect')
+    },
+    async onConnect() {
+      const accounts = await this.getAccounts()
+      const chainId = await this.getChainId()
+      config.emitter.emit('connect', { accounts, chainId })
+    },
+  }))
+}

--- a/packages/react/src/exports/connectors.test.ts
+++ b/packages/react/src/exports/connectors.test.ts
@@ -8,6 +8,7 @@ test('exports', () => {
       "injected",
       "mock",
       "coinbaseWallet",
+      "ledger",
       "metaMask",
       "safe",
       "walletConnect",

--- a/playgrounds/vite-core/src/wagmi.ts
+++ b/playgrounds/vite-core/src/wagmi.ts
@@ -1,4 +1,4 @@
-import { coinbaseWallet, walletConnect } from '@wagmi/connectors'
+import { coinbaseWallet, ledger, walletConnect } from '@wagmi/connectors'
 import { http, createConfig, createStorage } from '@wagmi/core'
 import { mainnet, optimism, sepolia } from '@wagmi/core/chains'
 
@@ -7,6 +7,9 @@ export const config = createConfig({
   connectors: [
     walletConnect({ projectId: import.meta.env.VITE_WC_PROJECT_ID }),
     coinbaseWallet({ appName: 'Vite React Playground' }),
+    ledger({
+      projectId: import.meta.env.VITE_WC_PROJECT_ID,
+    }),
   ],
   storage: createStorage({ storage: localStorage, key: 'vite-core' }),
   transports: {

--- a/playgrounds/vite-react/src/wagmi.ts
+++ b/playgrounds/vite-react/src/wagmi.ts
@@ -1,7 +1,7 @@
 import { del, get, set } from 'idb-keyval'
 import { http, createConfig } from 'wagmi'
 import { celo, mainnet, optimism, sepolia } from 'wagmi/chains'
-import { coinbaseWallet, walletConnect } from 'wagmi/connectors'
+import { coinbaseWallet, ledger, walletConnect } from 'wagmi/connectors'
 
 // biome-ignore lint/correctness/noUnusedVariables: <explanation>
 const indexedDBStorage = {
@@ -23,6 +23,9 @@ export const config = createConfig({
       projectId: import.meta.env.VITE_WC_PROJECT_ID,
     }),
     coinbaseWallet({ appName: 'Vite React Playground', darkMode: true }),
+    ledger({
+      projectId: import.meta.env.VITE_WC_PROJECT_ID,
+    }),
   ],
   transports: {
     [mainnet.id]: http(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@coinbase/wallet-sdk':
         specifier: 3.9.1
         version: 3.9.1
+      '@ledgerhq/connect-kit':
+        specifier: 1.1.10
+        version: 1.1.10
       '@metamask/sdk':
         specifier: 0.14.1
         version: 0.14.1
@@ -2548,6 +2551,18 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
+  /@ledgerhq/connect-kit@1.1.10:
+    resolution: {integrity: sha512-oISgGJOsUwASnxT1GlEq+vkQhYLAajV3CRNHRyDL5sFLDVVN3CARYNyMdBKbTNDV6e1hZKYRuEAQpBKSIJ43mg==}
+    dependencies:
+      '@segment/analytics-next': 1.63.0
+      rollup-plugin-dotenv: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+    dev: false
+
   /@lit-labs/ssr-dom-shim@1.1.0:
     resolution: {integrity: sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong==}
     dev: false
@@ -2556,6 +2571,18 @@ packages:
     resolution: {integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==}
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.1.0
+    dev: false
+
+  /@lukeed/csprng@1.1.0:
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@lukeed/uuid@2.0.1:
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@lukeed/csprng': 1.1.0
     dev: false
 
   /@manypkg/find-root@1.1.0:
@@ -3491,6 +3518,19 @@ packages:
       merge-options: 3.0.4
     dev: false
 
+  /@rollup/plugin-replace@5.0.5:
+    resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2
+      magic-string: 0.30.5
+    dev: false
+
   /@rollup/pluginutils@5.0.2:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
@@ -3503,7 +3543,6 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    dev: true
 
   /@safe-global/safe-apps-provider@0.18.1(typescript@5.3.2):
     resolution: {integrity: sha512-V4a05A3EgJcriqtDoJklDz1BOinWhC6P0hjUSxshA4KOZM7rGPCTto/usXs09zr1vvL28evl/NldSTv97j2bmg==}
@@ -3577,6 +3616,78 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.3
+
+  /@segment/analytics-core@1.4.1:
+    resolution: {integrity: sha512-kV0Pf33HnthuBOVdYNani21kYyj118Fn+9757bxqoksiXoZlYvBsFq6giNdCsKcTIE1eAMqNDq3xE1VQ0cfsHA==}
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      '@segment/analytics-generic-utils': 1.1.1
+      dset: 3.1.3
+      tslib: 2.5.0
+    dev: false
+
+  /@segment/analytics-generic-utils@1.1.1:
+    resolution: {integrity: sha512-THTIzBPHnvu1HYJU3fARdJ3qIkukO3zDXsmDm+kAeUks5R9CBXOQ6rPChiASVzSmwAIIo5uFIXXnCraojlq/Gw==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+
+  /@segment/analytics-next@1.63.0:
+    resolution: {integrity: sha512-6GCZXq2vNiZj/jnolT+Rsl51PZdlw2dNyFutfwnY+GjMZB+UkzaLbpwc20q+cMWj5FvhksIxrfG1F+aYZBf5lw==}
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      '@segment/analytics-core': 1.4.1
+      '@segment/analytics-generic-utils': 1.1.1
+      '@segment/analytics.js-video-plugins': 0.2.1
+      '@segment/facade': 3.4.10
+      '@segment/tsub': 2.0.0
+      dset: 3.1.3
+      js-cookie: 3.0.1
+      node-fetch: 2.7.0
+      spark-md5: 3.0.2
+      tslib: 2.5.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@segment/analytics.js-video-plugins@0.2.1:
+    resolution: {integrity: sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==}
+    dependencies:
+      unfetch: 3.1.2
+    dev: false
+
+  /@segment/facade@3.4.10:
+    resolution: {integrity: sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==}
+    dependencies:
+      '@segment/isodate-traverse': 1.1.1
+      inherits: 2.0.4
+      new-date: 1.0.3
+      obj-case: 0.2.1
+    dev: false
+
+  /@segment/isodate-traverse@1.1.1:
+    resolution: {integrity: sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==}
+    dependencies:
+      '@segment/isodate': 1.0.3
+    dev: false
+
+  /@segment/isodate@1.0.3:
+    resolution: {integrity: sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==}
+    dev: false
+
+  /@segment/tsub@2.0.0:
+    resolution: {integrity: sha512-NzkBK8GwPsyQ74AceLjENbUoaFrObnzEKOX4ko2wZDuIyK+DnDm3B//8xZYI2LCKt+wUD55l6ygfjCoVs8RMWw==}
+    hasBin: true
+    dependencies:
+      '@stdlib/math-base-special-ldexp': 0.0.5
+      dlv: 1.1.3
+      dset: 3.1.3
+      tiny-hashes: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@sentry/core@5.30.0:
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -3780,6 +3891,1037 @@ packages:
       '@stablelib/keyagreement': 1.0.1
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stdlib/array-float32@0.0.6:
+    resolution: {integrity: sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-float32array-support': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/array-float64@0.0.6:
+    resolution: {integrity: sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-float64array-support': 0.0.8
+    dev: false
+
+  /@stdlib/array-uint16@0.0.6:
+    resolution: {integrity: sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-uint16array-support': 0.0.8
+    dev: false
+
+  /@stdlib/array-uint32@0.0.6:
+    resolution: {integrity: sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-uint32array-support': 0.0.8
+    dev: false
+
+  /@stdlib/array-uint8@0.0.7:
+    resolution: {integrity: sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-uint8array-support': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-float32array-support@0.0.8:
+    resolution: {integrity: sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-float32array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-float64-pinf': 0.0.8
+      '@stdlib/fs-read-file': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/assert-has-float64array-support@0.0.8:
+    resolution: {integrity: sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-float64array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-node-buffer-support@0.0.8:
+    resolution: {integrity: sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-buffer': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-own-property@0.0.7:
+    resolution: {integrity: sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/assert-has-symbol-support@0.0.8:
+    resolution: {integrity: sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-tostringtag-support@0.0.9:
+    resolution: {integrity: sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-has-symbol-support': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-uint16array-support@0.0.8:
+    resolution: {integrity: sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-uint16array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-uint16-max': 0.0.7
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-uint32array-support@0.0.8:
+    resolution: {integrity: sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-uint32array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-uint32-max': 0.0.7
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-has-uint8array-support@0.0.8:
+    resolution: {integrity: sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-uint8array': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/constants-uint8-max': 0.0.7
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-array@0.0.7:
+    resolution: {integrity: sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-big-endian@0.0.7:
+    resolution: {integrity: sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/array-uint16': 0.0.6
+      '@stdlib/array-uint8': 0.0.7
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-boolean@0.0.8:
+    resolution: {integrity: sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-buffer@0.0.8:
+    resolution: {integrity: sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-object-like': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-float32array@0.0.8:
+    resolution: {integrity: sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-float64array@0.0.8:
+    resolution: {integrity: sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-function@0.0.8:
+    resolution: {integrity: sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-type-of': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-little-endian@0.0.7:
+    resolution: {integrity: sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/array-uint16': 0.0.6
+      '@stdlib/array-uint8': 0.0.7
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-number@0.0.7:
+    resolution: {integrity: sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/number-ctor': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-object-like@0.0.8:
+    resolution: {integrity: sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-tools-array-function': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/assert-is-object@0.0.8:
+    resolution: {integrity: sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-array': 0.0.7
+    dev: false
+
+  /@stdlib/assert-is-plain-object@0.0.7:
+    resolution: {integrity: sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-object': 0.0.8
+      '@stdlib/utils-get-prototype-of': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-regexp-string@0.0.9:
+    resolution: {integrity: sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/regexp-eol': 0.0.7
+      '@stdlib/regexp-regexp': 0.0.8
+      '@stdlib/streams-node-stdin': 0.0.7
+    dev: false
+
+  /@stdlib/assert-is-regexp@0.0.7:
+    resolution: {integrity: sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-string@0.0.8:
+    resolution: {integrity: sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-uint16array@0.0.8:
+    resolution: {integrity: sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-uint32array@0.0.8:
+    resolution: {integrity: sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-is-uint8array@0.0.8:
+    resolution: {integrity: sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/assert-tools-array-function@0.0.7:
+    resolution: {integrity: sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-array': 0.0.7
+    dev: false
+
+  /@stdlib/buffer-ctor@0.0.7:
+    resolution: {integrity: sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-node-buffer-support': 0.0.8
+    dev: false
+
+  /@stdlib/buffer-from-string@0.0.8:
+    resolution: {integrity: sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/buffer-ctor': 0.0.7
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/cli-ctor@0.0.3:
+    resolution: {integrity: sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-noop': 0.0.14
+      minimist: 1.2.8
+    dev: false
+
+  /@stdlib/complex-float32@0.0.7:
+    resolution: {integrity: sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-number': 0.0.7
+      '@stdlib/number-float64-base-to-float32': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-define-property': 0.0.9
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/complex-float64@0.0.8:
+    resolution: {integrity: sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-number': 0.0.7
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-define-property': 0.0.9
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/complex-reim@0.0.6:
+    resolution: {integrity: sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/complex-float64': 0.0.8
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/complex-reimf@0.0.1:
+    resolution: {integrity: sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float32': 0.0.6
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-exponent-bias@0.0.8:
+    resolution: {integrity: sha512-IzBJQw9hYgWCki7VoC/zJxEA76Nmf8hmY+VkOWnJ8IyfgTXClgY8tfDGS1cc4l/hCOEllxGp9FRvVdn24A5tKQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-high-word-abs-mask@0.0.1:
+    resolution: {integrity: sha512-1vy8SUyMHFBwqUUVaZFA7r4/E3cMMRKSwsaa/EZ15w7Kmc01W/ZmaaTLevRcIdACcNgK+8i8813c8H7LScXNcQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-high-word-exponent-mask@0.0.8:
+    resolution: {integrity: sha512-z28/EQERc0VG7N36bqdvtrRWjFc8600PKkwvl/nqx6TpKAzMXNw55BS1xT4C28Sa9Z7uBWeUj3UbIFedbkoyMw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-high-word-sign-mask@0.0.1:
+    resolution: {integrity: sha512-hmTr5caK1lh1m0eyaQqt2Vt3y+eEdAx57ndbADEbXhxC9qSGd0b4bLSzt/Xp4MYBYdQkHAE/BlkgUiRThswhCg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-max-base2-exponent-subnormal@0.0.8:
+    resolution: {integrity: sha512-YGBZykSiXFebznnJfWFDwhho2Q9xhUWOL+X0lZJ4ItfTTo40W6VHAyNYz98tT/gJECFype0seNzzo1nUxCE7jQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-max-base2-exponent@0.0.8:
+    resolution: {integrity: sha512-xBAOtso1eiy27GnTut2difuSdpsGxI8dJhXupw0UukGgvy/3CSsyNm+a1Suz/dhqK4tPOTe5QboIdNMw5IgXKQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-min-base2-exponent-subnormal@0.0.8:
+    resolution: {integrity: sha512-bt81nBus/91aEqGRQBenEFCyWNsf8uaxn4LN1NjgkvY92S1yVxXFlC65fJHsj9FTqvyZ+uj690/gdMKUDV3NjQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-ninf@0.0.8:
+    resolution: {integrity: sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/number-ctor': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-pinf@0.0.8:
+    resolution: {integrity: sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-float64-smallest-normal@0.0.8:
+    resolution: {integrity: sha512-Qwxpn5NA3RXf+mQcffCWRcsHSPTUQkalsz0+JDpblDszuz2XROcXkOdDr5LKgTAUPIXsjOgZzTsuRONENhsSEg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/constants-uint16-max@0.0.7:
+    resolution: {integrity: sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/constants-uint32-max@0.0.7:
+    resolution: {integrity: sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/constants-uint8-max@0.0.7:
+    resolution: {integrity: sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/fs-exists@0.0.8:
+    resolution: {integrity: sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-cwd': 0.0.8
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/fs-read-file@0.0.8:
+    resolution: {integrity: sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/fs-resolve-parent-path@0.0.8:
+    resolution: {integrity: sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-plain-object': 0.0.7
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-exists': 0.0.8
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-cwd': 0.0.8
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/math-base-assert-is-infinite@0.0.9:
+    resolution: {integrity: sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-ninf': 0.0.8
+      '@stdlib/constants-float64-pinf': 0.0.8
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-assert-is-nan@0.0.8:
+    resolution: {integrity: sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-napi-binary@0.0.8:
+    resolution: {integrity: sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/complex-float64': 0.0.8
+      '@stdlib/complex-reim': 0.0.6
+      '@stdlib/complex-reimf': 0.0.1
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-napi-unary@0.0.9:
+    resolution: {integrity: sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/complex-float32': 0.0.7
+      '@stdlib/complex-float64': 0.0.8
+      '@stdlib/complex-reim': 0.0.6
+      '@stdlib/complex-reimf': 0.0.1
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-special-abs@0.0.6:
+    resolution: {integrity: sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/math-base-napi-unary': 0.0.9
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-special-copysign@0.0.7:
+    resolution: {integrity: sha512-7Br7oeuVJSBKG8BiSk/AIRFTBd2sbvHdV3HaqRj8tTZHX8BQomZ3Vj4Qsiz3kPyO4d6PpBLBTYlGTkSDlGOZJA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-high-word-abs-mask': 0.0.1
+      '@stdlib/constants-float64-high-word-sign-mask': 0.0.1
+      '@stdlib/math-base-napi-binary': 0.0.8
+      '@stdlib/number-float64-base-from-words': 0.0.6
+      '@stdlib/number-float64-base-get-high-word': 0.0.6
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/math-base-special-ldexp@0.0.5:
+    resolution: {integrity: sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-exponent-bias': 0.0.8
+      '@stdlib/constants-float64-max-base2-exponent': 0.0.8
+      '@stdlib/constants-float64-max-base2-exponent-subnormal': 0.0.8
+      '@stdlib/constants-float64-min-base2-exponent-subnormal': 0.0.8
+      '@stdlib/constants-float64-ninf': 0.0.8
+      '@stdlib/constants-float64-pinf': 0.0.8
+      '@stdlib/math-base-assert-is-infinite': 0.0.9
+      '@stdlib/math-base-assert-is-nan': 0.0.8
+      '@stdlib/math-base-special-copysign': 0.0.7
+      '@stdlib/number-float64-base-exponent': 0.0.6
+      '@stdlib/number-float64-base-from-words': 0.0.6
+      '@stdlib/number-float64-base-normalize': 0.0.9
+      '@stdlib/number-float64-base-to-words': 0.0.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-ctor@0.0.7:
+    resolution: {integrity: sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/number-float64-base-exponent@0.0.6:
+    resolution: {integrity: sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-exponent-bias': 0.0.8
+      '@stdlib/constants-float64-high-word-exponent-mask': 0.0.8
+      '@stdlib/number-float64-base-get-high-word': 0.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-from-words@0.0.6:
+    resolution: {integrity: sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/array-uint32': 0.0.6
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-get-high-word@0.0.6:
+    resolution: {integrity: sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/array-uint32': 0.0.6
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/number-float64-base-to-words': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-normalize@0.0.9:
+    resolution: {integrity: sha512-+rm7RQJEj8zHkqYFE2a6DgNQSB5oKE/IydHAajgZl40YB91BoYRYf/ozs5/tTwfy2Fc04+tIpSfFtzDr4ZY19Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/constants-float64-smallest-normal': 0.0.8
+      '@stdlib/math-base-assert-is-infinite': 0.0.9
+      '@stdlib/math-base-assert-is-nan': 0.0.8
+      '@stdlib/math-base-special-abs': 0.0.6
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-to-float32@0.0.7:
+    resolution: {integrity: sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float32': 0.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/number-float64-base-to-words@0.0.7:
+    resolution: {integrity: sha512-7wsYuq+2MGp9rAkTnQ985rah7EJI9TfgHrYSSd4UIu4qIjoYmWIKEhIDgu7/69PfGrls18C3PxKg1pD/v7DQTg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/array-float64': 0.0.6
+      '@stdlib/array-uint32': 0.0.6
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/os-byte-order': 0.0.7
+      '@stdlib/os-float-word-order': 0.0.7
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/os-byte-order@0.0.7:
+    resolution: {integrity: sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-big-endian': 0.0.7
+      '@stdlib/assert-is-little-endian': 0.0.7
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/os-float-word-order@0.0.7:
+    resolution: {integrity: sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/os-byte-order': 0.0.7
+      '@stdlib/utils-library-manifest': 0.0.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/process-cwd@0.0.8:
+    resolution: {integrity: sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+    dev: false
+
+  /@stdlib/process-read-stdin@0.0.7:
+    resolution: {integrity: sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/buffer-ctor': 0.0.7
+      '@stdlib/buffer-from-string': 0.0.8
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/utils-next-tick': 0.0.8
+    dev: false
+
+  /@stdlib/regexp-eol@0.0.7:
+    resolution: {integrity: sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-is-boolean': 0.0.8
+      '@stdlib/assert-is-plain-object': 0.0.7
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/regexp-extended-length-path@0.0.7:
+    resolution: {integrity: sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/regexp-function-name@0.0.7:
+    resolution: {integrity: sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/regexp-regexp@0.0.8:
+    resolution: {integrity: sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
+    dev: false
+
+  /@stdlib/streams-node-stdin@0.0.7:
+    resolution: {integrity: sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/string-base-format-interpolate@0.0.4:
+    resolution: {integrity: sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/string-base-format-tokenize@0.0.4:
+    resolution: {integrity: sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/string-format@0.0.3:
+    resolution: {integrity: sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/string-base-format-interpolate': 0.0.4
+      '@stdlib/string-base-format-tokenize': 0.0.4
+    dev: false
+
+  /@stdlib/string-lowercase@0.0.9:
+    resolution: {integrity: sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/string-replace@0.0.11:
+    resolution: {integrity: sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/assert-is-regexp': 0.0.7
+      '@stdlib/assert-is-regexp-string': 0.0.9
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/regexp-eol': 0.0.7
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/string-format': 0.0.3
+      '@stdlib/utils-escape-regexp-string': 0.0.9
+      '@stdlib/utils-regexp-from-string': 0.0.9
+    dev: false
+
+  /@stdlib/types@0.0.14:
+    resolution: {integrity: sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/utils-constructor-name@0.0.8:
+    resolution: {integrity: sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-buffer': 0.0.8
+      '@stdlib/regexp-function-name': 0.0.7
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/utils-convert-path@0.0.8:
+    resolution: {integrity: sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-read-file': 0.0.8
+      '@stdlib/process-read-stdin': 0.0.7
+      '@stdlib/regexp-eol': 0.0.7
+      '@stdlib/regexp-extended-length-path': 0.0.7
+      '@stdlib/streams-node-stdin': 0.0.7
+      '@stdlib/string-lowercase': 0.0.9
+      '@stdlib/string-replace': 0.0.11
+    dev: false
+
+  /@stdlib/utils-define-nonenumerable-read-only-property@0.0.7:
+    resolution: {integrity: sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/types': 0.0.14
+      '@stdlib/utils-define-property': 0.0.9
+    dev: false
+
+  /@stdlib/utils-define-property@0.0.9:
+    resolution: {integrity: sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/types': 0.0.14
+    dev: false
+
+  /@stdlib/utils-escape-regexp-string@0.0.9:
+    resolution: {integrity: sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/utils-get-prototype-of@0.0.7:
+    resolution: {integrity: sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-function': 0.0.8
+      '@stdlib/utils-native-class': 0.0.8
+    dev: false
+
+  /@stdlib/utils-global@0.0.7:
+    resolution: {integrity: sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-boolean': 0.0.8
+    dev: false
+
+  /@stdlib/utils-library-manifest@0.0.8:
+    resolution: {integrity: sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    hasBin: true
+    dependencies:
+      '@stdlib/cli-ctor': 0.0.3
+      '@stdlib/fs-resolve-parent-path': 0.0.8
+      '@stdlib/utils-convert-path': 0.0.8
+      debug: 2.6.9
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@stdlib/utils-native-class@0.0.8:
+    resolution: {integrity: sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-has-own-property': 0.0.7
+      '@stdlib/assert-has-tostringtag-support': 0.0.9
+    dev: false
+
+  /@stdlib/utils-next-tick@0.0.8:
+    resolution: {integrity: sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/utils-noop@0.0.14:
+    resolution: {integrity: sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dev: false
+
+  /@stdlib/utils-regexp-from-string@0.0.9:
+    resolution: {integrity: sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/assert-is-string': 0.0.8
+      '@stdlib/regexp-regexp': 0.0.8
+      '@stdlib/string-format': 0.0.3
+    dev: false
+
+  /@stdlib/utils-type-of@0.0.8:
+    resolution: {integrity: sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==}
+    engines: {node: '>=0.10.0', npm: '>2.7.0'}
+    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
+    dependencies:
+      '@stdlib/utils-constructor-name': 0.0.8
+      '@stdlib/utils-global': 0.0.7
     dev: false
 
   /@swc/helpers@0.5.2:
@@ -4011,7 +5153,6 @@ packages:
 
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
@@ -4293,7 +5434,7 @@ packages:
       colorette: 2.0.20
       consola: 3.2.3
       fast-glob: 3.3.1
-      magic-string: 0.30.2
+      magic-string: 0.30.5
       pathe: 1.1.1
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
@@ -4333,7 +5474,7 @@ packages:
       '@unocss/core': 0.53.6
       css-tree: 2.3.1
       fast-glob: 3.3.1
-      magic-string: 0.30.2
+      magic-string: 0.30.5
       postcss: 8.4.27
     dev: true
 
@@ -4448,7 +5589,7 @@ packages:
       '@unocss/transformer-directives': 0.53.6
       chokidar: 3.5.3
       fast-glob: 3.3.1
-      magic-string: 0.30.2
+      magic-string: 0.30.5
       vite: 4.4.9(@types/node@20.11.5)
     transitivePeerDependencies:
       - rollup
@@ -4522,7 +5663,7 @@ packages:
   /@vitest/snapshot@0.34.5:
     resolution: {integrity: sha512-+ikwSbhu6z2yOdtKmk/aeoDZ9QPm2g/ZO5rXT58RR9Vmu/kB2MamyDSx77dctqdZfP3Diqv4mbc/yw2kPT8rmA==}
     dependencies:
-      magic-string: 0.30.2
+      magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.6.2
     dev: true
@@ -6351,6 +7492,10 @@ packages:
     dependencies:
       path-type: 4.0.0
 
+  /dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: false
+
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
@@ -6383,6 +7528,11 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
     dev: true
+
+  /dset@3.1.3:
+    resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
+    engines: {node: '>=4'}
+    dev: false
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -6727,7 +7877,6 @@ packages:
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -8283,6 +9432,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /js-cookie@3.0.1:
+    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
@@ -8721,6 +9875,12 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -8924,7 +10084,6 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
@@ -9116,6 +10275,12 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /new-date@1.0.3:
+    resolution: {integrity: sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==}
+    dependencies:
+      '@segment/isodate': 1.0.3
+    dev: false
+
   /next@13.5.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4Nt4HRLYDW/yRpJ/QR2t1v63UOMS55A38dnWv3UDOWGezuY0ZyFO1ABNbD7mulVzs9qVhgy2+ppjdsANpKP1mg==}
     engines: {node: '>=16.14.0'}
@@ -9287,6 +10452,10 @@ packages:
   /nwsapi@2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
     dev: true
+
+  /obj-case@0.2.1:
+    resolution: {integrity: sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==}
+    dev: false
 
   /obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
@@ -10304,6 +11473,16 @@ packages:
       bn.js: 5.2.1
     dev: true
 
+  /rollup-plugin-dotenv@0.5.0:
+    resolution: {integrity: sha512-M2gZqEZebtcKaA7OBdO4UF3WmkI02wVD6UVwoxFlRKoq4/n1Q9Cw6UV8dPvVZYpGQ+ug2JPoogrCLaydIKU96A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0
+    dependencies:
+      '@rollup/plugin-replace': 5.0.5
+      dotenv: 16.3.1
+    dev: false
+
   /rollup-plugin-visualizer@5.9.2:
     resolution: {integrity: sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==}
     engines: {node: '>=14'}
@@ -10709,6 +11888,10 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
+  /spark-md5@3.0.2:
+    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
+    dev: false
+
   /spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
     dependencies:
@@ -11038,6 +12221,10 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
+  /tiny-hashes@1.0.1:
+    resolution: {integrity: sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==}
+    dev: false
+
   /tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
@@ -11308,6 +12495,10 @@ packages:
       string.fromcodepoint: 0.2.1
     dev: true
 
+  /unfetch@3.1.2:
+    resolution: {integrity: sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==}
+    dev: false
+
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
     dev: false
@@ -11529,6 +12720,11 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ importers:
         specifier: 3.9.1
         version: 3.9.1
       '@ledgerhq/connect-kit':
-        specifier: 1.1.10
-        version: 1.1.10
+        specifier: 1.1.12
+        version: 1.1.12
       '@metamask/sdk':
         specifier: 0.14.1
         version: 0.14.1
@@ -2521,7 +2521,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/resolve-uri@3.1.0:
@@ -2551,16 +2551,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
-  /@ledgerhq/connect-kit@1.1.10:
-    resolution: {integrity: sha512-oISgGJOsUwASnxT1GlEq+vkQhYLAajV3CRNHRyDL5sFLDVVN3CARYNyMdBKbTNDV6e1hZKYRuEAQpBKSIJ43mg==}
+  /@ledgerhq/connect-kit@1.1.12:
+    resolution: {integrity: sha512-dmnG2BGBckzaUaqXmkoDxy1+Yvk/simH8NNaZOQaOFk2EfFNsaw5Q3EKrw9tzqjSXmg6t6eGUNPxE0ji9uZprw==}
     dependencies:
-      '@segment/analytics-next': 1.63.0
       rollup-plugin-dotenv: 0.5.0
       uuid: 9.0.1
     transitivePeerDependencies:
-      - encoding
       - rollup
-      - supports-color
     dev: false
 
   /@lit-labs/ssr-dom-shim@1.1.0:
@@ -2571,18 +2568,6 @@ packages:
     resolution: {integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==}
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.1.0
-    dev: false
-
-  /@lukeed/csprng@1.1.0:
-    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
-    engines: {node: '>=8'}
-    dev: false
-
-  /@lukeed/uuid@2.0.1:
-    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@lukeed/csprng': 1.1.0
     dev: false
 
   /@manypkg/find-root@1.1.0:
@@ -3617,78 +3602,6 @@ packages:
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.3
 
-  /@segment/analytics-core@1.4.1:
-    resolution: {integrity: sha512-kV0Pf33HnthuBOVdYNani21kYyj118Fn+9757bxqoksiXoZlYvBsFq6giNdCsKcTIE1eAMqNDq3xE1VQ0cfsHA==}
-    dependencies:
-      '@lukeed/uuid': 2.0.1
-      '@segment/analytics-generic-utils': 1.1.1
-      dset: 3.1.3
-      tslib: 2.5.0
-    dev: false
-
-  /@segment/analytics-generic-utils@1.1.1:
-    resolution: {integrity: sha512-THTIzBPHnvu1HYJU3fARdJ3qIkukO3zDXsmDm+kAeUks5R9CBXOQ6rPChiASVzSmwAIIo5uFIXXnCraojlq/Gw==}
-    dependencies:
-      tslib: 2.5.0
-    dev: false
-
-  /@segment/analytics-next@1.63.0:
-    resolution: {integrity: sha512-6GCZXq2vNiZj/jnolT+Rsl51PZdlw2dNyFutfwnY+GjMZB+UkzaLbpwc20q+cMWj5FvhksIxrfG1F+aYZBf5lw==}
-    dependencies:
-      '@lukeed/uuid': 2.0.1
-      '@segment/analytics-core': 1.4.1
-      '@segment/analytics-generic-utils': 1.1.1
-      '@segment/analytics.js-video-plugins': 0.2.1
-      '@segment/facade': 3.4.10
-      '@segment/tsub': 2.0.0
-      dset: 3.1.3
-      js-cookie: 3.0.1
-      node-fetch: 2.7.0
-      spark-md5: 3.0.2
-      tslib: 2.5.0
-      unfetch: 4.2.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@segment/analytics.js-video-plugins@0.2.1:
-    resolution: {integrity: sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==}
-    dependencies:
-      unfetch: 3.1.2
-    dev: false
-
-  /@segment/facade@3.4.10:
-    resolution: {integrity: sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==}
-    dependencies:
-      '@segment/isodate-traverse': 1.1.1
-      inherits: 2.0.4
-      new-date: 1.0.3
-      obj-case: 0.2.1
-    dev: false
-
-  /@segment/isodate-traverse@1.1.1:
-    resolution: {integrity: sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==}
-    dependencies:
-      '@segment/isodate': 1.0.3
-    dev: false
-
-  /@segment/isodate@1.0.3:
-    resolution: {integrity: sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==}
-    dev: false
-
-  /@segment/tsub@2.0.0:
-    resolution: {integrity: sha512-NzkBK8GwPsyQ74AceLjENbUoaFrObnzEKOX4ko2wZDuIyK+DnDm3B//8xZYI2LCKt+wUD55l6ygfjCoVs8RMWw==}
-    hasBin: true
-    dependencies:
-      '@stdlib/math-base-special-ldexp': 0.0.5
-      dlv: 1.1.3
-      dset: 3.1.3
-      tiny-hashes: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@sentry/core@5.30.0:
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
     engines: {node: '>=6'}
@@ -3891,1037 +3804,6 @@ packages:
       '@stablelib/keyagreement': 1.0.1
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
-    dev: false
-
-  /@stdlib/array-float32@0.0.6:
-    resolution: {integrity: sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-float32array-support': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/array-float64@0.0.6:
-    resolution: {integrity: sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-float64array-support': 0.0.8
-    dev: false
-
-  /@stdlib/array-uint16@0.0.6:
-    resolution: {integrity: sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-uint16array-support': 0.0.8
-    dev: false
-
-  /@stdlib/array-uint32@0.0.6:
-    resolution: {integrity: sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-uint32array-support': 0.0.8
-    dev: false
-
-  /@stdlib/array-uint8@0.0.7:
-    resolution: {integrity: sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-uint8array-support': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-float32array-support@0.0.8:
-    resolution: {integrity: sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-float32array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-float64-pinf': 0.0.8
-      '@stdlib/fs-read-file': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/assert-has-float64array-support@0.0.8:
-    resolution: {integrity: sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-float64array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-node-buffer-support@0.0.8:
-    resolution: {integrity: sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-buffer': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-own-property@0.0.7:
-    resolution: {integrity: sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/assert-has-symbol-support@0.0.8:
-    resolution: {integrity: sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-tostringtag-support@0.0.9:
-    resolution: {integrity: sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-has-symbol-support': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-uint16array-support@0.0.8:
-    resolution: {integrity: sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-uint16array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-uint16-max': 0.0.7
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-uint32array-support@0.0.8:
-    resolution: {integrity: sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-uint32array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-uint32-max': 0.0.7
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-has-uint8array-support@0.0.8:
-    resolution: {integrity: sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-uint8array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-uint8-max': 0.0.7
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-array@0.0.7:
-    resolution: {integrity: sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-big-endian@0.0.7:
-    resolution: {integrity: sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/array-uint16': 0.0.6
-      '@stdlib/array-uint8': 0.0.7
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-boolean@0.0.8:
-    resolution: {integrity: sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-buffer@0.0.8:
-    resolution: {integrity: sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-object-like': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-float32array@0.0.8:
-    resolution: {integrity: sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-float64array@0.0.8:
-    resolution: {integrity: sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-function@0.0.8:
-    resolution: {integrity: sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-type-of': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-little-endian@0.0.7:
-    resolution: {integrity: sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/array-uint16': 0.0.6
-      '@stdlib/array-uint8': 0.0.7
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-number@0.0.7:
-    resolution: {integrity: sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/number-ctor': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-object-like@0.0.8:
-    resolution: {integrity: sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-tools-array-function': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/assert-is-object@0.0.8:
-    resolution: {integrity: sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-array': 0.0.7
-    dev: false
-
-  /@stdlib/assert-is-plain-object@0.0.7:
-    resolution: {integrity: sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-object': 0.0.8
-      '@stdlib/utils-get-prototype-of': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-regexp-string@0.0.9:
-    resolution: {integrity: sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/regexp-eol': 0.0.7
-      '@stdlib/regexp-regexp': 0.0.8
-      '@stdlib/streams-node-stdin': 0.0.7
-    dev: false
-
-  /@stdlib/assert-is-regexp@0.0.7:
-    resolution: {integrity: sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-string@0.0.8:
-    resolution: {integrity: sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-uint16array@0.0.8:
-    resolution: {integrity: sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-uint32array@0.0.8:
-    resolution: {integrity: sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-is-uint8array@0.0.8:
-    resolution: {integrity: sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/assert-tools-array-function@0.0.7:
-    resolution: {integrity: sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-array': 0.0.7
-    dev: false
-
-  /@stdlib/buffer-ctor@0.0.7:
-    resolution: {integrity: sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-node-buffer-support': 0.0.8
-    dev: false
-
-  /@stdlib/buffer-from-string@0.0.8:
-    resolution: {integrity: sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/buffer-ctor': 0.0.7
-      '@stdlib/string-format': 0.0.3
-    dev: false
-
-  /@stdlib/cli-ctor@0.0.3:
-    resolution: {integrity: sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-noop': 0.0.14
-      minimist: 1.2.8
-    dev: false
-
-  /@stdlib/complex-float32@0.0.7:
-    resolution: {integrity: sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-number': 0.0.7
-      '@stdlib/number-float64-base-to-float32': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-define-property': 0.0.9
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/complex-float64@0.0.8:
-    resolution: {integrity: sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-number': 0.0.7
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-define-property': 0.0.9
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/complex-reim@0.0.6:
-    resolution: {integrity: sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/complex-float64': 0.0.8
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/complex-reimf@0.0.1:
-    resolution: {integrity: sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/array-float32': 0.0.6
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-exponent-bias@0.0.8:
-    resolution: {integrity: sha512-IzBJQw9hYgWCki7VoC/zJxEA76Nmf8hmY+VkOWnJ8IyfgTXClgY8tfDGS1cc4l/hCOEllxGp9FRvVdn24A5tKQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-high-word-abs-mask@0.0.1:
-    resolution: {integrity: sha512-1vy8SUyMHFBwqUUVaZFA7r4/E3cMMRKSwsaa/EZ15w7Kmc01W/ZmaaTLevRcIdACcNgK+8i8813c8H7LScXNcQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-high-word-exponent-mask@0.0.8:
-    resolution: {integrity: sha512-z28/EQERc0VG7N36bqdvtrRWjFc8600PKkwvl/nqx6TpKAzMXNw55BS1xT4C28Sa9Z7uBWeUj3UbIFedbkoyMw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-high-word-sign-mask@0.0.1:
-    resolution: {integrity: sha512-hmTr5caK1lh1m0eyaQqt2Vt3y+eEdAx57ndbADEbXhxC9qSGd0b4bLSzt/Xp4MYBYdQkHAE/BlkgUiRThswhCg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-max-base2-exponent-subnormal@0.0.8:
-    resolution: {integrity: sha512-YGBZykSiXFebznnJfWFDwhho2Q9xhUWOL+X0lZJ4ItfTTo40W6VHAyNYz98tT/gJECFype0seNzzo1nUxCE7jQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-max-base2-exponent@0.0.8:
-    resolution: {integrity: sha512-xBAOtso1eiy27GnTut2difuSdpsGxI8dJhXupw0UukGgvy/3CSsyNm+a1Suz/dhqK4tPOTe5QboIdNMw5IgXKQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-min-base2-exponent-subnormal@0.0.8:
-    resolution: {integrity: sha512-bt81nBus/91aEqGRQBenEFCyWNsf8uaxn4LN1NjgkvY92S1yVxXFlC65fJHsj9FTqvyZ+uj690/gdMKUDV3NjQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-ninf@0.0.8:
-    resolution: {integrity: sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/number-ctor': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-pinf@0.0.8:
-    resolution: {integrity: sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-float64-smallest-normal@0.0.8:
-    resolution: {integrity: sha512-Qwxpn5NA3RXf+mQcffCWRcsHSPTUQkalsz0+JDpblDszuz2XROcXkOdDr5LKgTAUPIXsjOgZzTsuRONENhsSEg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/constants-uint16-max@0.0.7:
-    resolution: {integrity: sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/constants-uint32-max@0.0.7:
-    resolution: {integrity: sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/constants-uint8-max@0.0.7:
-    resolution: {integrity: sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/fs-exists@0.0.8:
-    resolution: {integrity: sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-cwd': 0.0.8
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/fs-read-file@0.0.8:
-    resolution: {integrity: sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/fs-resolve-parent-path@0.0.8:
-    resolution: {integrity: sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-plain-object': 0.0.7
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-exists': 0.0.8
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-cwd': 0.0.8
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/math-base-assert-is-infinite@0.0.9:
-    resolution: {integrity: sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/constants-float64-ninf': 0.0.8
-      '@stdlib/constants-float64-pinf': 0.0.8
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/math-base-assert-is-nan@0.0.8:
-    resolution: {integrity: sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/math-base-napi-binary@0.0.8:
-    resolution: {integrity: sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/complex-float64': 0.0.8
-      '@stdlib/complex-reim': 0.0.6
-      '@stdlib/complex-reimf': 0.0.1
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/math-base-napi-unary@0.0.9:
-    resolution: {integrity: sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/complex-float64': 0.0.8
-      '@stdlib/complex-reim': 0.0.6
-      '@stdlib/complex-reimf': 0.0.1
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/math-base-special-abs@0.0.6:
-    resolution: {integrity: sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/math-base-napi-unary': 0.0.9
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/math-base-special-copysign@0.0.7:
-    resolution: {integrity: sha512-7Br7oeuVJSBKG8BiSk/AIRFTBd2sbvHdV3HaqRj8tTZHX8BQomZ3Vj4Qsiz3kPyO4d6PpBLBTYlGTkSDlGOZJA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/constants-float64-high-word-abs-mask': 0.0.1
-      '@stdlib/constants-float64-high-word-sign-mask': 0.0.1
-      '@stdlib/math-base-napi-binary': 0.0.8
-      '@stdlib/number-float64-base-from-words': 0.0.6
-      '@stdlib/number-float64-base-get-high-word': 0.0.6
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/math-base-special-ldexp@0.0.5:
-    resolution: {integrity: sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/constants-float64-exponent-bias': 0.0.8
-      '@stdlib/constants-float64-max-base2-exponent': 0.0.8
-      '@stdlib/constants-float64-max-base2-exponent-subnormal': 0.0.8
-      '@stdlib/constants-float64-min-base2-exponent-subnormal': 0.0.8
-      '@stdlib/constants-float64-ninf': 0.0.8
-      '@stdlib/constants-float64-pinf': 0.0.8
-      '@stdlib/math-base-assert-is-infinite': 0.0.9
-      '@stdlib/math-base-assert-is-nan': 0.0.8
-      '@stdlib/math-base-special-copysign': 0.0.7
-      '@stdlib/number-float64-base-exponent': 0.0.6
-      '@stdlib/number-float64-base-from-words': 0.0.6
-      '@stdlib/number-float64-base-normalize': 0.0.9
-      '@stdlib/number-float64-base-to-words': 0.0.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/number-ctor@0.0.7:
-    resolution: {integrity: sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/number-float64-base-exponent@0.0.6:
-    resolution: {integrity: sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/constants-float64-exponent-bias': 0.0.8
-      '@stdlib/constants-float64-high-word-exponent-mask': 0.0.8
-      '@stdlib/number-float64-base-get-high-word': 0.0.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/number-float64-base-from-words@0.0.6:
-    resolution: {integrity: sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/array-uint32': 0.0.6
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/number-float64-base-get-high-word@0.0.6:
-    resolution: {integrity: sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/array-uint32': 0.0.6
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/number-float64-base-normalize@0.0.9:
-    resolution: {integrity: sha512-+rm7RQJEj8zHkqYFE2a6DgNQSB5oKE/IydHAajgZl40YB91BoYRYf/ozs5/tTwfy2Fc04+tIpSfFtzDr4ZY19Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/constants-float64-smallest-normal': 0.0.8
-      '@stdlib/math-base-assert-is-infinite': 0.0.9
-      '@stdlib/math-base-assert-is-nan': 0.0.8
-      '@stdlib/math-base-special-abs': 0.0.6
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/number-float64-base-to-float32@0.0.7:
-    resolution: {integrity: sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/array-float32': 0.0.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/number-float64-base-to-words@0.0.7:
-    resolution: {integrity: sha512-7wsYuq+2MGp9rAkTnQ985rah7EJI9TfgHrYSSd4UIu4qIjoYmWIKEhIDgu7/69PfGrls18C3PxKg1pD/v7DQTg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/array-uint32': 0.0.6
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/os-byte-order': 0.0.7
-      '@stdlib/os-float-word-order': 0.0.7
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/os-byte-order@0.0.7:
-    resolution: {integrity: sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-big-endian': 0.0.7
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/os-float-word-order@0.0.7:
-    resolution: {integrity: sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/os-byte-order': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/process-cwd@0.0.8:
-    resolution: {integrity: sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-    dev: false
-
-  /@stdlib/process-read-stdin@0.0.7:
-    resolution: {integrity: sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/buffer-ctor': 0.0.7
-      '@stdlib/buffer-from-string': 0.0.8
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/utils-next-tick': 0.0.8
-    dev: false
-
-  /@stdlib/regexp-eol@0.0.7:
-    resolution: {integrity: sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-is-boolean': 0.0.8
-      '@stdlib/assert-is-plain-object': 0.0.7
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/regexp-extended-length-path@0.0.7:
-    resolution: {integrity: sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/regexp-function-name@0.0.7:
-    resolution: {integrity: sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/regexp-regexp@0.0.8:
-    resolution: {integrity: sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
-
-  /@stdlib/streams-node-stdin@0.0.7:
-    resolution: {integrity: sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/string-base-format-interpolate@0.0.4:
-    resolution: {integrity: sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/string-base-format-tokenize@0.0.4:
-    resolution: {integrity: sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/string-format@0.0.3:
-    resolution: {integrity: sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/string-base-format-interpolate': 0.0.4
-      '@stdlib/string-base-format-tokenize': 0.0.4
-    dev: false
-
-  /@stdlib/string-lowercase@0.0.9:
-    resolution: {integrity: sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/string-format': 0.0.3
-    dev: false
-
-  /@stdlib/string-replace@0.0.11:
-    resolution: {integrity: sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-regexp': 0.0.7
-      '@stdlib/assert-is-regexp-string': 0.0.9
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/regexp-eol': 0.0.7
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/string-format': 0.0.3
-      '@stdlib/utils-escape-regexp-string': 0.0.9
-      '@stdlib/utils-regexp-from-string': 0.0.9
-    dev: false
-
-  /@stdlib/types@0.0.14:
-    resolution: {integrity: sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/utils-constructor-name@0.0.8:
-    resolution: {integrity: sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-buffer': 0.0.8
-      '@stdlib/regexp-function-name': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/utils-convert-path@0.0.8:
-    resolution: {integrity: sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/regexp-eol': 0.0.7
-      '@stdlib/regexp-extended-length-path': 0.0.7
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/string-lowercase': 0.0.9
-      '@stdlib/string-replace': 0.0.11
-    dev: false
-
-  /@stdlib/utils-define-nonenumerable-read-only-property@0.0.7:
-    resolution: {integrity: sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-define-property': 0.0.9
-    dev: false
-
-  /@stdlib/utils-define-property@0.0.9:
-    resolution: {integrity: sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/types': 0.0.14
-    dev: false
-
-  /@stdlib/utils-escape-regexp-string@0.0.9:
-    resolution: {integrity: sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/string-format': 0.0.3
-    dev: false
-
-  /@stdlib/utils-get-prototype-of@0.0.7:
-    resolution: {integrity: sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/utils-native-class': 0.0.8
-    dev: false
-
-  /@stdlib/utils-global@0.0.7:
-    resolution: {integrity: sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-boolean': 0.0.8
-    dev: false
-
-  /@stdlib/utils-library-manifest@0.0.8:
-    resolution: {integrity: sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-resolve-parent-path': 0.0.8
-      '@stdlib/utils-convert-path': 0.0.8
-      debug: 2.6.9
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@stdlib/utils-native-class@0.0.8:
-    resolution: {integrity: sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-    dev: false
-
-  /@stdlib/utils-next-tick@0.0.8:
-    resolution: {integrity: sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/utils-noop@0.0.14:
-    resolution: {integrity: sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
-
-  /@stdlib/utils-regexp-from-string@0.0.9:
-    resolution: {integrity: sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/regexp-regexp': 0.0.8
-      '@stdlib/string-format': 0.0.3
-    dev: false
-
-  /@stdlib/utils-type-of@0.0.8:
-    resolution: {integrity: sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dependencies:
-      '@stdlib/utils-constructor-name': 0.0.8
-      '@stdlib/utils-global': 0.0.7
     dev: false
 
   /@swc/helpers@0.5.2:
@@ -5746,7 +4628,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.5
     dev: true
 
   /@vue/reactivity@3.3.4:
@@ -7492,10 +6374,6 @@ packages:
     dependencies:
       path-type: 4.0.0
 
-  /dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-    dev: false
-
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
@@ -7528,11 +6406,6 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
     dev: true
-
-  /dset@3.1.3:
-    resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
-    engines: {node: '>=4'}
-    dev: false
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -9432,11 +8305,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /js-cookie@3.0.1:
-    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
-    engines: {node: '>=12'}
-    dev: false
-
   /js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
@@ -9865,7 +8733,7 @@ packages:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /magic-string@0.30.2:
@@ -10084,6 +8952,7 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
 
   /minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
@@ -10275,12 +9144,6 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /new-date@1.0.3:
-    resolution: {integrity: sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==}
-    dependencies:
-      '@segment/isodate': 1.0.3
-    dev: false
-
   /next@13.5.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4Nt4HRLYDW/yRpJ/QR2t1v63UOMS55A38dnWv3UDOWGezuY0ZyFO1ABNbD7mulVzs9qVhgy2+ppjdsANpKP1mg==}
     engines: {node: '>=16.14.0'}
@@ -10452,10 +9315,6 @@ packages:
   /nwsapi@2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
     dev: true
-
-  /obj-case@0.2.1:
-    resolution: {integrity: sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==}
-    dev: false
 
   /obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
@@ -11888,10 +10747,6 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
-  /spark-md5@3.0.2:
-    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
-    dev: false
-
   /spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
     dependencies:
@@ -12221,10 +11076,6 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
-  /tiny-hashes@1.0.1:
-    resolution: {integrity: sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==}
-    dev: false
-
   /tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
@@ -12494,10 +11345,6 @@ packages:
     dependencies:
       string.fromcodepoint: 0.2.1
     dev: true
-
-  /unfetch@3.1.2:
-    resolution: {integrity: sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==}
-    dev: false
 
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}


### PR DESCRIPTION
## Description

This PR restores the Ledger connector. (reverting https://github.com/wevm/wagmi/commit/53ca1f7eb411d912e11fcce7e03bd61ed067959c) and migrating the old connector to v2 of wagmi. 

It now loads the [@ledgerhq/connect-kit](https://github.com/LedgerHQ/connect-kit?tab=readme-ov-file#-important-notice-) package without going through **@ledgerhq/connect-kit-loader**'s `loadConnectKit` function.  

**@ledgerhq/connect-kit** is thus added (with a fixed version, 1.1.9) in packages/connectors/package.json

## Additional Information

 **@ledgerhq/connect-kit-loader** is removed from the required packages.
 
 ### Additional security measures taken: 

Two new github workflows on the [@ledger/hq-connect-kit](https://github.com/LedgerHQ/connect-kit/) repository: 

- one checking any discrepancy between the version in that repo and the one published on npm, to alert ASAP (unlike during the exploit): https://github.com/LedgerHQ/connect-kit/actions/workflows/check_npm_repo.yml

- the second using [CodeQL](https://codeql.github.com/) to discover vulnerabilities early: https://github.com/LedgerHQ/connect-kit/actions/workflows/github-code-scanning/codeql 
 