### PR TITLE
fix: metamask chain switch with missing net_version

### DIFF
--- a/.changeset/tough-steaks-rush.md
+++ b/.changeset/tough-steaks-rush.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Added workaround to injected connector for MetaMask bug, where chain switching does not work if target chain RPC `'net_version'` request fails.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -388,13 +388,11 @@ export function injected(parameters: InjectedParameters = {}) {
               method: 'wallet_switchEthereumChain',
               params: [{ chainId: numberToHex(chainId) }],
             })
-            // MetaMask makes a `net_version` RPC call to the target chain during `wallet_switchEthereumChain`.
-            // If this request fails, MetaMask doesn't emit a `chainChanged` event, but will still switch the chain.
-            // See https://github.com/MetaMask/metamask-extension/issues/24247
-            //
-            // To work around this, we can ask MetaMask for the current chain ID and emit our internal `changed`
-            // event as if the chain has changed. This will allow the promise below to also resolve. We still want to
-            // wait for the `change` event in case the `eth_chainId` check fails or isn't immediately available.
+            // During `'wallet_switchEthereumChain'`, MetaMask makes a `'net_version'` RPC call to the target chain.
+            // If this request fails, MetaMask does not emit the `'chainChanged'` event, but will still switch the chain.
+            // To counter this behavior, we request and emit the current chain ID to confirm the chain switch either via
+            // this callback or an externally emitted `'chainChanged'` event.
+            // https://github.com/MetaMask/metamask-extension/issues/24247
             .then(async () => {
               const currentChainId = await this.getChainId()
               if (currentChainId === chainId)


### PR DESCRIPTION
### Description

This is a workaround for the issue described in https://github.com/MetaMask/metamask-extension/issues/24247.

I've left a big inline comment explaining everything.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
