### PR TITLE
chore: tweak estimate fees type tests

### DIFF
--- a/packages/core/src/actions/estimateFeesPerGas.test-d.ts
+++ b/packages/core/src/actions/estimateFeesPerGas.test-d.ts
@@ -4,7 +4,7 @@ import { estimateFeesPerGas } from './estimateFeesPerGas.js'
 
 test('types', async () => {
   const default_ = await estimateFeesPerGas(config)
-  expectTypeOf(default_).toEqualTypeOf<{
+  expectTypeOf(default_).toMatchTypeOf<{
     gasPrice?: undefined
     maxFeePerGas: bigint
     maxPriorityFeePerGas: bigint
@@ -16,7 +16,7 @@ test('types', async () => {
   }>()
 
   const legacy = await estimateFeesPerGas(config, { type: 'legacy' })
-  expectTypeOf(legacy).toEqualTypeOf<{
+  expectTypeOf(legacy).toMatchTypeOf<{
     gasPrice: bigint
     maxFeePerGas?: undefined
     maxPriorityFeePerGas?: undefined
@@ -28,7 +28,7 @@ test('types', async () => {
   }>()
 
   const eip1559 = await estimateFeesPerGas(config, { type: 'eip1559' })
-  expectTypeOf(eip1559).toEqualTypeOf<{
+  expectTypeOf(eip1559).toMatchTypeOf<{
     gasPrice?: undefined
     maxFeePerGas: bigint
     maxPriorityFeePerGas: bigint

--- a/packages/react/src/hooks/useEstimateFeesPerGas.test-d.ts
+++ b/packages/react/src/hooks/useEstimateFeesPerGas.test-d.ts
@@ -3,7 +3,7 @@ import { useEstimateFeesPerGas } from './useEstimateFeesPerGas.js'
 
 test('types', () => {
   const result = useEstimateFeesPerGas()
-  expectTypeOf(result.data).toEqualTypeOf<
+  expectTypeOf(result.data).toMatchTypeOf<
     | {
         gasPrice?: undefined
         maxFeePerGas: bigint
@@ -18,7 +18,7 @@ test('types', () => {
   >()
 
   const result2 = useEstimateFeesPerGas({ type: 'legacy' })
-  expectTypeOf(result2.data).toEqualTypeOf<
+  expectTypeOf(result2.data).toMatchTypeOf<
     | {
         gasPrice: bigint
         maxFeePerGas?: undefined
@@ -33,7 +33,7 @@ test('types', () => {
   >()
 
   const result3 = useEstimateFeesPerGas({ type: 'eip1559' })
-  expectTypeOf(result3.data).toEqualTypeOf<
+  expectTypeOf(result3.data).toMatchTypeOf<
     | {
         gasPrice?: undefined
         maxFeePerGas: bigint


### PR DESCRIPTION
Introduction of `maxFeePerBlobGas` in Viem seems to be causing these tests to fail in the [Wagmi regression tests on Viem](https://github.com/wevm/viem/actions/runs/7719107929/job/21041823398). 

Tweaking the test to match the return type, instead of strictly equal.