### PR TITLE
feat: engrained connector exports

### DIFF
--- a/.changeset/quiet-bananas-retire.md
+++ b/.changeset/quiet-bananas-retire.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": patch
+"wagmi": patch
+"@wagmi/core": patch
+---
+
+Added engrained exports for Connectors (e.g. `wagmi/connectors/metaMask`).

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -32,6 +32,22 @@
       "types": "./dist/types/exports/index.d.ts",
       "default": "./dist/esm/exports/index.js"
     },
+    "./coinbaseWallet": {
+      "types": "./dist/types/exports/coinbaseWallet.d.ts",
+      "default": "./dist/esm/exports/coinbaseWallet.js"
+    },
+    "./metaMask": {
+      "types": "./dist/types/exports/metaMask.d.ts",
+      "default": "./dist/esm/exports/metaMask.js"
+    },
+    "./safe": {
+      "types": "./dist/types/exports/safe.d.ts",
+      "default": "./dist/esm/exports/safe.js"
+    },
+    "./walletConnect": {
+      "types": "./dist/types/exports/walletConnect.d.ts",
+      "default": "./dist/esm/exports/walletConnect.js"
+    },
     "./package.json": "./package.json"
   },
   "peerDependencies": {
@@ -56,10 +72,7 @@
     "@wagmi/core": "workspace:*",
     "msw": "^2.2.14"
   },
-  "contributors": [
-    "awkweb.eth <t@wevm.dev>",
-    "jxom.eth <j@wevm.dev>"
-  ],
+  "contributors": ["awkweb.eth <t@wevm.dev>", "jxom.eth <j@wevm.dev>"],
   "funding": "https://github.com/sponsors/wevm",
   "keywords": [
     "react",

--- a/packages/connectors/src/exports/coinbaseWallet.test.ts
+++ b/packages/connectors/src/exports/coinbaseWallet.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './coinbaseWallet.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "coinbaseWallet",
+    ]
+  `)
+})

--- a/packages/connectors/src/exports/coinbaseWallet.ts
+++ b/packages/connectors/src/exports/coinbaseWallet.ts
@@ -1,0 +1,4 @@
+export {
+  type CoinbaseWalletParameters,
+  coinbaseWallet,
+} from '../coinbaseWallet.js'

--- a/packages/connectors/src/exports/metaMask.test.ts
+++ b/packages/connectors/src/exports/metaMask.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './metaMask.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "metaMask",
+    ]
+  `)
+})

--- a/packages/connectors/src/exports/metaMask.ts
+++ b/packages/connectors/src/exports/metaMask.ts
@@ -1,0 +1,4 @@
+export {
+  type MetaMaskParameters,
+  metaMask,
+} from '../metaMask.js'

--- a/packages/connectors/src/exports/safe.test.ts
+++ b/packages/connectors/src/exports/safe.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './safe.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "safe",
+    ]
+  `)
+})

--- a/packages/connectors/src/exports/safe.ts
+++ b/packages/connectors/src/exports/safe.ts
@@ -1,0 +1,4 @@
+export {
+  type SafeParameters,
+  safe,
+} from '../safe.js'

--- a/packages/connectors/src/exports/walletConnect.test.ts
+++ b/packages/connectors/src/exports/walletConnect.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './walletConnect.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "walletConnect",
+    ]
+  `)
+})

--- a/packages/connectors/src/exports/walletConnect.ts
+++ b/packages/connectors/src/exports/walletConnect.ts
@@ -1,0 +1,4 @@
+export {
+  type WalletConnectParameters,
+  walletConnect,
+} from '../walletConnect.js'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,22 @@
       "types": "./dist/types/exports/connectors.d.ts",
       "default": "./dist/esm/exports/connectors.js"
     },
