### PR TITLE
docs: update `gatewaysUrl` in useEnsAvatar.md

### DIFF
--- a/docs/react/api/hooks/useEnsAvatar.md
+++ b/docs/react/api/hooks/useEnsAvatar.md
@@ -139,7 +139,7 @@ function App() {
 
 ### gatewayUrls
 
-`{ ipfs?: string | undefined; arweave?: string | undefined } | undefined`
+`string[] | undefined`
 
 Gateway urls to resolve IPFS and/or Arweave assets.
 
@@ -150,9 +150,7 @@ import { normalize } from 'viem/ens'
 
 function App() {
   const result = useEnsAvatar({
-    gatewayUrls: { // [!code focus]
-      ipfs: 'https://cloudflare-ipfs.com', // [!code focus]
-    }, // [!code focus]
+    gatewayUrls: ['https://cloudflare-ipfs.com'] { // [!code focus]
     name: normalize('wevm.eth'),
   })
 }


### PR DESCRIPTION
## Description

I propose those changes because the current documented version for `useEnsAvatar`'s `gatewayUrls` parameter doesn't work anymore.

For example:

```ts
const { data: avatar } = useEnsAvatar({
    name: normalize(ensName!) || undefined,
    chainId: mainnet.id,
    gatewayUrls: {
      ipfs: 'https://ipfs.io/',
    },
  });
```

had to be replaced with

```ts
const { data: avatar } = useEnsAvatar({
    name: normalize(ensName!) || undefined,
    chainId: mainnet.id,
    gatewayUrls: ['https://ipfs.io/'],
  });
```

and it now works on my side.

Additionally, it could be better documented what exactly should be passed as `gatewayUrls`, since there are no fields `ipfs` and `arweave` left, which explicitly set the gateways, and now the type has changed from `{ ipfs?: string | undefined; arweave?: string | undefined } | undefined` to `string[] | undefined`.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
