### PR TITLE
bugfix: batch size didnt work from createConfig #3485

### DIFF
--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -146,14 +146,18 @@ export function createConfig<
       // Grab all properties off `rest` and resolve for use in `createClient`
       const properties: Partial<viem_ClientConfig> = {}
       const entries = Object.entries(rest) as [keyof typeof rest, any][]
+
       for (const [key, value] of entries) {
         if (key === 'client' || key === 'connectors' || key === 'transports')
           continue
-        else {
+        else if (key === 'batch') {
+          properties[key] = value
+        } else {
           if (typeof value === 'object') properties[key] = value[chainId]
           else properties[key] = value
         }
       }
+      console.log('configconfig1234', rest, properties, properties.batch)
       client = createClient({
         ...properties,
         chain,


### PR DESCRIPTION
Description:
This pull request addresses a bug in the "getClient" function where the "batchSize" parameter was not being correctly passed when executing the function. This bug resulted in unexpected behavior. This fix ensures that the "batchSize" parameter is properly provided during function execution, resolving the issue.

Changes Made:
Updated the if else function to pass the "batchSize" parameter into "properties" variable.
