### PR TITLE
add walletkit to thrid-party libraries list

### DIFF
--- a/docs/core/why.md
+++ b/docs/core/why.md
@@ -32,7 +32,7 @@ Wagmi Core supports the most popular and commonly-used Ethereum features out of 
 
 If you need lower-level control, you can always drop down to [Viem](https://viem.sh), which Wagmi Core uses internally to perform blockchain operations. Wagmi Core also manages multi-chain support automatically so developers can focus on their applications instead of adding custom code.
 
-Finally, Wagmi Core has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [Web3Modal](https://web3modal.com), [Dynamic](https://www.dynamic.xyz), and many more, so you can get started quickly without needing to build everything from scratch.
+Finally, Wagmi Core has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [Web3Modal](https://web3modal.com), [Dynamic](https://www.dynamic.xyz), [WalletKit](https://walletkit.com/) and many more, so you can get started quickly without needing to build everything from scratch.
 
 ## Stability
 

--- a/docs/react/guides/connect-wallet.md
+++ b/docs/react/guides/connect-wallet.md
@@ -12,6 +12,7 @@ You can use a pre-built Connect Wallet module from a third-party library such as
 - [Web3Modal](https://web3modal.com/) - [Guide](https://docs.walletconnect.com/web3modal/react/about)
 - [RainbowKit](https://www.rainbowkit.com/) - [Guide](https://www.rainbowkit.com/docs/installation)
 - [Dynamic](https://www.dynamic.xyz/) - [Guide](https://docs.dynamic.xyz/quickstart)
+- [WalletKit](https://walletkit.com/) - [Guide](https://docs.walletkit.com/link/installation)
 
 The above libraries are all built on top of Wagmi, handle all the edge cases around wallet connection, and provide a seamless Connect Wallet UX that you can use in your Dapp.
 

--- a/docs/react/why.md
+++ b/docs/react/why.md
@@ -32,7 +32,7 @@ Wagmi supports the most popular and commonly-used Ethereum features out of the b
 
 If you need lower-level control, you can always drop down to [Wagmi Core](/core/getting-started) or [Viem](https://viem.sh), which Wagmi uses internally to perform blockchain operations. Wagmi also manages multi-chain support automatically so developers can focus on their applications instead of adding custom code.
 
-Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [Web3Modal](https://web3modal.com), [Dynamic](https://www.dynamic.xyz), and many more, so you can get started quickly without needing to build everything from scratch.
+Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [Web3Modal](https://web3modal.com), [Dynamic](https://www.dynamic.xyz), [WalletKit](https://walletkit.com/) and many more, so you can get started quickly without needing to build everything from scratch.
 
 ## Stability
 


### PR DESCRIPTION
## Description

Hi team, this PR adds [WalletKit](https://walletkit.com/) to the third-party libraries list alongside similar libraries. WalletKit has full support for wagmi: https://docs.walletkit.com/link/installation

We're here to answer any questions. Thanks!

What changes are made in this PR? Is it a feature or a bug fix?
docs update

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ x ] Read the [contributing guide](https://wagmi.sh/dev/contributing)
- [ x ] Added documentation related to the changes made.
- [ x ] Added or updated tests (and snapshots) related to the changes made.
