### PR TITLE
tmm/fix get address mapping

### DIFF
--- a/.changeset/funny-owls-perform.md
+++ b/.changeset/funny-owls-perform.md
@@ -1,6 +1,0 @@
----
-"@wagmi/connectors": patch
-"create-wagmi": patch
----
-
-Bumped dependencies

--- a/.changeset/loud-cooks-flash.md
+++ b/.changeset/loud-cooks-flash.md
@@ -1,0 +1,8 @@
+---
+"@wagmi/connectors": patch
+"@wagmi/core": patch
+"create-wagmi": patch
+"wagmi": patch
+---
+
+Fixed issue where connectors returning multiple addresses didn't checksum correctly.

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -62,7 +62,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
           (await provider.request({
             method: 'eth_requestAccounts',
           })) as string[]
-        ).map(getAddress)
+        ).map((x) => getAddress(x))
 
         provider.on('accountsChanged', this.onAccountsChanged)
         provider.on('chainChanged', this.onChainChanged)
@@ -105,7 +105,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
         await provider.request<string[]>({
           method: 'eth_accounts',
         })
-      ).map(getAddress)
+      ).map((x) => getAddress(x))
     },
     async getChainId() {
       const provider = await this.getProvider()
@@ -190,7 +190,10 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
     },
     onAccountsChanged(accounts) {
       if (accounts.length === 0) config.emitter.emit('disconnect')
-      else config.emitter.emit('change', { accounts: accounts.map(getAddress) })
+      else
+        config.emitter.emit('change', {
+          accounts: accounts.map((x) => getAddress(x)),
+        })
     },
     onChainChanged(chain) {
       const chainId = normalizeChainId(chain)

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -77,7 +77,9 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
               method: 'wallet_requestPermissions',
               params: [{ eth_accounts: {} }],
             })) as WalletPermission[]
-            accounts = permissions[0]?.caveats?.[0]?.value?.map(getAddress)
+            accounts = (permissions[0]?.caveats?.[0]?.value as string[])?.map(
+              (x) => getAddress(x),
+            )
           } catch (err) {
             const error = err as RpcError
             // Not all injected providers support `wallet_requestPermissions` (e.g. MetaMask iOS).
@@ -92,7 +94,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
       try {
         if (!accounts?.length) {
           const requestedAccounts = (await sdk.connect()) as string[]
-          accounts = requestedAccounts.map(getAddress)
+          accounts = requestedAccounts.map((x) => getAddress(x))
         }
 
         provider.removeListener(
@@ -161,7 +163,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
       const accounts = (await provider.request({
         method: 'eth_accounts',
       })) as string[]
-      return accounts.map(getAddress)
+      return accounts.map((x) => getAddress(x))
     },
     async getChainId() {
       const provider = await this.getProvider()
@@ -294,7 +296,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         await config.storage?.removeItem('metaMaskSDK.disconnected')
       }
       // Regular change event
-      else config.emitter.emit('change', { accounts: accounts.map(getAddress) })
+      else
+        config.emitter.emit('change', {
+          accounts: accounts.map((x) => getAddress(x)),
+        })
     },
     onChainChanged(chain) {
       const chainId = normalizeChainId(chain)

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -145,7 +145,7 @@ export function walletConnect(parameters: WalletConnectParameters) {
         }
 
         // If session exists and chains are authorized, enable provider for required chain
-        const accounts = (await provider.enable()).map(getAddress)
+        const accounts = (await provider.enable()).map((x) => getAddress(x))
         const currentChainId = await this.getChainId()
 
         provider.removeListener('display_uri', this.onDisplayUri)
@@ -191,7 +191,7 @@ export function walletConnect(parameters: WalletConnectParameters) {
     },
     async getAccounts() {
       const provider = await this.getProvider()
-      return provider.accounts.map(getAddress)
+      return provider.accounts.map((x) => getAddress(x))
     },
     async getProvider({ chainId } = {}) {
       async function initProvider() {
@@ -292,7 +292,10 @@ export function walletConnect(parameters: WalletConnectParameters) {
     },
     onAccountsChanged(accounts) {
       if (accounts.length === 0) this.onDisconnect()
-      else config.emitter.emit('change', { accounts: accounts.map(getAddress) })
+      else
+        config.emitter.emit('change', {
+          accounts: accounts.map((x) => getAddress(x)),
+        })
     },
     onChainChanged(chain) {
       const chainId = normalizeChainId(chain)

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -157,7 +157,9 @@ export function injected(parameters: InjectedParameters = {}) {
               method: 'wallet_requestPermissions',
               params: [{ eth_accounts: {} }],
             })
-            accounts = permissions[0]?.caveats?.[0]?.value?.map(getAddress)
+            accounts = (permissions[0]?.caveats?.[0]?.value as string[])?.map(
+              (x) => getAddress(x),
+            )
           } catch (err) {
             const error = err as RpcError
             // Not all injected providers support `wallet_requestPermissions` (e.g. MetaMask iOS).
@@ -174,7 +176,7 @@ export function injected(parameters: InjectedParameters = {}) {
           const requestedAccounts = await provider.request({
             method: 'eth_requestAccounts',
           })
-          accounts = requestedAccounts.map(getAddress)
+          accounts = requestedAccounts.map((x) => getAddress(x))
         }
 
         provider.removeListener('connect', this.onConnect.bind(this))
@@ -233,7 +235,7 @@ export function injected(parameters: InjectedParameters = {}) {
       const provider = await this.getProvider()
       if (!provider) throw new ProviderNotFoundError()
       const accounts = await provider.request({ method: 'eth_accounts' })
-      return accounts.map(getAddress)
+      return accounts.map((x) => getAddress(x))
     },
     async getChainId() {
       const provider = await this.getProvider()
@@ -405,7 +407,10 @@ export function injected(parameters: InjectedParameters = {}) {
           await config.storage?.removeItem(`${this.id}.disconnected`)
       }
       // Regular change event
-      else config.emitter.emit('change', { accounts: accounts.map(getAddress) })
+      else
+        config.emitter.emit('change', {
+          accounts: accounts.map((x) => getAddress(x)),
+        })
     },
     onChainChanged(chain) {
       const chainId = normalizeChainId(chain)

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -80,7 +80,7 @@ export function mock(parameters: MockParameters) {
       if (!connected) throw new ConnectorNotConnectedError()
       const provider = await this.getProvider()
       const accounts = await provider.request({ method: 'eth_accounts' })
-      return accounts.map(getAddress)
+      return accounts.map((x) => getAddress(x))
     },
     async getChainId() {
       const provider = await this.getProvider()
@@ -106,7 +106,10 @@ export function mock(parameters: MockParameters) {
     },
     onAccountsChanged(accounts) {
       if (accounts.length === 0) this.onDisconnect()
-      else config.emitter.emit('change', { accounts: accounts.map(getAddress) })
+      else
+        config.emitter.emit('change', {
+          accounts: accounts.map((x) => getAddress(x)),
+        })
     },
     onChainChanged(chain) {
       const chainId = normalizeChainId(chain)


### PR DESCRIPTION
## Description

Calling `.map(getAddress)` in various places doesn't return what we expect because the `index` ends up getting passed through implicitly as the second parameter of `getAddress(value: string, chainId?: number)`.

Closes https://github.com/wevm/wagmi/issues/3507

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
