### PR TITLE
Update link to multiInjectedProviderDiscovery

### DIFF
--- a/docs/shared/connectors/injected.md
+++ b/docs/shared/connectors/injected.md
@@ -58,7 +58,7 @@ const connector = injected({
 `TargetId | (TargetMap[TargetId] & { id: string }) | (() => (TargetMap[TargetId] & { id: string }) | undefined) | undefined`
 
 - [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Ethereum Provider to target.
-- [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) supported via `createConfig`'s <a :href="`/${docsPath}/api/connectors/injected`">`multiInjectedProviderDiscovery`</a> property.
+- [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) supported via `createConfig`'s <a :href="`/${docsPath}/api/createConfig#multiinjectedproviderdiscovery`">`multiInjectedProviderDiscovery`</a> property.
 
 ```ts-vue
 import { injected } from '{{connectorsPackageName}}'


### PR DESCRIPTION
## Description
In the [connectors/injected#target](https://wagmi.sh/react/api/connectors/injected#target) section, you reference multiInjectedProviderDiscovery

Previous link: https://wagmi.sh/react/api/connectors/injected
Correct placement:  https://wagmi.sh/react/api/createConfig#multiinjectedproviderdiscovery

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
