### PR TITLE
docs: fix createConfig links to 'State'

### DIFF
--- a/docs/shared/createConfig.md
+++ b/docs/shared/createConfig.md
@@ -321,7 +321,7 @@ Connectors set up from passing [`connectors`](#connectors) and [`multiInjectedPr
 
 `State<chains>`
 
-The `Config` object's internal state. See [`State`](#state) for more info.
+The `Config` object's internal state. See [`State`](#state-1) for more info.
 
 ### storage
 
@@ -361,7 +361,7 @@ export const config = createConfig({
 
 `(value: State<chains> | ((state: State<chains>) => State<chains>)) => void`
 
-Updates the `Config` object's internal state. See [`State`](#state) for more info.
+Updates the `Config` object's internal state. See [`State`](#state-1) for more info.
 
 ::: code-group
 ```ts-vue [index.ts]


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

Some of the links in the docs regarding the `Config` object's internal state were linking back to themselves/the first mention of state in that .md file, rather than linking down to the `State`(below):

<img width="803" alt="image" src="https://github.com/wevm/wagmi/assets/80223622/6fc9b111-6f32-4064-98be-622bd8597a74">

Quick link to vercel deployment from below's github workflow:
[vercel.app/react/api/createConfig#state](https://wagmi-git-fork-seranged-docs-fix-in-createconfig-wevm.vercel.app/react/api/createConfig#state)

## Additional Information

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
