### PR TITLE
Update coinbaseWallet Connector

### DIFF
--- a/.changeset/lazy-ladybugs-attend.md
+++ b/.changeset/lazy-ladybugs-attend.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': major
+---
+
+We are experiences issues when you connect with the coinbaseConnector. It redirects you to the coinbase app, it opens the page in their in app browser. Enabling enableMobileWalletLink will fix this issue.

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -38,12 +38,19 @@ export type CoinbaseWalletParameters = Evaluate<
      * @default false
      */
     reloadOnDisconnect?: boolean | undefined
+     /**
+     * Whether to connect mobile web app via WalletLink, defaults to false
+     * @default false
+     */
+    enableMobileWalletLink?: boolean | undefined
+    
   }
 >
 
 coinbaseWallet.type = 'coinbaseWallet' as const
 export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
   const reloadOnDisconnect = false
+  const enableMobileWalletLink = true
 
   type Provider = CoinbaseWalletProvider
   type Properties = {}
@@ -113,7 +120,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
     },
     async getProvider() {
       if (!walletProvider) {
-        sdk = new CoinbaseWalletSDK({ reloadOnDisconnect, ...parameters })
+        sdk = new CoinbaseWalletSDK({ reloadOnDisconnect, enableMobileWalletLink, ...parameters })
 
         // Mock implementations to retrieve private `walletExtension` method from the Coinbase Wallet SDK.
         abstract class WalletProvider {


### PR DESCRIPTION


## Description

We are experiences issues when you connect with the `coinbaseConnector`.  It redirects you to the coinbase app, it opens the page in their in app browser. Enabling `enableMobileWalletLink` will fix this issue.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
