### PR TITLE
Fix useBlockNumber multiple websocket subscriptions

### DIFF
--- a/packages/react/src/hooks/useBlockNumber.ts
+++ b/packages/react/src/hooks/useBlockNumber.ts
@@ -18,7 +18,7 @@ import {
   type GetBlockNumberQueryKey,
   getBlockNumberQueryOptions,
 } from '@wagmi/core/query'
-
+import { useRef } from 'react'
 import type { ConfigParameter, QueryParameter } from '../types/properties.js'
 import { type UseQueryReturnType, useQuery } from '../utils/query.js'
 import { useChainId } from './useChainId.js'
@@ -76,6 +76,11 @@ export function useBlockNumber<
     chainId,
   })
 
+  // memoize this function for deepEqual fn.constructor comparison to work
+  const onBlockNumber = useRef((blockNumber: bigint) => {
+    queryClient.setQueryData(options.queryKey, blockNumber)
+  })
+
   useWatchBlockNumber({
     ...({
       config: parameters.config,
@@ -86,9 +91,7 @@ export function useBlockNumber<
       (query.enabled ?? true) &&
         (typeof watch === 'object' ? watch.enabled : watch),
     ),
-    onBlockNumber(blockNumber) {
-      queryClient.setQueryData(options.queryKey, blockNumber)
-    },
+    onBlockNumber: onBlockNumber.current,
   })
 
   return useQuery({ ...query, ...options })

--- a/packages/react/src/hooks/useWatchBlockNumber.ts
+++ b/packages/react/src/hooks/useWatchBlockNumber.ts
@@ -39,7 +39,9 @@ export function useWatchBlockNumber<
 
   const chainId = parameters.chainId ?? configChainId
 
-  const watchBlockNumberParameters =
+  const watchBlockNumberParameters:
+    | WatchBlockNumberParameters<config, chainId>
+    | undefined =
     enabled && onBlockNumber
       ? {
           onBlockNumber,
@@ -48,7 +50,9 @@ export function useWatchBlockNumber<
         }
       : undefined
 
-  const watchBlockNumberParametersRef = useRef(watchBlockNumberParameters)
+  const watchBlockNumberParametersRef = useRef<
+    WatchBlockNumberParameters<config, chainId> | undefined
+  >()
   const subscription = useRef<WatchBlockNumberReturnType | undefined>(undefined)
 
   useEffect(() => {
@@ -58,11 +62,7 @@ export function useWatchBlockNumber<
       watchBlockNumberParameters,
     )
 
-    if (
-      (!parametersEqual || !subscription.current) &&
-      enabled &&
-      watchBlockNumberParameters
-    ) {
+    if (!parametersEqual && enabled && watchBlockNumberParameters) {
       watchBlockNumberParametersRef.current = watchBlockNumberParameters
 
       subscription.current = watchBlockNumber(


### PR DESCRIPTION
## Description

fixes #3656  When using `useBlockNumber` with websocket transport, the `onBlockNumber` passed to useEffect of `useWatchBlockNumber` (as property of `...rest` object), react's Object.equal would consider them to be different and run the effect every time new block arrives, causing multiple subcriptions to the same block. `watchBlockNumber` action does have code like this `if (unwatch) unwatch()` but it doesn't make sense as new `watchBlockNumber` is called every time, so `unwatch` will always be undefined, unless we define `unwatch` outside of the function, but then would need to store instances by some unique keys to only unwatch if the same subscription is being created.

The code is not ideal, and adds a bit too much probably. My head is wonky after trying to debug this for a few hours. Let me know where I can improve it, or I might review it after some rest, and come up with ways to make it smaller. Otherwise if you think this is fine as is, then that's cool too 😄 

One test snapshot for `getBlock` is failing for me, but it also fails on master with no changes. I made sure that .env file is the same as in contribution docs, so not sure what is it, perhaps the snapshot was made with different block number from the one specified in sample .env

<img width="519" alt="image" src="https://github.com/wevm/wagmi/assets/666169/5eecfadd-9811-45cc-bb9a-e6a4d275d0c0">


## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
