### PR TITLE
Fix return type of useWatchContractEvent which should be unsubscribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sherif": "^0.8.1",
     "simple-git-hooks": "^2.9.0",
     "typescript": "5.4.2",
-    "viem": "2.8.4",
+    "viem": "2.8.13",
     "vitest": "^0.34.5"
   },
   "packageManager": "pnpm@8.10.5",

--- a/packages/react/src/hooks/useWatchContractEvent.ts
+++ b/packages/react/src/hooks/useWatchContractEvent.ts
@@ -28,7 +28,7 @@ export type UseWatchContractEventParameters<
     EnabledParameter
 >
 
-export type UseWatchContractEventReturnType = void
+export type UseWatchContractEventReturnType = undefined | (() => void)
 
 /** https://wagmi.sh/react/api/hooks/useWatchContractEvent */
 export function useWatchContractEvent<
@@ -47,6 +47,7 @@ export function useWatchContractEvent<
   > = {} as any,
 ): UseWatchContractEventReturnType {
   const { enabled = true, onLogs, config: _, ...rest } = parameters
+  let unsubscribe: UseWatchContractEventReturnType
 
   const config = useConfig(parameters)
   const configChainId = useChainId()
@@ -55,10 +56,18 @@ export function useWatchContractEvent<
   useEffect(() => {
     if (!enabled) return
     if (!onLogs) return
-    return watchContractEvent(config, {
+    unsubscribe = watchContractEvent(config, {
       ...(rest as any),
       chainId,
       onLogs,
     })
-  }, [chainId, config, enabled, rest, onLogs])
+
+    return () => {
+      unsubscribe?.()
+    }
+  }, [chainId, config, enabled, rest, onLogs, unsubscribe])
+
+  return () => {
+    unsubscribe?.()
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 5.4.2
         version: 5.4.2
       viem:
-        specifier: 2.8.4
-        version: 2.8.4(typescript@5.4.2)
+        specifier: 2.8.13
+        version: 2.8.13(typescript@5.4.2)
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(@vitest/ui@0.34.5)(happy-dom@12.2.1)(jsdom@20.0.3)
@@ -6925,6 +6925,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: true
+    bundledDependencies: false
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -11711,8 +11712,8 @@ packages:
       - zod
     dev: false
 
-  /viem@2.8.4(typescript@5.4.2):
-    resolution: {integrity: sha512-zBC8+YNKzo+XeUsCyXdrFzimH9Ei/nRfUKldPmVRoR/lR56/sqkDPyfCE1yvzwwmA9AJ9m9m2HtSPgl9NiTReA==}
+  /viem@2.8.13(typescript@5.4.2):
+    resolution: {integrity: sha512-jEbRUjsiBwmoDr3fnKL1Bh1GhK5ERhmZcPLeARtEaQoBTPB6bcO2siKhNPVOF8qrYRnGHGQrZHncBWMQhTjGYg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:


### PR DESCRIPTION
As per docs, the reutnr type of this hook should be unsubscribe

https://wagmi.sh/react/api/hooks/useWatchContractEvent#return-type

## Description

What changes are made in this PR? Is it a feature or a bug fix?

Bug. Returning `unsubscribe` correctly from `useWatchContractEvent` instead of void

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
