### PR TITLE
fix: dead link in docs to viem

### DIFF
--- a/docs/react/api/chains.md
+++ b/docs/react/api/chains.md
@@ -4,7 +4,7 @@ import SearchChains from '../../components/SearchChains.vue'
 
 # Chains
 
-Viem `Chain` objects. More info at the [Viem docs](https://viem.sh/docs/clients/chains.html).
+Viem `Chain` objects. More info at the [Viem docs](https://viem.sh/docs/chains/introduction).
 
 ## Import
 


### PR DESCRIPTION
fixes: dead link to viem chains docs