+    "./connectors/coinbaseWallet": {
+      "types": "./dist/types/exports/connectors/coinbaseWallet.d.ts",
+      "default": "./dist/esm/exports/connectors/coinbaseWallet.js"
+    },
+    "./connectors/metaMask": {
+      "types": "./dist/types/exports/connectors/metaMask.d.ts",
+      "default": "./dist/esm/exports/connectors/metaMask.js"
+    },
+    "./connectors/safe": {
+      "types": "./dist/types/exports/connectors/safe.d.ts",
+      "default": "./dist/esm/exports/connectors/safe.js"
+    },
+    "./connectors/walletConnect": {
+      "types": "./dist/types/exports/connectors/walletConnect.d.ts",
+      "default": "./dist/esm/exports/connectors/walletConnect.js"
+    },
     "./experimental": {
       "types": "./dist/types/exports/experimental.d.ts",
       "default": "./dist/esm/exports/experimental.js"
@@ -66,24 +82,12 @@
   },
   "typesVersions": {
     "*": {
-      "actions": [
-        "./dist/types/exports/actions.d.ts"
-      ],
-      "chains": [
-        "./dist/types/exports/chains.d.ts"
-      ],
-      "codegen": [
-        "./dist/types/exports/codegen.d.ts"
-      ],
-      "connectors": [
-        "./dist/types/exports/connectors.d.ts"
-      ],
-      "experimental": [
-        "./dist/types/exports/experimental.d.ts"
-      ],
-      "query": [
-        "./dist/types/exports/query.d.ts"
-      ]
+      "actions": ["./dist/types/exports/actions.d.ts"],
+      "chains": ["./dist/types/exports/chains.d.ts"],
+      "codegen": ["./dist/types/exports/codegen.d.ts"],
+      "connectors": ["./dist/types/exports/connectors.d.ts"],
+      "experimental": ["./dist/types/exports/experimental.d.ts"],
+      "query": ["./dist/types/exports/query.d.ts"]
     }
   },
   "peerDependencies": {
@@ -111,10 +115,7 @@
     "react": ">=18.3.1",
     "react-dom": ">=18.3.1"
   },
-  "contributors": [
-    "awkweb.eth <t@wevm.dev>",
-    "jxom.eth <j@wevm.dev>"
-  ],
+  "contributors": ["awkweb.eth <t@wevm.dev>", "jxom.eth <j@wevm.dev>"],
   "funding": "https://github.com/sponsors/wevm",
   "keywords": [
     "wagmi",

--- a/packages/react/src/exports/connectors/coinbaseWallet.test.ts
+++ b/packages/react/src/exports/connectors/coinbaseWallet.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './coinbaseWallet.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "coinbaseWallet",
+    ]
+  `)
+})

--- a/packages/react/src/exports/connectors/coinbaseWallet.ts
+++ b/packages/react/src/exports/connectors/coinbaseWallet.ts
@@ -1,0 +1,4 @@
+export {
+  type CoinbaseWalletParameters,
+  coinbaseWallet,
+} from '@wagmi/connectors/coinbaseWallet'

--- a/packages/react/src/exports/connectors/metaMask.test.ts
+++ b/packages/react/src/exports/connectors/metaMask.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './metaMask.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "metaMask",
+    ]
+  `)
+})

--- a/packages/react/src/exports/connectors/metaMask.ts
+++ b/packages/react/src/exports/connectors/metaMask.ts
@@ -1,0 +1,4 @@
+export {
+  type MetaMaskParameters,
+  metaMask,
+} from '@wagmi/connectors/metaMask'

--- a/packages/react/src/exports/connectors/safe.test.ts
+++ b/packages/react/src/exports/connectors/safe.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './safe.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "safe",
+    ]
+  `)
+})

--- a/packages/react/src/exports/connectors/safe.ts
+++ b/packages/react/src/exports/connectors/safe.ts
@@ -1,0 +1,4 @@
+export {
+  type SafeParameters,
+  safe,
+} from '@wagmi/connectors/safe'

--- a/packages/react/src/exports/connectors/walletConnect.test.ts
+++ b/packages/react/src/exports/connectors/walletConnect.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import * as exports from './walletConnect.js'
+
+test('exports', () => {
+  expect(Object.keys(exports)).toMatchInlineSnapshot(`
+    [
+      "walletConnect",
+    ]
+  `)
+})

--- a/packages/react/src/exports/connectors/walletConnect.ts
+++ b/packages/react/src/exports/connectors/walletConnect.ts
@@ -1,0 +1,4 @@
+export {
+  type WalletConnectParameters,
+  walletConnect,
+} from '@wagmi/connectors/walletConnect'


### PR DESCRIPTION
### Description

Some bundlers (such as Vite) load entire modules **in the dev environment**[^1], instead of utilizing tree-shaking to omit unused modules.

As a result, this will invoke side-effects in certain dependencies of a connector which may not even be used by the consumer. For example: MetaMask depends on `react-dom` to render React in their popup, which [invokes a "Download the React DevTools" log in the browser in the dev environment](https://github.com/facebook/react/blob/04b058868c9fc61c78124b12efb168734d79d09e/packages/react-dom/src/client/ReactDOMClient.js#L59-L84)[^2]. Seeing this type of log does not make sense when you are building in a library/framework other than React.

To resolve this issue, I have added engrained connector exports to `@wagmi/connectors` & `wagmi` so that consumers can opt-out of this behavior. 

[^1]: ![image](https://github.com/wevm/wagmi/assets/7336481/b3bb9d75-f1c3-4c23-b245-a44a8e1b91eb)

[^2]: ![image](https://github.com/wevm/wagmi/assets/7336481/a63ef140-7a4c-4d94-af4e-c1c4e1deda00)

