### PR TITLE
Add missing requirement "strictNullChecks: true" to typescript sections in docs

### DIFF
--- a/docs/core/typescript.md
+++ b/docs/core/typescript.md
@@ -16,13 +16,14 @@ Wagmi Core is designed to be as type-safe as possible! Things to keep in mind:
 - It is highly recommended that you lock your `@wagmi/core` and `typescript` versions to specific patch releases and upgrade with the expectation that types may be fixed or upgraded between any release.
 - The non-type-related public API of Wagmi Core still follows semver very strictly.
 
-To ensure everything works correctly, make sure your `tsconfig.json` has [`strict`](https://www.typescriptlang.org/tsconfig#strict) mode set to `true`.
+To ensure everything works correctly, make sure your `tsconfig.json` has [`strict`](https://www.typescriptlang.org/tsconfig#strict) and [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) modes set to `true`.
 
 ::: code-group
 ```json [tsconfig.json]
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "strictNullChecks": true
   }
 }
 ```

--- a/docs/react/typescript.md
+++ b/docs/react/typescript.md
@@ -16,13 +16,14 @@ Wagmi is designed to be as type-safe as possible! Things to keep in mind:
 - It is highly recommended that you lock your `wagmi` and `typescript` versions to specific patch releases and upgrade with the expectation that types may be fixed or upgraded between any release.
 - The non-type-related public API of Wagmi still follows semver very strictly.
 
-To ensure everything works correctly, make sure your `tsconfig.json` has [`strict`](https://www.typescriptlang.org/tsconfig#strict) mode set to `true`.
+To ensure everything works correctly, make sure your `tsconfig.json` has [`strict`](https://www.typescriptlang.org/tsconfig#strict) and [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) modes set to `true`.
 
 ::: code-group
 ```json [tsconfig.json]
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "strictNullChecks": true
   }
 }
 ```


### PR DESCRIPTION
## Description

- Added note about required `"strictNullChecks: true"` to typescript sections in core/docs and react/docs

## Additional Information
Without this option, there are many problems with types in wagmi methods and hooks.

A simple example taken from one of yours [tsplayground](https://www.typescriptlang.org/play?strictNullChecks=false#code/JYWwDg9gTgLgBAbzgVwM4FMBK6CGATAYQgDsYocBjGVAGhQwHUpgZ0jTyq4BfOAMygQQcAOQB3HAHMQwEQChQkWIjjooFAEwAGAIIAjYD36DhIgG7B0IeXIolU8KOlTIANvAC89LLkIkylNQAFAhycHA4rq4QYgBiOMCuyE4AXPyRGDRhcHYcgahpANrZ4aHh5RF4eE6oBaJaAB4AbABCAIwA7ACsACwdPQCiABwAnFojPQQ9PQAiOCNDeiO9A+h46DpTyxodbXhasSJZFeE4BmlqmroGxyd8yMRUwCQAcjgg6GkiepE4j+gAeT4RxK5RwUEkdUKIkaPS6XQ67SGAw6HRGEx6LViAxGeA6Qx0TQ6GjhGgAzGS2gQ2kMmvM+D0hiIALq3cLcNmIUGnKo1Oow5rtbp9QajcaTaZzBZLFZrDZbLo7PYHEEnCLnVTqbT6YCc8L3R4wZ7EN4fL7rCigDKq8oc0FlE74arOfmNVqdXr9YZjCZTWbzRbLQZyzY9ba7faHPXq4AXLXXXXc-gPJ6vd6fUSoACeID0EFcNvZt1Zcm4AEo5LZ7PAkGJmKx2AEqDps48jF40OgmCw2P5ODAghWq8QHHBWA4ALLoGAACwgeDgXkHi4AfHA6z3G-2W1nHiFsk6+V83ULPaKfRL-dKg6t1qHw8qoweNZdtTdsgbUyb018fq4-hQgLArc4KQkUJblpWNRuDAAB0eA4DAOByAA9ChJwAHoAPxyEAA). There are:
- `Type instantiation is excessively deep and possibly infinite` ts error on `useReadContracts`. 
- No type narrowing for `functionName` and `args` in `writeContractAsync`.

Also, type inference doesn't work in other places.
But everything works fine, when `strictNullChecks` is `true` in a config.
