### PR TITLE
feat(core): migrate store

### DIFF
--- a/.changeset/seven-mugs-brake.md
+++ b/.changeset/seven-mugs-brake.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": patch
+"create-wagmi": patch
+"wagmi": patch
+---
+
+Bumped dependencies.

--- a/.changeset/thirty-ducks-compete.md
+++ b/.changeset/thirty-ducks-compete.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed internal store migration between versions.

--- a/playgrounds/vite-react/src/wagmi.ts
+++ b/playgrounds/vite-react/src/wagmi.ts
@@ -25,12 +25,8 @@ export const config = createConfig({
     coinbaseWallet({ appName: 'Vite React Playground', darkMode: true }),
   ],
   transports: {
-    [mainnet.id]: http(
-      'https://eth-mainnet.g.alchemy.com/v2/StF61Ht3J9nXAojZX-b21LVt9l0qDL38',
-    ),
-    [sepolia.id]: http(
-      'https://eth-sepolia.g.alchemy.com/v2/roJyEHxkj7XWg1T9wmYnxvktDodQrFAS',
-    ),
+    [mainnet.id]: http(),
+    [sepolia.id]: http(),
     [optimism.id]: http(),
     [celo.id]: http(),
   },


### PR DESCRIPTION
## Description

Adds code to automatically version and migrate Wagmi Config store between major and canary versions.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
