### PR TITLE
docs: added deprecated warning to useBalance

### DIFF
--- a/docs/react/api/hooks/useBalance.md
+++ b/docs/react/api/hooks/useBalance.md
@@ -175,7 +175,7 @@ function App() {
 ERC-20 token address to get balance for.
 
 ::: warning Deprecated
-See [deprecation notices](/react/guides/migrate-from-v1-to-v2#removed-usebalance-token-parameter) for more info.
+See [deprecation notices](/react/guides/migrate-from-v1-to-v2#deprecated-usebalance-token-parameter) for more info.
 :::
 
 ::: code-group
@@ -198,6 +198,10 @@ function App() {
 
 - Units to use when formatting result.
 - Defaults to `'ether'`.
+
+::: warning Deprecated
+See [deprecation notices](/react/guides/migrate-from-v1-to-v2#deprecated-usebalance-unit-parameter-and-formatted-return-value) for more info.
+:::
 
 ::: code-group
 ```ts [index.ts]


### PR DESCRIPTION
## Description

Add deprecated warning to the `unit` parameter in `useBalance`. Fix existing deprecated warning link for the `token` parameter.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.