### PR TITLE
chore: add check for Infura API key with error message pointing to the MetaMaskSDK documentation 

### DIFF
--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -173,7 +173,13 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
     },
     async getProvider() {
       if (!walletProvider) {
-        if (!sdk || !sdk?.isInitialized()) {
+        if (!sdk || !sdk?.isInitialized()) { 
+          if (!parameters.infuraAPIKey) {
+            console.error(
+              "Wagmi isn't optimized for mobile use and relies heavily on read-only calls. To ensure proper functionality, add your own Infura API key. Check https://github.com/MetaMask/metamask-sdk/blob/main/docs/why-infura-wagmi.md for further explanations.",
+            )
+          }
+
           sdk = new MetaMaskSDK({
             enableDebug: false,
             dappMetadata: { name: 'wagmi' },


### PR DESCRIPTION
## Description

Add check for the Infura API key with an error message pointing to the MetaMaskSDK documentation if it missing 

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
