### PR TITLE
feat: wagmi cli should consider wagmi.config.ts to decide if using ts

### DIFF
--- a/.changeset/slimy-mayflies-mix.md
+++ b/.changeset/slimy-mayflies-mix.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": minor
+---
+
+Added resolution of TypeScript Wagmi CLI config to determine if TypeScript generated output is allowed.

--- a/packages/cli/src/utils/getIsUsingTypeScript.test.ts
+++ b/packages/cli/src/utils/getIsUsingTypeScript.test.ts
@@ -7,10 +7,23 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-test('true', async () => {
+test('true if has tsconfig', async () => {
   const { dir } = await createFixture({
     files: {
       'tsconfig.json': '',
+    },
+  })
+
+  const spy = vi.spyOn(process, 'cwd')
+  spy.mockImplementation(() => dir)
+
+  await expect(getIsUsingTypeScript()).resolves.toBe(true)
+})
+
+test('true if has wagmi.config', async () => {
+  const { dir } = await createFixture({
+    files: {
+      'wagmi.config.ts': '',
     },
   })
 

--- a/packages/cli/src/utils/getIsUsingTypeScript.ts
+++ b/packages/cli/src/utils/getIsUsingTypeScript.ts
@@ -4,7 +4,8 @@ export async function getIsUsingTypeScript() {
   try {
     const cwd = process.cwd()
     const tsconfig = await findUp('tsconfig.json', { cwd })
-    return !!tsconfig
+    const wagmiConfig = await findUp('wagmi.config.ts', { cwd })
+    return !!tsconfig || !!wagmiConfig
   } catch {
     return false
   }

--- a/packages/cli/src/utils/getIsUsingTypeScript.ts
+++ b/packages/cli/src/utils/getIsUsingTypeScript.ts
@@ -4,8 +4,14 @@ export async function getIsUsingTypeScript() {
   try {
     const cwd = process.cwd()
     const tsconfig = await findUp('tsconfig.json', { cwd })
-    const wagmiConfig = await findUp('wagmi.config.ts', { cwd })
-    return !!tsconfig || !!wagmiConfig
+    if (tsconfig) return true
+
+    const wagmiConfig = await findUp(['wagmi.config.ts', 'wagmi.config.mts'], {
+      cwd,
+    })
+    if (wagmiConfig) return true
+
+    return false
   } catch {
     return false
   }


### PR DESCRIPTION
## Description

Improve wagmi/cli by detecting presence of wagmi.config.ts too, to decide TypeScript usage.

## Additional Information
resolves #3505
Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
