### PR TITLE
internal: widen internal types

### DIFF
--- a/packages/core/src/actions/getBlock.ts
+++ b/packages/core/src/actions/getBlock.ts
@@ -62,7 +62,7 @@ export async function getBlock<
   const action = getAction(client, viem_getBlock, 'getBlock')
   const block = await action(rest)
   return {
-    ...(block as GetBlockReturnType<
+    ...(block as unknown as GetBlockReturnType<
       includeTransactions,
       blockTag,
       config,

--- a/packages/core/src/actions/getPublicClient.ts
+++ b/packages/core/src/actions/getPublicClient.ts
@@ -44,8 +44,8 @@ export function getPublicClient<
   config: config,
   parameters: GetPublicClientParameters<config, chainId> = {},
 ): GetPublicClientReturnType<config, chainId> {
-  const client = getClient(config, parameters) as Client
-  return client?.extend(publicActions) as GetPublicClientReturnType<
+  const client = getClient(config, parameters)
+  return (client as Client)?.extend(publicActions) as GetPublicClientReturnType<
     config,
     chainId
   >

--- a/packages/core/src/actions/getPublicClient.ts
+++ b/packages/core/src/actions/getPublicClient.ts
@@ -1,4 +1,4 @@
-import { type PublicClient, publicActions } from 'viem'
+import { type Client, type PublicClient, publicActions } from 'viem'
 
 import { type Config } from '../createConfig.js'
 import { type ChainIdParameter } from '../types/properties.js'
@@ -44,7 +44,7 @@ export function getPublicClient<
   config: config,
   parameters: GetPublicClientParameters<config, chainId> = {},
 ): GetPublicClientReturnType<config, chainId> {
-  const client = getClient(config, parameters)
+  const client = getClient(config, parameters) as Client
   return client?.extend(publicActions) as GetPublicClientReturnType<
     config,
     chainId

--- a/packages/core/src/actions/getTransactionReceipt.ts
+++ b/packages/core/src/actions/getTransactionReceipt.ts
@@ -49,5 +49,7 @@ export async function getTransactionReceipt<
     viem_getTransactionReceipt,
     'getTransactionReceipt',
   )
-  return action(rest)
+  return action(rest) as unknown as Promise<
+    GetTransactionReceiptReturnType<config, chainId>
+  >
 }

--- a/packages/core/src/actions/waitForTransactionReceipt.ts
+++ b/packages/core/src/actions/waitForTransactionReceipt.ts
@@ -1,4 +1,4 @@
-import { type Chain } from 'viem'
+import { type CallParameters, type Chain } from 'viem'
 import { hexToString } from 'viem'
 import {
   type WaitForTransactionReceiptErrorType as viem_WaitForTransactionReceiptErrorType,
@@ -69,10 +69,13 @@ export async function waitForTransactionReceipt<
       maxFeePerGas: txn.type === 'eip1559' ? txn.maxFeePerGas : undefined,
       maxPriorityFeePerGas:
         txn.type === 'eip1559' ? txn.maxPriorityFeePerGas : undefined,
-    })) as unknown as string
+    } as CallParameters)) as unknown as string
     const reason = hexToString(`0x${code.substring(138)}`)
     throw new Error(reason)
   }
 
-  return { ...receipt, chainId: client.chain.id }
+  return {
+    ...receipt,
+    chainId: client.chain.id,
+  } as WaitForTransactionReceiptReturnType<config, chainId>
 }

--- a/packages/core/src/actions/waitForTransactionReceipt.ts
+++ b/packages/core/src/actions/waitForTransactionReceipt.ts
@@ -1,4 +1,4 @@
-import { type CallParameters, type Chain } from 'viem'
+import { type Chain } from 'viem'
 import { hexToString } from 'viem'
 import {
   type WaitForTransactionReceiptErrorType as viem_WaitForTransactionReceiptErrorType,
@@ -64,12 +64,12 @@ export async function waitForTransactionReceipt<
     const txn = await action_getTransaction({ hash: receipt.transactionHash })
     const action_call = getAction(client, call, 'call')
     const code = (await action_call({
-      ...txn,
+      ...(txn as any),
       gasPrice: txn.type !== 'eip1559' ? txn.gasPrice : undefined,
       maxFeePerGas: txn.type === 'eip1559' ? txn.maxFeePerGas : undefined,
       maxPriorityFeePerGas:
         txn.type === 'eip1559' ? txn.maxPriorityFeePerGas : undefined,
-    } as CallParameters)) as unknown as string
+    })) as unknown as string
     const reason = hexToString(`0x${code.substring(138)}`)
     throw new Error(reason)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: 2.0.0(bufferutil@4.0.8)(typescript@5.3.2)(utf-8-validate@6.0.3)
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.7.0)
+        version: 4.4.9(@types/node@20.11.5)
       vitepress:
         specifier: 1.0.0-rc.20
         version: 1.0.0-rc.20(@types/react@18.2.23)(react@18.2.0)
@@ -432,7 +432,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.7.0)
+        version: 4.4.9(@types/node@20.11.5)
 
   playgrounds/vite-react:
     dependencies:
@@ -478,7 +478,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.7.0)
+        version: 4.4.9(@types/node@20.11.5)
 
   playgrounds/vite-ssr-react:
     dependencies:
@@ -4463,7 +4463,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.1
       magic-string: 0.30.2
-      vite: 4.4.9(@types/node@20.7.0)
+      vite: 4.4.9(@types/node@20.11.5)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -4492,7 +4492,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.0)
       '@types/babel__core': 7.20.2
       react-refresh: 0.14.0
-      vite: 4.4.9(@types/node@20.7.0)
+      vite: 4.4.9(@types/node@20.11.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -11752,7 +11752,6 @@ packages:
       rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vite@4.4.9(@types/node@20.7.0):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
@@ -11788,6 +11787,7 @@ packages:
       rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: false
 
   /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.3.2)(vitepress@1.0.0-rc.20):
     resolution: {integrity: sha512-CjMF01Vb/zwOKKCqq6QmkJbTJnRxipv8oiPjRWTjzH2jPaQH4gGCF2fZHS7uY53J3gbU3GwtrXI02J6axLYmbg==}
@@ -11823,7 +11823,7 @@ packages:
       mark.js: 8.11.1
       minisearch: 6.1.0
       shiki: 0.14.4
-      vite: 4.4.9(@types/node@20.7.0)
+      vite: 4.4.9(@types/node@20.11.5)
       vue: 3.3.4
     transitivePeerDependencies:
       - '@algolia/client-search'


### PR DESCRIPTION
## Description

[Narrowing formatter return types](https://github.com/wevm/viem/commit/b4cca34cc4a52e5f9697d958959b7f84bdc576b2) in Viem (to infer return type when no narrowed `chain` generic is passed) seems to [break internal types in Wagmi](https://github.com/wevm/viem/actions/runs/7791863392/job/21248850480). Previously, Viem returned `any` as the return type if it couldn't infer the chain, so that probably explains why it was not breaking before.
