### PR TITLE
fix: reconnect race condition

### DIFF
--- a/.changeset/quick-hairs-nail.md
+++ b/.changeset/quick-hairs-nail.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Fixed race condition arising from `reconnect`.

--- a/packages/core/src/actions/reconnect.test.ts
+++ b/packages/core/src/actions/reconnect.test.ts
@@ -68,3 +68,11 @@ test("behavior: doesn't reconnect if already reconnecting", async () => {
   ).resolves.toStrictEqual([])
   config.setState((x) => ({ ...x, status: previousStatus }))
 })
+
+test("behaviour: doesn't overwrite connected status", async () => {
+  config.setState((x) => ({ ...x, status: 'connected' }))
+  await expect(
+    reconnect(config, { connectors: [connector] }),
+  ).resolves.toStrictEqual([])
+  expect(config.state.status).toEqual('connected')
+})

--- a/packages/core/src/actions/reconnect.ts
+++ b/packages/core/src/actions/reconnect.ts
@@ -106,15 +106,21 @@ export async function reconnect(
     connected = true
   }
 
-  // If connecting didn't succeed, set to disconnected
-  if (!connected)
-    config.setState((x) => ({
-      ...x,
-      connections: new Map(),
-      current: undefined,
-      status: 'disconnected',
-    }))
-  else config.setState((x) => ({ ...x, status: 'connected' }))
+  // Prevent overwriting connected status from race condition
+  if (
+    config.state.status === 'reconnecting' ||
+    config.state.status === 'connecting'
+  ) {
+    // If connecting didn't succeed, set to disconnected
+    if (!connected)
+      config.setState((x) => ({
+        ...x,
+        connections: new Map(),
+        current: undefined,
+        status: 'disconnected',
+      }))
+    else config.setState((x) => ({ ...x, status: 'connected' }))
+  }
 
   isReconnecting = false
   return connections


### PR DESCRIPTION
## Description

previously, calling `reconnect()` could potentially result in a race condition if `connect()` was called while reconnection was still pending. if `connect()` resolved before `reconnect()`, status would be set to `connected` and then be set to `disconnected` once `reconnect()` resolved (if there was no successful reconnection).

for me this issue was occurring via a combination of walletconnect's `getProvider()` taking a long time to resolve, and having automatic reconnection on mount enabled. if a user managed to connect before walletconnect's provider was initialised, they would connect and then be disconnected soon after.

there are definitely other potential solutions to this issue but i think this one is very straight forward with low impact on anything else.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
