### PR TITLE
injected.ts - check shimDisconnect before requestPermissions

### DIFF
--- a/.changeset/two-sheep-shop.md
+++ b/.changeset/two-sheep-shop.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": minor
+---
+
+Add shimDisconnect check to disable MetaMask requestPermissions if it's false

--- a/.changeset/two-sheep-shop.md
+++ b/.changeset/two-sheep-shop.md
@@ -2,4 +2,4 @@
 "@wagmi/core": minor
 ---
 
-Add shimDisconnect check to disable MetaMask requestPermissions if it's false
+Disabled `wallet_requestPermissions` prompt when `shimDisconnect` is `false`.

--- a/.changeset/two-sheep-shop.md
+++ b/.changeset/two-sheep-shop.md
@@ -1,5 +1,5 @@
 ---
-"@wagmi/core": minor
+"@wagmi/core": patch
 ---
 
 Disabled `wallet_requestPermissions` prompt when `shimDisconnect` is `false`.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -150,7 +150,7 @@ export function injected(parameters: InjectedParameters = {}) {
       if (!isReconnecting) {
         accounts = await this.getAccounts().catch(() => null)
         const isAuthorized = !!accounts?.length
-        if (isAuthorized && !shimDisconnect)
+        if (isAuthorized && shimDisconnect)
           // Attempt to show another prompt for selecting account if already connected
           try {
             const permissions = await provider.request({

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -150,7 +150,7 @@ export function injected(parameters: InjectedParameters = {}) {
       if (!isReconnecting) {
         accounts = await this.getAccounts().catch(() => null)
         const isAuthorized = !!accounts?.length
-        if (isAuthorized)
+        if (isAuthorized && !shimDisconnect)
           // Attempt to show another prompt for selecting account if already connected
           try {
             const permissions = await provider.request({


### PR DESCRIPTION
Following https://github.com/wevm/wagmi/issues/3603

## Description

`shimDisconnect` should be considered before showing prompt for selecting account

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
