### PR TITLE
chore: export Transport for rainbowkit

### DIFF
--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -443,6 +443,7 @@ export {
   type CreateConfigParameters,
   type State,
   createConfig,
+  type Transport
 } from '../createConfig.js'
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

feature for export Transport.
At the file https://github.com/rainbow-me/rainbowkit/blob/main/packages/rainbowkit/src/config/getDefaultConfig.ts
rainbowkit use a wrong Transport type to create config, but wagmi have not export the Transport type.
