### PR TITLE
Fix injected connector docs for target

### DIFF
--- a/docs/shared/connectors/injected.md
+++ b/docs/shared/connectors/injected.md
@@ -69,7 +69,7 @@ const connector = injected({
       id: 'windowProvider', // [!code focus]
       name: 'Window Provider', // [!code focus]
       provider: window.ethereum, // [!code focus]
-    }, // [!code focus]
+    }; // [!code focus]
   }, // [!code focus]
 })
 ```


### PR DESCRIPTION
## Description

It is a documentation update, current code snippet is not correct:

https://wagmi.sh/react/api/connectors/injected#target

It uses a `,` instead of a `;`

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.

The previous code was using a `,` instead of a `;`:

### Before with the `,`

<img width="837" alt="image" src="https://github.com/wevm/wagmi/assets/477945/1a64bf1d-a4ff-4e60-93f0-55a5c3c3f5fd">

### After with the `;`

<img width="387" alt="image" src="https://github.com/wevm/wagmi/assets/477945/6add299c-1ce5-4f29-ae69-7a68a88a85d0">
