### PR TITLE
Fix error when adding chains without explorers to MetaMask

### DIFF
--- a/.changeset/two-deers-love.md
+++ b/.changeset/two-deers-love.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/connectors": patch
+"@wagmi/core": patch
+---
+
+Fixed error occurring when adding chains without explorers to MetaMask.

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -250,7 +250,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           try {
             const { default: blockExplorer, ...blockExplorers } =
               chain.blockExplorers ?? {}
-            let blockExplorerUrls: string[] = []
+            let blockExplorerUrls
             if (blockExplorer)
               blockExplorerUrls = [
                 blockExplorer.url,

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -372,7 +372,7 @@ export function injected(parameters: InjectedParameters = {}) {
           try {
             const { default: blockExplorer, ...blockExplorers } =
               chain.blockExplorers ?? {}
-            let blockExplorerUrls: string[] = []
+            let blockExplorerUrls
             if (blockExplorer)
               blockExplorerUrls = [
                 blockExplorer.url,


### PR DESCRIPTION
## Description

This pull request resolves https://github.com/wevm/wagmi/issues/3652.

Following the steps outlined in the issue, I reproduced the error in the playground, applied this fix, and confirmed that it resolves the error.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.