### PR TITLE
Add a Devtools section to tanstack-query docs page

### DIFF
--- a/docs/react/guides/tanstack-query.md
+++ b/docs/react/guides/tanstack-query.md
@@ -394,10 +394,10 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools"; // [!code h
 import { hashFn } from "@wagmi/core/query"; // [!code hl]
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
+  defaultOptions: { // [!code hl]
+    queries: { // [!code hl]
       queryKeyHashFn: hashFn, // [!code hl]
-    },
-  },
+    }, // [!code hl]
+  }, // [!code hl]
 });
 ```

--- a/docs/react/guides/tanstack-query.md
+++ b/docs/react/guides/tanstack-query.md
@@ -361,7 +361,7 @@ It is possible to utilize TanStack Query's SSR strategies with Wagmi Hooks & Que
 
 ## Devtools
 
-TanStack Query includes dedicated [Devtools](https://tanstack.com/query/latest/docs/framework/react/devtools) that assist in visualizing and debugging your queries, their cache states, and much more. However, by default, the Devtools code cannot correctly serialize BigInt values in queryKeys for display. To address this, you can provide a custom `queryKeyHashFn` when creating a `QueryClient` instance to serialize BigInt values. Alternatively, you can use the `hashFn` from `@wagmi/core/query`, which already handles this serialization.
+TanStack Query includes dedicated [Devtools](https://tanstack.com/query/latest/docs/framework/react/devtools) that assist in visualizing and debugging your queries, their cache states, and much more. You will have to pass a custom `queryKeyFn` to your `QueryClient` for Devtools to correctly serialize BigInt values for display. Alternatively, You can use the `hashFn` from `@wagmi/core/query`, which already handles this serialization.
 
 #### Install
 

--- a/docs/react/guides/tanstack-query.md
+++ b/docs/react/guides/tanstack-query.md
@@ -358,3 +358,46 @@ function App() {
 ## SSR
 
 It is possible to utilize TanStack Query's SSR strategies with Wagmi Hooks & Query Keys. Check out the [Server Rendering & Hydration](https://tanstack.com/query/v5/docs/react/guides/ssr) & [Advanced Server Rendering](https://tanstack.com/query/v5/docs/react/guides/advanced-ssr) guides.
+
+## Devtools
+
+TanStack Query includes dedicated [Devtools](https://tanstack.com/query/latest/docs/framework/react/devtools) that assist in visualizing and debugging your queries, their cache states, and much more. However, by default, the Devtools code cannot correctly serialize BigInt values in queryKeys for display. To address this, you can provide a custom `queryKeyHashFn` when creating a `QueryClient` instance to serialize BigInt values. Alternatively, you can use the `hashFn` from `@wagmi/core/query`, which already handles this serialization.
+
+#### Install
+
+::: code-group
+```bash [pnpm]
+pnpm i @tanstack/react-query-devtools
+```
+
+```bash [npm]
+npm i @tanstack/react-query-devtools
+```
+
+```bash [yarn]
+yarn add @tanstack/react-query-devtools
+```
+
+```bash [bun]
+bun i @tanstack/react-query-devtools
+```
+:::
+
+#### Usage
+
+```tsx
+import {
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"; // [!code hl]
+import { hashFn } from "@wagmi/core/query"; // [!code hl]
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      queryKeyHashFn: hashFn, // [!code hl]
+    },
+  },
+});
+```


### PR DESCRIPTION
## Description

Added a `Devtools` section to tanstack query page in docs, to provide a workaround for "Cannot serialize BigInt" when tanstack devtools tries to display queryKeys in the devtool.

wagmi already does custom serialization on every hook level, but obviously client instance still has the default function to hash keys, and this is what is used by devtools.

<img width="1630" alt="image" src="https://github.com/wevm/wagmi/assets/666169/015d2a60-3706-49a5-b551-493bdb6ba0a7">


## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
