### PR TITLE
feat: add `.npmrc` to create-wagmi templates

### DIFF
--- a/.changeset/eighty-insects-love.md
+++ b/.changeset/eighty-insects-love.md
@@ -1,0 +1,5 @@
+---
+"create-wagmi": patch
+---
+
+Added `.npmrc` with `legacy-peer-deps = true` to templates.

--- a/packages/create-wagmi/src/cli.ts
+++ b/packages/create-wagmi/src/cli.ts
@@ -46,6 +46,7 @@ const cwd = process.cwd()
 const renameFiles: Record<string, string | undefined> = {
   '_env.local': '.env.local',
   _gitignore: '.gitignore',
+  _npmrc: '.npmrc',
 }
 
 const defaultTargetDir = 'wagmi-project'

--- a/packages/create-wagmi/templates/next/_npmrc
+++ b/packages/create-wagmi/templates/next/_npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps = true

--- a/packages/create-wagmi/templates/vite-react/_npmrc
+++ b/packages/create-wagmi/templates/vite-react/_npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps = true

--- a/packages/create-wagmi/templates/vite-vanilla/_npmrc
+++ b/packages/create-wagmi/templates/vite-vanilla/_npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps = true


### PR DESCRIPTION
### Description

Adds `.npmrc` with `legacy-peer-deps = true`. Seems that npm automatically installs optional peerdeps causing the initial install to take a while.
