### PR TITLE
Update `useWatchContractEvent` return type description in docs

### DIFF
--- a/docs/react/api/hooks/useWatchContractEvent.md
+++ b/docs/react/api/hooks/useWatchContractEvent.md
@@ -406,7 +406,7 @@ function App() {
 import { type UseWatchContractEventReturnType } from 'wagmi'
 ```
 
-Function to unsubscribe from the event listener.
+Hook returns `void`
 
 ## Action
 


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

`useWatchContractEvent` docs incorrectly stated that return type is unsubscribe function, while in reality the return type is void

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
