### PR TITLE
Improve tree-shakability by modularizing @wagmi/connectors package structure

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -32,6 +32,22 @@
       "types": "./dist/types/exports/index.d.ts",
       "default": "./dist/esm/exports/index.js"
     },
+    "./coinbaseWallet": {
+      "types": "./dist/types/coinbaseWallet.d.ts",
+      "default": "./dist/esm/coinbaseWallet.js"
+    },
+    "./metaMask": {
+      "types": "./dist/types/metaMask.d.ts",
+      "default": "./dist/esm/metaMask.js"
+    },
+    "./safe": {
+      "types": "./dist/types/safe.d.ts",
+      "default": "./dist/esm/safe.js"
+    },
+    "./walletConnect": {
+      "types": "./dist/types/walletConnect.d.ts",
+      "default": "./dist/esm/walletConnect.js"
+    },
     "./package.json": "./package.json"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

This PR addresses this discussion: https://github.com/wevm/wagmi/discussions/1371

It allows for importing of all connectors like this:

```
import { walletConnect } from "@wagmi/connectors/walletConnect";
```

In addition to this:

```
import { walletConnect } from "@wagmi/connectors";
```

The current structure of the @wagmi/connectors NPM package does not favor tree-shaking. All the connectors are accessed via a single entry point (index.js) under the exports directory. This makes it impossible to import specific modules directly, and it produces a uniform, large bundle size regardless of which of which connector is imported.

Package size appears to be a known issue (https://wagmi.sh/core/api/connectors/metaMask#import). However, given my current build config (`vite build` targeting an index.html linking to a vanilla jsn file), the large Metamask SDK dependencies appear to be included in my JS no matter which connector I import.  

If you approve of this general approach I can include documentation.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [] Added or updated tests (and snapshots) related to the changes made.
