### PR TITLE
Fixes address comparison in getConnectorClient

### DIFF
--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -39,7 +39,7 @@ test('behavior: account does not exist on connector', async () => {
   await expect(
     getConnectorClient(config, { account: address.usdcHolder }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    "Account \\"0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078\\" not found for connector \\"Mock Connector\\".
+    "Account \\"0x5414d89a8bF7E99d732BC52f3e6A3Ef461c0C078\\" not found for connector \\"Mock Connector\\".
 
     Version: @wagmi/core@x.y.z"
   `)

--- a/packages/core/src/actions/getConnectorClient.ts
+++ b/packages/core/src/actions/getConnectorClient.ts
@@ -7,7 +7,7 @@ import {
   custom,
 } from 'viem'
 
-import { parseAccount } from 'viem/utils'
+import { getAddress, parseAccount } from 'viem/utils'
 import type { Config, Connection } from '../createConfig.js'
 import type { ErrorType } from '../errors/base.js'
 import {
@@ -88,6 +88,8 @@ export async function getConnectorClient<
   const provider = (await connection.connector.getProvider({ chainId })) as {
     request(...args: any): Promise<any>
   }
+
+  account.address = getAddress(account.address)
 
   // if account was provided, check that it exists on the connector
   if (parameters.account && !connection.accounts.includes(account.address))


### PR DESCRIPTION
## Description

This PR implements a fix for the checksum comparison discussed in #3598.

It applies a checksum in `getConnectorClient` before verifying if the account is included in those authorized by the connector. It also updates the related test by formatting the expected address.

Tested locally and transactions now go through even when feeding a non-formatted address to `writeContract`.
