### PR TITLE
fix: getConnectorClient account comparison

### DIFF
--- a/.changeset/hip-owls-battle.md
+++ b/.changeset/hip-owls-battle.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `getConnectorClient` internal address comparison.

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -39,7 +39,7 @@ test('behavior: account does not exist on connector', async () => {
   await expect(
     getConnectorClient(config, { account: address.usdcHolder }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    "Account \\"0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078\\" not found for connector \\"Mock Connector\\".
+    "Account \\"0x5414d89a8bF7E99d732BC52f3e6A3Ef461c0C078\\" not found for connector \\"Mock Connector\\".
 
     Version: @wagmi/core@x.y.z"
   `)

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -24,6 +24,17 @@ test('parameters: connector', async () => {
 
 test.todo('custom connector client')
 
+test('behavior: account address is checksummed', async () => {
+  await connect(config, { connector })
+  const account = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+  const client = await getConnectorClient(config, { account })
+  expect(client.account.address).toMatchInlineSnapshot(
+    '"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"',
+  )
+  expect(client.account.address).not.toBe(account)
+  await disconnect(config, { connector })
+})
+
 test('behavior: not connected', async () => {
   await expect(
     getConnectorClient(config),

--- a/packages/core/src/actions/getConnectorClient.ts
+++ b/packages/core/src/actions/getConnectorClient.ts
@@ -6,8 +6,8 @@ import {
   createClient,
   custom,
 } from 'viem'
-
 import { getAddress, parseAccount } from 'viem/utils'
+
 import type { Config, Connection } from '../createConfig.js'
 import type { ErrorType } from '../errors/base.js'
 import {
@@ -84,12 +84,12 @@ export async function getConnectorClient<
 
   // Default using `custom` transport
   const account = parseAccount(parameters.account ?? connection.accounts[0]!)
+  account.address = getAddress(account.address) // TODO: Checksum address as part of `parseAccount`?
+
   const chain = config.chains.find((chain) => chain.id === chainId)
   const provider = (await connection.connector.getProvider({ chainId })) as {
     request(...args: any): Promise<any>
   }
-
-  account.address = getAddress(account.address)
 
   // if account was provided, check that it exists on the connector
   if (parameters.account && !connection.accounts.includes(account.address))

--- a/packages/core/src/actions/getConnectorClient.ts
+++ b/packages/core/src/actions/getConnectorClient.ts
@@ -7,7 +7,7 @@ import {
   custom,
 } from 'viem'
 
-import { parseAccount } from 'viem/utils'
+import { getAddress, parseAccount } from 'viem/utils'
 import type { Config, Connection } from '../createConfig.js'
 import type { ErrorType } from '../errors/base.js'
 import {
@@ -88,6 +88,8 @@ export async function getConnectorClient<
   const provider = (await connection.connector.getProvider({ chainId })) as {
     request(...args: any): Promise<any>
   }
+
+  account.address = getAddress(account.address)
 
   // if account was provided, check that it exists on the connector
   if (parameters.account && !connection.accounts.includes(account.address))


### PR DESCRIPTION
## Description

Fixes `getConnectorClient` `account` comparison

https://github.com/wevm/wagmi/pull/3605

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.
