### PR TITLE
feat: connector property to skip contract simulation

### DIFF
--- a/.changeset/twelve-walls-deny.md
+++ b/.changeset/twelve-walls-deny.md
@@ -4,4 +4,4 @@
 "wagmi": minor
 ---
 
-Added `supportsSimulation` property to connectors.
+Added `supportsSimulation` property to connectors that indicates if the connector's wallet supports contract simulation.

--- a/.changeset/twelve-walls-deny.md
+++ b/.changeset/twelve-walls-deny.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": minor
+"@wagmi/core": minor
+"wagmi": minor
+---
+
+Added `skipSimulateContract` property to connectors.

--- a/.changeset/twelve-walls-deny.md
+++ b/.changeset/twelve-walls-deny.md
@@ -4,4 +4,4 @@
 "wagmi": minor
 ---
 
-Added `skipSimulateContract` property to connectors.
+Added `supportsSimulation` property to connectors.

--- a/docs/dev/creating-connectors.md
+++ b/docs/dev/creating-connectors.md
@@ -54,7 +54,7 @@ The type error tells you what properties are missing from `createConnector`'s re
 - `icon`: Optional icon URL for the connector.
 - `id`: The ID for the connector. This should be camel-cased and as short as possible. Example: `fooBarBaz`.
 - `name`: Human-readable name for the connector. Example: `'Foo Bar Baz'`.
-- `skipSimulateContract`: Identifier to skip simulation for contract writes. This should be disabled if a connector's wallet cannot accurately simulate contract writes or display contract revert messages. Defaults to `false`.
+- `supportsSimulation`: Whether the connector supports contract simulation. This should be disabled if a connector's wallet cannot accurately simulate contract writes or display contract revert messages. Defaults to `false`.
 
 #### Methods
 

--- a/docs/dev/creating-connectors.md
+++ b/docs/dev/creating-connectors.md
@@ -54,6 +54,7 @@ The type error tells you what properties are missing from `createConnector`'s re
 - `icon`: Optional icon URL for the connector.
 - `id`: The ID for the connector. This should be camel-cased and as short as possible. Example: `fooBarBaz`.
 - `name`: Human-readable name for the connector. Example: `'Foo Bar Baz'`.
+- `skipSimulateContract`: Identifier to skip simulation for contract writes. This should be disabled if a connector's wallet cannot accurately simulate contract writes or display contract revert messages. Defaults to `false`.
 
 #### Methods
 

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -59,6 +59,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'coinbaseWalletSDK',
     name: 'Coinbase Wallet',
