### PR TITLE
Replace SnowTrace with SnowScan an Etherscan product.

### DIFF
--- a/.changeset/cuddly-dodos-visit.md
+++ b/.changeset/cuddly-dodos-visit.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Replace SnowTrace with SnowScan an Etherscan product.
+Replaced SnowTrace with SnowScan for the Etherscan plugin

--- a/.changeset/cuddly-dodos-visit.md
+++ b/.changeset/cuddly-dodos-visit.md
@@ -1,5 +1,4 @@
 ---
-"docs": patch
 "@wagmi/cli": patch
 ---
 

--- a/.changeset/cuddly-dodos-visit.md
+++ b/.changeset/cuddly-dodos-visit.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Replace SnowTrace with SnowScan an Etherscan product.

--- a/.changeset/cuddly-dodos-visit.md
+++ b/.changeset/cuddly-dodos-visit.md
@@ -1,4 +1,5 @@
 ---
+"docs": patch
 "@wagmi/cli": patch
 ---
 

--- a/docs/cli/api/plugins/etherscan.md
+++ b/docs/cli/api/plugins/etherscan.md
@@ -34,7 +34,7 @@ The following Etherscan block explorers and their testnets are supported (e.g. E
 
 - [Ethereum](https://etherscan.io)
 - [Arbiscan](https://arbiscan.io)
-- [Snowtrace](https://snowtrace.io)
+- [SnowScan](https://snowscan.xyz)
 - [BscScan](https://bscscan.com)
 - [FTMScan](https://ftmscan.com)
 - [HecoScan](https://hecoinfo.com)

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -28,8 +28,8 @@ const apiUrls = {
   [250]: 'https://api.ftmscan.com/api',
   [4002]: 'https://api-testnet.ftmscan.com/api',
   // Avalanche
-  [43114]: 'https://api.snowtrace.io/api',
-  [43113]: 'https://api-testnet.snowtrace.io/api',
+  [43114]: 'https://api.snowscan.xyz/api',
+  [43113]: 'https://api-testnet.snowscan.xyz/api',
   // Celo
   [42220]: 'https://api.celoscan.io/api',
   [44787]: 'https://api-alfajores.celoscan.io/api',
@@ -43,7 +43,7 @@ export type EtherscanConfig<chainId extends number> = {
    * API keys are specific per network and include testnets (e.g. Ethereum Mainnet and Goerli share same API key). Create or manage keys:
    * - [__Ethereum__](https://etherscan.io/myapikey)
    * - [__Arbitrum__](https://arbiscan.io/myapikey)
-   * - [__Avalanche__](https://snowtrace.io/myapikey)
+   * - [__Avalanche__](https://snowscan.xyz/myapikey)
    * - [__BNB Smart Chain__](https://bscscan.com/myapikey)
    * - [__Celo__](https://celoscan.io/myapikey)
    * - [__Fantom__](https://ftmscan.com/myapikey)


### PR DESCRIPTION
## Description
SnowTrace is not maintained by EtherScan anymore but by AvaScan team. Etherscan has deployed their block explorer under https://snowscan.xyz now.

See VIEM PR for more info: https://github.com/wevm/viem/pull/1824

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
