### PR TITLE
Adding Holesky testnet to Etherscan plugin for wagmi CLI

### DIFF
--- a/.changeset/slimy-toys-retire.md
+++ b/.changeset/slimy-toys-retire.md
@@ -1,5 +1,5 @@
 ---
-"@wagmi/cli": major
+"@wagmi/cli": patch
 ---
 
 Added holesky testnet to the etherscan plug in to verify contracts

--- a/.changeset/slimy-toys-retire.md
+++ b/.changeset/slimy-toys-retire.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": major
+---
+
+Added holesky testnet to the etherscan plug in to verify contracts

--- a/.changeset/slimy-toys-retire.md
+++ b/.changeset/slimy-toys-retire.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Added holesky testnet to the etherscan plug in to verify contracts
+Added Holesky Testnet to Etherscan Plugin

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -6,6 +6,7 @@ const apiUrls = {
   // Ethereum
   [1]: 'https://api.etherscan.io/api',
   [5]: 'https://api-goerli.etherscan.io/api',
+  [17000]: 'https://api-holesky.etherscan.io/api',
   [11155111]: 'https://api-sepolia.etherscan.io/api',
   // Optimism
   [10]: 'https://api-optimistic.etherscan.io/api',


### PR DESCRIPTION
## Description

Adding Holesky testnet api URL to the Etherscan plugin for wagmi CLI to use the commands for Holesky contracts.