+    skipSimulateContract: false,
     type: coinbaseWallet.type,
     async connect({ chainId } = {}) {
       try {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -59,7 +59,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'coinbaseWalletSDK',
     name: 'Coinbase Wallet',
-    supportsSimulation: false,
+    supportsSimulation: true,
     type: coinbaseWallet.type,
     async connect({ chainId } = {}) {
       try {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -59,7 +59,7 @@ export function coinbaseWallet(parameters: CoinbaseWalletParameters) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'coinbaseWalletSDK',
     name: 'Coinbase Wallet',
-    skipSimulateContract: false,
+    supportsSimulation: false,
     type: coinbaseWallet.type,
     async connect({ chainId } = {}) {
       try {

--- a/packages/core/src/actions/sendTransaction.test.ts
+++ b/packages/core/src/actions/sendTransaction.test.ts
@@ -75,7 +75,6 @@ test('behavior: value exceeds balance', async () => {
       from:   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
       to:     0xd2135CfB216b74109775236E36d4b433F1DF507B
       value:  99999 ETH
-      gas:    21000
 
     Details: Insufficient funds for gas * price + value
     Version: viem@2.8.4"

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -82,7 +82,7 @@ export async function sendTransaction<
     if (!('data' in parameters) || !parameters.data) return undefined
 
     // Skip gas estimation if connector specifies.
-    if (activeConnector?.skipSimulateContract) return undefined
+    if (activeConnector?.supportsSimulation) return undefined
 
     // Skip gas estimation if `null` is provided.
     if (gas_ === null) return undefined

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -81,7 +81,7 @@ export async function sendTransaction<
     // Skip gas estimation if `data` doesn't exist (not a contract interaction).
     if (!('data' in parameters) || !parameters.data) return undefined
 
-    // Skip gas estimation if connector specifies.
+    // Skip gas estimation if connector supports simulation.
     if (activeConnector?.supportsSimulation) return undefined
 
     // Skip gas estimation if `null` is provided.

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types/properties.js'
 import { type Evaluate } from '../types/utils.js'
 import { getAction } from '../utils/getAction.js'
+import { getAccount } from './getAccount.js'
 import {
   type GetConnectorClientErrorType,
   getConnectorClient,
@@ -74,7 +75,15 @@ export async function sendTransaction<
   else
     client = await getConnectorClient(config, { account, chainId, connector })
 
+  const { connector: activeConnector } = getAccount(config)
+
   const gas = await (async () => {
+    // Skip gas estimation if `data` doesn't exist (likely not a contract interaction).
+    if (!('data' in parameters) || !parameters.data) return undefined
+
+    // Skip gas estimation if connector specifies.
+    if (activeConnector?.skipSimulateContract) return undefined
+
     // Skip gas estimation if `null` is provided.
     if (gas_ === null) return undefined
 

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -78,7 +78,7 @@ export async function sendTransaction<
   const { connector: activeConnector } = getAccount(config)
 
   const gas = await (async () => {
-    // Skip gas estimation if `data` doesn't exist (likely not a contract interaction).
+    // Skip gas estimation if `data` doesn't exist (not a contract interaction).
     if (!('data' in parameters) || !parameters.data) return undefined
 
     // Skip gas estimation if connector specifies.

--- a/packages/core/src/actions/writeContract.ts
+++ b/packages/core/src/actions/writeContract.ts
@@ -105,7 +105,7 @@ export async function writeContract<
   const { connector: activeConnector } = getAccount(config)
 
   let request
-  if (__mode === 'prepared' || activeConnector?.skipSimulateContract)
+  if (__mode === 'prepared' || activeConnector?.supportsSimulation)
     request = rest
   else {
     const { request: simulateRequest } = await simulateContract(config, {

--- a/packages/core/src/actions/writeContract.ts
+++ b/packages/core/src/actions/writeContract.ts
@@ -21,6 +21,7 @@ import {
 } from '../types/properties.js'
 import type { Evaluate, UnionEvaluate, UnionOmit } from '../types/utils.js'
 import { getAction } from '../utils/getAction.js'
+import { getAccount } from './getAccount.js'
 import {
   type GetConnectorClientErrorType,
   getConnectorClient,
@@ -101,8 +102,11 @@ export async function writeContract<
   else
     client = await getConnectorClient(config, { account, chainId, connector })
 
+  const { connector: activeConnector } = getAccount(config)
+
   let request
-  if (__mode === 'prepared') request = rest
+  if (__mode === 'prepared' || activeConnector?.skipSimulateContract)
+    request = rest
   else {
     const { request: simulateRequest } = await simulateContract(config, {
       ...rest,

--- a/packages/core/src/connectors/createConnector.ts
+++ b/packages/core/src/connectors/createConnector.ts
@@ -34,6 +34,7 @@ export type CreateConnectorFn<
     readonly icon?: string | undefined
     readonly id: string
     readonly name: string
+    readonly skipSimulateContract?: boolean | undefined
     readonly type: string
 
     setup?(): Promise<void>

--- a/packages/core/src/connectors/createConnector.ts
+++ b/packages/core/src/connectors/createConnector.ts
@@ -34,7 +34,7 @@ export type CreateConnectorFn<
     readonly icon?: string | undefined
     readonly id: string
     readonly name: string
-    readonly skipSimulateContract?: boolean | undefined
+    readonly supportsSimulation?: boolean | undefined
     readonly type: string
 
     setup?(): Promise<void>

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -35,7 +35,7 @@ export type InjectedParameters = {
 }
 
 // Regex of wallets/providers that can accurately simulate contract calls & display contract revert reasons.
-const skipSimulateContractRegex = /(rabby|trustwallet)/
+const skipSimulateContractIdRegex = /(rabby|trustwallet)/
 
 const targetMap = {
   coinbaseWallet: {
@@ -145,7 +145,7 @@ export function injected(parameters: InjectedParameters = {}) {
       return getTarget().name
     },
     get skipSimulateContract() {
-      return skipSimulateContractRegex.test(this.id.toLowerCase())
+      return skipSimulateContractIdRegex.test(this.id.toLowerCase())
     },
     type: injected.type,
     async setup() {

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -34,6 +34,9 @@ export type InjectedParameters = {
   target?: TargetId | Target | (() => Target | undefined) | undefined
 }
 
+// Regex of wallets/providers that can accurately simulate contract calls & display contract revert reasons.
+const skipSimulateContractRegex = /(rabby|trustwallet)/
+
 const targetMap = {
   coinbaseWallet: {
     id: 'coinbaseWallet',
@@ -140,6 +143,10 @@ export function injected(parameters: InjectedParameters = {}) {
     },
     get name() {
       return getTarget().name
+    },
+    get skipSimulateContract() {
+      console.log(this.id)
+      return skipSimulateContractRegex.test(this.id.toLowerCase())
     },
     type: injected.type,
     async setup() {

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -35,7 +35,7 @@ export type InjectedParameters = {
 }
 
 // Regex of wallets/providers that can accurately simulate contract calls & display contract revert reasons.
-const skipSimulateContractIdRegex = /(rabby|trustwallet)/
+const supportsSimulationIdRegex = /(rabby|trustwallet)/
 
 const targetMap = {
   coinbaseWallet: {
@@ -144,8 +144,8 @@ export function injected(parameters: InjectedParameters = {}) {
     get name() {
       return getTarget().name
     },
-    get skipSimulateContract() {
-      return skipSimulateContractIdRegex.test(this.id.toLowerCase())
+    get supportsSimulation() {
+      return supportsSimulationIdRegex.test(this.id.toLowerCase())
     },
     type: injected.type,
     async setup() {

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -145,7 +145,6 @@ export function injected(parameters: InjectedParameters = {}) {
       return getTarget().name
     },
     get skipSimulateContract() {
-      console.log(this.id)
       return skipSimulateContractRegex.test(this.id.toLowerCase())
     },
     type: injected.type,


### PR DESCRIPTION
### Description

Adds a property to the connector to indicate whether it supports contract simulation. We can defer contract write simulation to the connector's wallet if it can accurately simulate the contract write & display contract revert reasons correctly. 

As a result, the time between user interaction and the wallet opening[^1] will become nearly instantaneous. 

This means it will resolve the issue of iOS Safari popup & universal link dismissal[^2] which some connectors rely on (ie. Coinbase Smart Wallet & the MetaMask SDK), provided that their wallets can accurately simulate contract write calls.

[^1]: TTOW: Time To Open Wallet.
[^2]: These dismissals occur if the intent does not get invoked within ~500ms of user interaction.

