### PR TITLE
Fix `writeContract` `chainId` forwarding during contract call simulation

### DIFF
--- a/.changeset/big-guests-live.md
+++ b/.changeset/big-guests-live.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `writeContract` to forward `chainIn` when simulating contract call

--- a/packages/core/src/actions/writeContract.ts
+++ b/packages/core/src/actions/writeContract.ts
@@ -106,8 +106,8 @@ export async function writeContract<
   else {
     const { request: simulateRequest } = await simulateContract(config, {
       ...rest,
-      chainId,
       account,
+      chainId,
     } as any)
     request = simulateRequest
   }

--- a/packages/core/src/actions/writeContract.ts
+++ b/packages/core/src/actions/writeContract.ts
@@ -106,6 +106,7 @@ export async function writeContract<
   else {
     const { request: simulateRequest } = await simulateContract(config, {
       ...rest,
+      chainId,
       account,
     } as any)
     request = simulateRequest


### PR DESCRIPTION
## Description

`chainId` was not forwarded to the simulation call which was leading to calling wrong RPC node
