### PR TITLE
docs: Add Ant Design Web3 to the Third-party Libraries for Connect Wallet

### DIFF
--- a/docs/react/guides/connect-wallet.md
+++ b/docs/react/guides/connect-wallet.md
@@ -12,6 +12,7 @@ You can use a pre-built Connect Wallet module from a third-party library such as
 - [Web3Modal](https://web3modal.com/) - [Guide](https://docs.walletconnect.com/web3modal/react/about)
 - [RainbowKit](https://www.rainbowkit.com/) - [Guide](https://www.rainbowkit.com/docs/installation)
 - [Dynamic](https://www.dynamic.xyz/) - [Guide](https://docs.dynamic.xyz/quickstart)
+- [Ant Design Web3](https://web3.ant.design/) - [Guide](https://web3.ant.design/guide/ant-design-web3)
 
 The above libraries are all built on top of Wagmi, handle all the edge cases around wallet connection, and provide a seamless Connect Wallet UX that you can use in your Dapp.
 


### PR DESCRIPTION
## Description

I'm a developer from the [Ant Design](https://github.com/ant-design) team, and we're currently building an open-source Web3 React component library [Ant Design Web3](https://github.com/ant-design/ant-design-web3). Wagmi is a fantastic open-source framework, and we're thrilled to be supporting Ethereum based on Wagmi. We hope to be able to mention the Ant Design Web3 in Wagmi's documentation, which is important for us as it can help get more developers to try our components and provide us with feedback.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
