### PR TITLE
docs: remove unnecessary async keyword from getEthersSigner

### DIFF
--- a/docs/core/guides/ethers.md
+++ b/docs/core/guides/ethers.md
@@ -189,7 +189,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a Viem Client to an ethers.js Signer. */
-export async function getEthersSigner(
+export function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {
@@ -216,7 +216,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a viem Wallet Client to an ethers.js Signer. */
-export async function getEthersSigner(
+export function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {
@@ -262,7 +262,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a Viem Client to an ethers.js Signer. */
-export async function getEthersSigner(
+export function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {
@@ -289,7 +289,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a viem Wallet Client to an ethers.js Signer. */
-export async function getEthersSigner(
+export function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {

--- a/docs/core/guides/ethers.md
+++ b/docs/core/guides/ethers.md
@@ -189,7 +189,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a Viem Client to an ethers.js Signer. */
-export function getEthersSigner(
+export async function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {
@@ -216,7 +216,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a viem Wallet Client to an ethers.js Signer. */
-export function getEthersSigner(
+export async function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {
@@ -262,7 +262,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a Viem Client to an ethers.js Signer. */
-export function getEthersSigner(
+export async function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {
@@ -289,7 +289,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a viem Wallet Client to an ethers.js Signer. */
-export function getEthersSigner(
+export async function getEthersSigner(
   config: Config,
   { chainId }: { chainId?: number } = {},
 ) {

--- a/docs/react/guides/ethers.md
+++ b/docs/react/guides/ethers.md
@@ -184,7 +184,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Hook to convert a Viem Client to an ethers.js Signer. */
-export async function useEthersSigner({ chainId }: { chainId?: number } = {}) {
+export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
   const { data: client } = useConnectorClient<Config>({ chainId })
   return useMemo(() => (client ? clientToSigner(client) : undefined), [client])
 }
@@ -209,7 +209,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Hook to convert a viem Wallet Client to an ethers.js Signer. */
-export async function useEthersSigner({ chainId }: { chainId?: number } = {}) {
+export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
   const { data: client } = useConnectorClient<Config>({ chainId })
   return useMemo(() => (client ? clientToSigner(client) : undefined), [client])
 }
@@ -251,7 +251,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Action to convert a Viem Client to an ethers.js Signer. */
-export async function useEthersSigner({ chainId }: { chainId?: number } = {}) {
+export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
   const { data: client } = useConnectorClient<Config>({ chainId })
   return useMemo(() => (client ? clientToSigner(client) : undefined), [client])
 }
@@ -276,7 +276,7 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 }
 
 /** Hook to convert a viem Wallet Client to an ethers.js Signer. */
-export async function useEthersSigner({ chainId }: { chainId?: number } = {}) {
+export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
   const { data: client } = useConnectorClient<Config>({ chainId })
   return useMemo(() => (client ? clientToSigner(client) : undefined), [client])
 }


### PR DESCRIPTION
## Description

The async keyword makes the `getEtherSigner` return a promise when it shouldn't.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
