### PR TITLE
Add Gnosis to Etherscan plugin

### DIFF
--- a/.changeset/violet-pianos-tickle.md
+++ b/.changeset/violet-pianos-tickle.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Added Gnosis to Etherscan plugin.

--- a/docs/cli/api/plugins/etherscan.md
+++ b/docs/cli/api/plugins/etherscan.md
@@ -40,6 +40,9 @@ The following Etherscan block explorers and their testnets are supported (e.g. E
 - [HecoScan](https://hecoinfo.com)
 - [Optimistic Etherscan](https://optimistic.etherscan.io)
 - [PolygonScan](https://polygonscan.com)
+- [CeloScan](https://celoscan.io)
+- [FraxScan](https://fraxscan.com)
+- [GnosisScan](https://gnosisscan.io)
 
 ## Configuration
 

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -37,6 +37,8 @@ const apiUrls = {
   // Fraxtal
   [252]: 'https://api.fraxscan.com/api',
   [2522]: 'https://api-holesky.fraxscan.com/api',
+  // Gnosis
+  [100]: 'https://api.gnosisscan.io/api',
 }
 type ChainId = keyof typeof apiUrls
 
@@ -55,6 +57,7 @@ export type EtherscanConfig<chainId extends number> = {
    * - [__Optimism__](https://optimistic.etherscan.io/myapikey)
    * - [__Polygon__](https://polygonscan.com/myapikey)
    * - [__Fraxtal__](https://fraxscan.com/myapikey)
+   * - [__Gnosis__](https://gnosisscan.io/myapikey)
    */
   apiKey: string
   /**


### PR DESCRIPTION
## Description

Add Gnosis Chain support to Etherscan plugin.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.
