### PR TITLE
feat: improve `UseMutationReturnType`

### DIFF
--- a/.changeset/large-apricots-grow.md
+++ b/.changeset/large-apricots-grow.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Replaced `Omit` with `UnionOmit` for `UseMutationReturnType`.

--- a/packages/react/src/utils/query.ts
+++ b/packages/react/src/utils/query.ts
@@ -15,6 +15,7 @@ import {
   type Evaluate,
   type ExactPartial,
   type Omit,
+  type UnionOmit,
   deepEqual,
 } from '@wagmi/core/internal'
 import { hashFn } from '@wagmi/core/query'
@@ -37,7 +38,7 @@ export type UseMutationReturnType<
   variables = void,
   context = unknown,
 > = Evaluate<
-  Omit<
+  UnionOmit<
     UseMutationResult<data, error, variables, context>,
     'mutate' | 'mutateAsync'
   >


### PR DESCRIPTION
Previously, `Omit` broke the discriminated union that was returned in `UseMutationReturnType`.

By using `UnionOmit`, the union is preserved.

## Description

What changes are made in this PR? Is it a feature or a bug fix?

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
