### PR TITLE
fix: TrustWallet getAccounts error

### DIFF
--- a/.changeset/odd-lobsters-beg.md
+++ b/.changeset/odd-lobsters-beg.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Handle providers who are throwing errors when calling getAccounts

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -276,7 +276,9 @@ export function injected(parameters: InjectedParameters = {}) {
     async getAccounts() {
       const provider = await this.getProvider()
       if (!provider) throw new ProviderNotFoundError()
-      const accounts = await provider.request({ method: 'eth_accounts' })
+      const accounts = await provider
+        .request({ method: 'eth_accounts' })
+        .catch(() => [])
       return accounts.map((x) => getAddress(x))
     },
     async getChainId() {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
It seems that TrustWallet returns an error instead of a `[]` on some `getAccounts` call, this PR should fallback to `[]` all the time instead of throwing an error.
![image](https://github.com/wevm/wagmi/assets/2752200/c2a43351-6280-4722-982b-5bbff9a17592)
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
