### PR TITLE
Adding Arbitrum Sepolia testnet to Etherscan plugin for Wagmi CLI

### DIFF
--- a/.changeset/clever-poems-arrive.md
+++ b/.changeset/clever-poems-arrive.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Added Arbitrum Sepolia testnet to wagmi cli etherscan plugin
+Added Arbitrum Sepolia testnet to Etherscan plugin

--- a/.changeset/clever-poems-arrive.md
+++ b/.changeset/clever-poems-arrive.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Added Arbitrum Sepolia testnet to wagmi cli etherscan plugin

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -18,6 +18,7 @@ const apiUrls = {
   // Arbitrum
   [42_161]: 'https://api.arbiscan.io/api',
   [421_613]: 'https://api-goerli.arbiscan.io/api',
+  [421_614]: 'https://api-sepolia.arbiscan.io/api',
   // BNB Smart Chain
   [56]: 'https://api.bscscan.com/api',
   [97]: 'https://api-testnet.bscscan.com/api',


### PR DESCRIPTION
## Description

Added Arbitrum Sepolia testnet to Etherscan plugin in the wagmi cli to add support to generate for contracts published to arbitrum sepolia

## Additional Information

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.