### PR TITLE
Add basescan to etherscan plugin

### DIFF
--- a/.changeset/olive-pears-wink.md
+++ b/.changeset/olive-pears-wink.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-Add basescan to etherscan cli plugin
+Added basescan to etherscan cli plugin

--- a/.changeset/olive-pears-wink.md
+++ b/.changeset/olive-pears-wink.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Add basescan to etherscan cli plugin

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -12,6 +12,9 @@ const apiUrls = {
   [10]: 'https://api-optimistic.etherscan.io/api',
   [420]: 'https://api-goerli-optimistic.etherscan.io/api',
   [11_155_420]: 'https://api-sepolia-optimistic.etherscan.io/api',
+  // Base
+  [84532]: 'https://api-sepolia.basescan.org/api',
+  [8453]: 'https://api.basescan.org/api',
   // Polygon
   [137]: 'https://api.polygonscan.com/api',
   [80_001]: 'https://api-testnet.polygonscan.com/api',

--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -58,6 +58,7 @@ export type EtherscanConfig<chainId extends number> = {
    * - [__Fantom__](https://ftmscan.com/myapikey)
    * - [__Heco Chain__](https://hecoinfo.com/myapikey)
    * - [__Optimism__](https://optimistic.etherscan.io/myapikey)
+   * - [__Base__](https://basescan.org/myapikey)
    * - [__Polygon__](https://polygonscan.com/myapikey)
    * - [__Fraxtal__](https://fraxscan.com/myapikey)
    * - [__Gnosis__](https://gnosisscan.io/myapikey)


### PR DESCRIPTION
Sourced from https://docs.basescan.org/getting-started/endpoint-urls

## Description
This adds Base and Base Sepolia to the `@wagmi/cli/plugins` for Etherscan.

## Additional Information

Didn't test -- just sourced the URLs and chain IDs from https://docs.basescan.org/getting-started/endpoint-urls 

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [x] Added documentation related to the changes made.
- [😬] Added or updated tests (and snapshots) related to the changes made.
