### PR TITLE
Updated etherscan plugin to include Optimism Sepolia chainId

### DIFF
--- a/.changeset/real-sheep-begin.md
+++ b/.changeset/real-sheep-begin.md
@@ -1,5 +1,5 @@
 ---
-"@wagmi/cli": minor
+"@wagmi/cli": patch
 ---
 
 Added the Optimism Sepolia chain id [11_155_420] to the apiUrls object in the etherscan plugin file. Also included is the corresponding API URL 'https://api-sepolia-optimistic.etherscan.io/api'.

--- a/.changeset/real-sheep-begin.md
+++ b/.changeset/real-sheep-begin.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Added the Optimism Sepolia chain id [11_155_420] to the apiUrls object in the etherscan plugin file. Also included is the corresponding API URL 'https://api-sepolia-optimistic.etherscan.io/api'.
+Added Optimism Sepolia Etherscan support

--- a/.changeset/real-sheep-begin.md
+++ b/.changeset/real-sheep-begin.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": minor
+---
+
+Added the Optimism Sepolia chain id [11_155_420] to the apiUrls object in the etherscan plugin file. Also included is the corresponding API URL 'https://api-sepolia-optimistic.etherscan.io/api'.

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -10,6 +10,7 @@ const apiUrls = {
   // Optimism
   [10]: 'https://api-optimistic.etherscan.io/api',
   [420]: 'https://api-goerli-optimistic.etherscan.io/api',
+  [11155420]: 'https://api-sepolia-optimistic.etherscan.io/api',
   // Polygon
   [137]: 'https://api.polygonscan.com/api',
   [80_001]: 'https://api-testnet.polygonscan.com/api',

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -10,7 +10,7 @@ const apiUrls = {
   // Optimism
   [10]: 'https://api-optimistic.etherscan.io/api',
   [420]: 'https://api-goerli-optimistic.etherscan.io/api',
-  [11155420]: 'https://api-sepolia-optimistic.etherscan.io/api',
+  [11_155_420]: 'https://api-sepolia-optimistic.etherscan.io/api',
   // Polygon
   [137]: 'https://api.polygonscan.com/api',
   [80_001]: 'https://api-testnet.polygonscan.com/api',


### PR DESCRIPTION
## Description

Added the Optimism Sepolia chain id [11155420] to the `apiUrls` object in the etherscan plugin file. Also included is the corresponding API URL 'https://api-sepolia-optimistic.etherscan.io/api'.

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added or updated tests (and snapshots) related to the changes made.
