### PR TITLE
Add Blocto Wallet connector

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -82,6 +82,10 @@ export function getSidebar() {
             link: '/react/api/connectors',
             items: [
               {
+                text: 'blocto',
+                link: '/react/api/connectors/blocto',
+              },
+              {
                 text: 'coinbaseWallet',
                 link: '/react/api/connectors/coinbaseWallet',
               },
@@ -404,6 +408,10 @@ export function getSidebar() {
             collapsed: true,
             link: '/core/api/connectors',
             items: [
+              {
+                text: 'blocto',
+                link: '/core/api/connectors/blocto',
+              },
               {
                 text: 'coinbaseWallet',
                 link: '/core/api/connectors/coinbaseWallet',

--- a/docs/core/api/connectors/blocto.md
+++ b/docs/core/api/connectors/blocto.md
@@ -1,0 +1,6 @@
+<script setup>
+const packageName = '@wagmi/core'
+const connectorsPackageName = '@wagmi/connectors'
+</script>
+
+<!-- @include: @shared/connectors/blocto.md -->

--- a/docs/react/api/connectors/blocto.md
+++ b/docs/react/api/connectors/blocto.md
@@ -1,0 +1,6 @@
+<script setup>
+const packageName = 'wagmi'
+const connectorsPackageName = 'wagmi/connectors'
+</script>
+
+<!-- @include: @shared/connectors/blocto.md -->

--- a/docs/react/guides/connect-wallet.md
+++ b/docs/react/guides/connect-wallet.md
@@ -32,7 +32,7 @@ Let's create a `config.ts` file and export a `config` object.
 ```tsx [config.ts]
 import { http, createConfig } from 'wagmi'
 import { base, mainnet, optimism } from 'wagmi/chains'
-import { injected, metaMask, safe, walletConnect } from 'wagmi/connectors'
+import { injected, metaMask, safe, walletConnect, blocto } from 'wagmi/connectors'
 
 const projectId = '<WALLETCONNECT_PROJECT_ID>'
 
@@ -43,6 +43,7 @@ export const config = createConfig({
     walletConnect({ projectId }),
     metaMask(),
     safe(),
+    blocto(),
   ],
   transports: {
     [mainnet.id]: http(),
@@ -93,7 +94,7 @@ function App() {
 ```tsx [config.ts]
 import { http, createConfig } from 'wagmi'
 import { base, mainnet, optimism } from 'wagmi/chains'
-import { injected, metaMask, safe, walletConnect } from 'wagmi/connectors'
+import { injected, metaMask, safe, walletConnect, blocto } from 'wagmi/connectors'
 
 const projectId = '<WALLETCONNECT_PROJECT_ID>'
 
@@ -104,6 +105,7 @@ export const config = createConfig({
     walletConnect({ projectId }),
     metaMask(),
     safe(),
+    blocto(),
   ],
   transports: {
     [mainnet.id]: http(),
@@ -161,7 +163,7 @@ function App() {
 ```tsx [config.ts]
 import { http, createConfig } from 'wagmi'
 import { base, mainnet, optimism } from 'wagmi/chains'
-import { injected, metaMask, safe, walletConnect } from 'wagmi/connectors'
+import { injected, metaMask, safe, walletConnect, blocto } from 'wagmi/connectors'
 
 const projectId = '<WALLETCONNECT_PROJECT_ID>'
 
@@ -172,6 +174,7 @@ export const config = createConfig({
     walletConnect({ projectId }),
     metaMask(),
     safe(),
+    blocto(),
   ],
   transports: {
     [mainnet.id]: http(),
@@ -275,7 +278,7 @@ function App() {
 ```tsx [config.ts]
 import { http, createConfig } from 'wagmi'
 import { base, mainnet, optimism } from 'wagmi/chains'
-import { injected, metaMask, safe, walletConnect } from 'wagmi/connectors'
+import { injected, metaMask, safe, walletConnect, blocto } from 'wagmi/connectors'
 
 const projectId = '<WALLETCONNECT_PROJECT_ID>'
 
@@ -286,6 +289,7 @@ export const config = createConfig({
     walletConnect({ projectId }),
     metaMask(),
     safe(),
+    blocto(),
   ],
   transports: {
     [mainnet.id]: http(),
@@ -390,7 +394,7 @@ function WalletOption({
 ```tsx [config.ts]
 import { http, createConfig } from 'wagmi'
 import { base, mainnet, optimism } from 'wagmi/chains'
-import { injected, metaMask, safe, walletConnect } from 'wagmi/connectors'
+import { injected, metaMask, safe, walletConnect, blocto } from 'wagmi/connectors'
 
 const projectId = '<WALLETCONNECT_PROJECT_ID>'
 
@@ -401,6 +405,7 @@ export const config = createConfig({
     walletConnect({ projectId }),
     metaMask(),
     safe(),
+    blocto(),
   ],
   transports: {
     [mainnet.id]: http(),

--- a/docs/shared/connectors/blocto.md
+++ b/docs/shared/connectors/blocto.md
@@ -1,0 +1,50 @@
+<!-- <script setup>
+const packageName = 'wagmi'
+const connectorsPackageName = 'wagmi/connectors'
+</script> -->
+
+# blocto
+
+Connector for [Blocto SDK](https://github.com/blocto/blocto-sdk).
+
+## Import
+
+```ts-vue
+import { blocto } from '{{connectorsPackageName}}'
+```
+
+## Usage
+
+```ts-vue{3,7}
+import { createConfig, http } from '{{packageName}}'
+import { mainnet, polygon } from '{{packageName}}/chains'
+import { blocto } from '{{connectorsPackageName}}'
+
+export const config = createConfig({
+  chains: [mainnet, polygon],
+  connectors: [blocto()],
+  transports: {
+    [mainnet.id]: http(),
+    [polygon.id]: http(),
+  },
+})
+```
+
+## Parameters
+
+```ts-vue
+import { type BloctoParameters } from '{{connectorsPackageName}}'
+```
+### appId
+
+`string | undefined`
+
+```ts-vue
+import { blocto } from '{{connectorsPackageName}}'
+
+const connector = blocto({
+  appId: 'REPLACE_WITH_YOUR_DAPP_ID'
+})
+```
+Check out the [Blocto docs](https://docs.blocto.app/blocto-sdk/register-app-id) for more info.
+

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -45,6 +45,7 @@
     }
   },
   "dependencies": {
+    "@blocto/sdk": "^0.9.1",
     "@coinbase/wallet-sdk": "3.9.1",
     "@metamask/sdk": "0.14.3",
     "@safe-global/safe-apps-provider": "0.18.1",

--- a/packages/connectors/src/blocto.test.ts
+++ b/packages/connectors/src/blocto.test.ts
@@ -1,0 +1,216 @@
+import { createConfig } from '@wagmi/core'
+import { normalizeChainId } from '@wagmi/core'
+import { arbitrumGoerli, polygonMumbai } from '@wagmi/core/chains'
+import { http, SwitchChainError, numberToHex } from 'viem'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { blocto } from './blocto.js'
+
+const walletProvider = {
+  on: vi.fn(),
+}
+
+describe('blocto-connector', () => {
+  let connector: any
+  beforeEach(() => {
+    const config = createConfig({
+      chains: [polygonMumbai, arbitrumGoerli],
+      pollingInterval: 100,
+      storage: null,
+      transports: {
+        [polygonMumbai.id]: http(),
+        [arbitrumGoerli.id]: http(),
+      },
+    })
+    connector = config._internal.connectors.setup(blocto())
+  })
+
+  afterEach(() => {
+    connector = null
+  })
+
+  test('setup', () => {
+    expect(connector.name).toEqual('Blocto')
+  })
+
+  test('connect', async () => {
+    const chainId = 1
+    const accounts = ['0xc61B4Aa62E5FD40cceB08C602Eb5D157b257b49a']
+    const provider = {
+      request: vi.fn().mockResolvedValue(accounts),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+    connector.getAccounts = vi.fn().mockResolvedValue(accounts)
+    connector.getChainId = vi.fn().mockResolvedValue(chainId)
+
+    const result = await connector.connect({ chainId })
+
+    expect(result).toEqual({ accounts, chainId })
+    expect(connector.getProvider).toHaveBeenCalledWith({ chainId })
+    expect(provider.request).toHaveBeenCalledWith({
+      method: 'eth_requestAccounts',
+    })
+  })
+
+  test('catch error when user decline to connect', () => {
+    const chainId = 1
+    const userRejectedRequest = new Error('User rejected request')
+    const provider = {
+      request: vi.fn().mockImplementation(() => {
+        throw userRejectedRequest
+      }),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+
+    expect(connector.connect({ chainId })).rejects.toThrow(userRejectedRequest)
+  })
+
+  test('disconnect', async () => {
+    const provider = {
+      request: vi.fn().mockResolvedValue(undefined),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+
+    await connector.disconnect()
+
+    expect(connector.getProvider).toHaveBeenCalled()
+    expect(provider.request).toHaveBeenCalledWith({
+      method: 'wallet_disconnect',
+    })
+  })
+
+  test('getAccounts', async () => {
+    const accounts = ['0xc61B4Aa62E5FD40cceB08C602Eb5D157b257b49a']
+    const provider = {
+      request: vi.fn().mockResolvedValue(accounts),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+
+    const result = await connector.getAccounts()
+
+    expect(result).toEqual(['0xc61B4Aa62E5FD40cceB08C602Eb5D157b257b49a'])
+    expect(connector.getProvider).toHaveBeenCalled()
+    expect(provider.request).toHaveBeenCalledWith({ method: 'eth_accounts' })
+  })
+
+  test('getChainId', async () => {
+    const chainId = '0x1'
+    const provider = {
+      chainId: undefined,
+      request: vi.fn().mockResolvedValue(chainId),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+
+    const result = await connector.getChainId()
+
+    expect(result).toEqual(normalizeChainId(chainId))
+    expect(connector.getProvider).toHaveBeenCalled()
+    expect(provider.request).toHaveBeenCalledWith({ method: 'eth_chainId' })
+  })
+
+  test('getProvider', async () => {
+    vi.mock('@blocto/sdk', () => ({
+      default: vi.fn().mockImplementation(() => ({
+        ethereum: walletProvider,
+      })),
+    }))
+
+    const chainId = 1
+    const result = await connector.getProvider({ chainId })
+
+    expect(result).toEqual(walletProvider)
+    expect(walletProvider.on).toHaveBeenCalledWith(
+      'accountsChanged',
+      expect.any(Function),
+    )
+    expect(walletProvider.on).toHaveBeenCalledWith(
+      'chainChanged',
+      expect.any(Function),
+    )
+    expect(walletProvider.on).toHaveBeenCalledWith(
+      'disconnect',
+      expect.any(Function),
+    )
+  })
+  test('isAuthorized', async () => {
+    const accounts = ['0xc61B4Aa62E5FD40cceB08C602Eb5D157b257b49a']
+    connector.getAccounts = vi.fn().mockResolvedValue(accounts)
+
+    const result = await connector.isAuthorized()
+
+    expect(result).toEqual(false)
+  })
+
+  test('switchChain', async () => {
+    const chainId = arbitrumGoerli.id
+    const provider = {
+      request: vi.fn().mockResolvedValue(undefined),
+      supportChainList: vi.fn().mockResolvedValue(
+        [polygonMumbai, arbitrumGoerli].map(({ id, name }) => ({
+          chainId: id,
+          chainName: name,
+        })),
+      ),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+
+    const chain = await connector.switchChain({ chainId })
+
+    expect(connector.getProvider).toHaveBeenCalled()
+    expect(provider.request).toHaveBeenCalledWith({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: numberToHex(chainId),
+          rpcUrls: arbitrumGoerli.rpcUrls.default.http,
+        },
+      ],
+    })
+    expect(provider.request).toHaveBeenCalledWith({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: numberToHex(chainId) }],
+    })
+    expect(chain.id).toEqual(chainId)
+  })
+
+  test('catch error when switching to unConfigured chain', async () => {
+    const unConfiguredChainId = 111111
+    const provider = {
+      request: vi.fn().mockResolvedValue(undefined),
+      supportChainList: vi.fn().mockResolvedValue(
+        [polygonMumbai, arbitrumGoerli].map(({ id, name }) => ({
+          chainId: id,
+          chainName: name,
+        })),
+      ),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+    const expectError = new SwitchChainError(
+      new Error(`Chain not in config: ${numberToHex(unConfiguredChainId)}`),
+    )
+
+    expect(
+      connector.switchChain({ chainId: unConfiguredChainId }),
+    ).rejects.toThrow(expectError)
+  })
+
+  test('catch error when switching to blocto unsupported chain', async () => {
+    const unsupportedChainId = arbitrumGoerli.id
+    const provider = {
+      request: vi.fn().mockResolvedValue(undefined),
+      supportChainList: vi.fn().mockResolvedValue(
+        [polygonMumbai].map(({ id, name }) => ({
+          chainId: id,
+          chainName: name,
+        })),
+      ),
+    }
+    connector.getProvider = vi.fn().mockResolvedValue(provider)
+    const expectError = new SwitchChainError(
+      new Error(`Blocto unsupported chain: ${numberToHex(unsupportedChainId)}`),
+    )
+
+    expect(
+      connector.switchChain({ chainId: unsupportedChainId }),
+    ).rejects.toThrow(expectError)
+  })
+})

--- a/packages/connectors/src/blocto.ts
+++ b/packages/connectors/src/blocto.ts
@@ -1,0 +1,165 @@
+import type {
+  EthereumProviderConfig as BloctoEthereumProviderParameters,
+  EthereumProviderInterface as BloctoProvider,
+} from '@blocto/sdk'
+import BloctoSDK from '@blocto/sdk'
+import { createConnector, normalizeChainId } from '@wagmi/core'
+import {
+  RpcError,
+  SwitchChainError,
+  UserRejectedRequestError,
+  getAddress,
+  numberToHex,
+} from 'viem'
+
+export type BloctoParameters = {
+  /**
+   * Your app’s unique identifier that can be obtained at https://developers.blocto.app,
+   * To get advanced features and support with Blocto.
+   *
+   * https://docs.blocto.app/blocto-sdk/register-app-id
+   */
+  appId?: string
+}
+
+blocto.type = 'blocto' as const
+export function blocto({ appId }: BloctoParameters = {}) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  type Properties = {}
+  type StorageItem = {
+    store: any
+    'wagmi.recentConnectorId': string
+  }
+
+  let walletProvider: BloctoProvider | undefined
+  const handleConnectReset = () => {
+    walletProvider = undefined
+  }
+
+  return createConnector<BloctoProvider, Properties, StorageItem>((config) => ({
+    id: 'blocto',
+    name: 'Blocto',
+    type: blocto.type,
+    async connect({ chainId } = {}) {
+      try {
+        const provider = await this.getProvider({ chainId })
+
+        config.emitter.emit('message', { type: 'connecting' })
+
+        await provider.request({
+          method: 'eth_requestAccounts',
+        })
+
+        const accounts = await this.getAccounts()
+        const _chainId = await this.getChainId()
+
+        return { accounts, chainId: _chainId }
+      } catch (error: unknown) {
+        handleConnectReset()
+        throw error
+      }
+    },
+    async disconnect() {
+      const provider = await this.getProvider()
+      await provider.request({ method: 'wallet_disconnect' })
+      handleConnectReset()
+    },
+    async getAccounts() {
+      const provider = await this.getProvider()
+      const accounts = (await provider.request({
+        method: 'eth_accounts',
+      })) as string[]
+
+      return accounts.map((x) => getAddress(x))
+    },
+    async getChainId() {
+      const provider = await this.getProvider()
+      const chainId = await provider?.request({ method: 'eth_chainId' })
+      return normalizeChainId(chainId)
+    },
+    async getProvider({ chainId } = {}) {
+      if (!walletProvider) {
+        const store = await config.storage?.getItem('store')
+        const lastConnectedChainId = store?.state?.chainId
+        const desiredChainId = chainId ?? lastConnectedChainId
+        const ethereum: BloctoEthereumProviderParameters = {
+          chainId: desiredChainId,
+          rpc: config.chains.find((x) => x.id === desiredChainId)?.rpcUrls
+            .default.http[0],
+        }
+
+        walletProvider = new BloctoSDK({ ethereum, appId })?.ethereum
+        if (!walletProvider) {
+          throw new Error('Blocto SDK is not initialized.')
+        }
+
+        walletProvider.on('accountsChanged', this.onAccountsChanged.bind(this))
+        walletProvider.on('chainChanged', this.onChainChanged.bind(this))
+        walletProvider.on('disconnect', this.onDisconnect.bind(this))
+      }
+
+      return Promise.resolve(walletProvider)
+    },
+    async isAuthorized() {
+      const recentConnectorId = await config.storage?.getItem(
+        'recentConnectorId',
+      )
+      if (recentConnectorId !== this.id) return false
+
+      const accounts = await this.getAccounts()
+      return !!accounts.length
+    },
+    async switchChain({ chainId }) {
+      try {
+        const provider = await this.getProvider()
+        const id = numberToHex(chainId)
+        const chain = config.chains.find((x) => x.id === chainId)
+        const networks = await provider.supportChainList()
+        const evmSupportMap = networks.reduce(
+          (a: any, v: any) => ({ ...a, [v.chainId]: v }),
+          {},
+        )
+        const isBloctoSupportChain = evmSupportMap[`${chainId}`]
+
+        if (!chain) {
+          throw new SwitchChainError(new Error(`Chain not in config: ${id}`))
+        }
+
+        if (!isBloctoSupportChain) {
+          throw new SwitchChainError(
+            new Error(`Blocto unsupported chain: ${id}`),
+          )
+        }
+
+        await provider.request({
+          method: 'wallet_addEthereumChain',
+          params: [{ chainId: id, rpcUrls: chain?.rpcUrls.default.http }],
+        })
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: id }],
+        })
+
+        return chain
+      } catch (err) {
+        const error = err as RpcError
+        if (error.code === UserRejectedRequestError.code)
+          throw new UserRejectedRequestError(error)
+
+        throw new SwitchChainError(error as Error)
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onAccountsChanged() {},
+    async onChainChanged(chainId: string) {
+      const accounts = await this.getAccounts()
+      config.emitter.emit('change', {
+        chainId: normalizeChainId(chainId),
+        accounts,
+      })
+    },
+    async onDisconnect() {
+      config.emitter.emit('disconnect')
+    },
+  }))
+}

--- a/packages/connectors/src/blocto.ts
+++ b/packages/connectors/src/blocto.ts
@@ -28,7 +28,6 @@ export function blocto({ appId }: BloctoParameters = {}) {
   type Properties = {}
   type StorageItem = {
     store: any
-    'wagmi.recentConnectorId': string
   }
 
   let walletProvider: BloctoProvider | undefined
@@ -101,13 +100,12 @@ export function blocto({ appId }: BloctoParameters = {}) {
       return Promise.resolve(walletProvider)
     },
     async isAuthorized() {
-      const recentConnectorId = await config.storage?.getItem(
-        'recentConnectorId',
-      )
-      if (recentConnectorId !== this.id) return false
-
-      const accounts = await this.getAccounts()
-      return !!accounts.length
+      try {
+        const accounts = await this.getAccounts()
+        return !!accounts.length
+      } catch {
+        return false
+      }
     },
     async switchChain({ chainId }) {
       try {

--- a/packages/connectors/src/exports/index.ts
+++ b/packages/connectors/src/exports/index.ts
@@ -19,4 +19,6 @@ export {
   walletConnect,
 } from '../walletConnect.js'
 
+export { type BloctoParameters, blocto } from '../blocto.js'
+
 export { version } from '../version.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
 
   packages/connectors:
     dependencies:
+      '@blocto/sdk':
+        specifier: ^0.9.1
+        version: 0.9.1
       '@coinbase/wallet-sdk':
         specifier: 3.9.1
         version: 3.9.1
@@ -1039,6 +1042,23 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@blocto/sdk@0.9.1:
+    resolution: {integrity: sha512-JPBKDUrgTrTc9PaCj1iNleMy68V6DARa93sJa6OBvxkFCtYNxGn+sNCOZqhCU/3YjQ6z75/Mls2oF4kQe/04cw==}
+    peerDependencies:
+      aptos: ^1.3.14
+    peerDependenciesMeta:
+      aptos:
+        optional: true
+    dependencies:
+      buffer: 6.0.3
+      eip1193-provider: 1.0.1
+      js-sha3: 0.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
 
   /@brillout/import@0.2.3:
     resolution: {integrity: sha512-1T8WlD75eeFSMrptGy8jiLHmfHgMmSjWvLOIUvHmSVZt+6k0eQqYUoK4KbmE4T9pVLIfxvZSOm2D68VEqKRHRw==}
@@ -2545,6 +2565,35 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
+  /@json-rpc-tools/provider@1.7.6:
+    resolution: {integrity: sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      '@json-rpc-tools/utils': 1.7.6
+      axios: 0.21.4
+      safe-json-utils: 1.1.1
+      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
+
+  /@json-rpc-tools/types@1.7.6:
+    resolution: {integrity: sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      keyvaluestorage-interface: 1.0.0
+    dev: false
+
+  /@json-rpc-tools/utils@1.7.6:
+    resolution: {integrity: sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      '@json-rpc-tools/types': 1.7.6
+      '@pedrouid/environment': 1.0.1
+    dev: false
+
   /@lit-labs/ssr-dom-shim@1.1.0:
     resolution: {integrity: sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong==}
     dev: false
@@ -3474,6 +3523,10 @@ packages:
       '@parcel/watcher-win32-arm64': 2.3.0
       '@parcel/watcher-win32-ia32': 2.3.0
       '@parcel/watcher-win32-x64': 2.3.0
+    dev: false
+
+  /@pedrouid/environment@1.0.1:
+    resolution: {integrity: sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==}
     dev: false
 
   /@pkgjs/parseargs@0.11.0:
@@ -5369,6 +5422,14 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
 
+  /axios@0.21.4:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
+    dependencies:
+      follow-redirects: 1.15.2(debug@4.3.4)
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -6448,6 +6509,17 @@ packages:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
+  /eip1193-provider@1.0.1:
+    resolution: {integrity: sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      '@json-rpc-tools/provider': 1.7.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
+
   /electron-to-chromium@1.4.504:
     resolution: {integrity: sha512-cSMwIAd8yUh54VwitVRVvHK66QqHWE39C3DRj8SWiXitEpVSY3wNPD9y1pxQtLIi4w3UdzF9klLsmuPshz09DQ==}
 
@@ -6911,6 +6983,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: true
+    bundledDependencies: false
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -7197,7 +7270,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -8292,7 +8364,6 @@ packages:
 
   /js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -10357,6 +10428,10 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  /safe-json-utils@1.1.1:
+    resolution: {integrity: sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ==}
+    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

This PR adds [Blocto wallet](https://blocto.io/) to the built-in wallet connectors, allowing more users to easily connect Blocto wallet in dApps.

## Additional Information

Blocto wallet is an ERC-4337 compatible smart contract wallet that aims to lower the entry barrier for users into Web3,
users can connect their wallets without the need to install browser extensions.

We understand the significance of this feature to our users, and we have committed ourselves to its implementation to enhance the usability of wagmi and Blocto wallet.

Connector request: https://github.com/wevm/wagmi/discussions/3436

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
