### PR TITLE
feat(safe): add getInfo timeout

### DIFF
--- a/.changeset/hot-rules-deny.md
+++ b/.changeset/hot-rules-deny.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Added timeout to `getInfo` called in `safe` connector since [non-Safe App iFrames cause it to not resolve](https://github.com/safe-global/safe-apps-sdk/issues/263#issuecomment-1029835840).

--- a/.changeset/new-cobras-work.md
+++ b/.changeset/new-cobras-work.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Added catch to `reconnect`.

--- a/packages/connectors/src/safe.ts
+++ b/packages/connectors/src/safe.ts
@@ -20,8 +20,10 @@ export type SafeParameters = Evaluate<
      */
     shimDisconnect?: boolean | undefined
     /**
-     * `getInfo` (from the Safe SDK) does not resolve when not used in Safe App iFrame. This allows the connector to force a timeout.
-     * @default 100
+     * Timeout in milliseconds for `getInfo` (from the Safe SDK) to resolve.
+     *
+     * `getInfo` does not resolve when not used in Safe App iFrame. This allows the connector to force a timeout.
+     * @default 10
      */
     unstable_getInfoTimeout?: number | undefined
   }
@@ -102,7 +104,7 @@ export function safe(parameters: SafeParameters = {}) {
         // `getInfo` hangs when not used in Safe App iFrame
         // https://github.com/safe-global/safe-apps-sdk/issues/263#issuecomment-1029835840
         const safe = await withTimeout(() => sdk.safe.getInfo(), {
-          timeout: parameters.unstable_getInfoTimeout ?? 100,
+          timeout: parameters.unstable_getInfoTimeout ?? 10,
         })
         if (!safe) throw new Error('Could not load Safe information')
         const { SafeAppProvider } = await import(

--- a/packages/core/src/actions/reconnect.ts
+++ b/packages/core/src/actions/reconnect.ts
@@ -65,7 +65,7 @@ export async function reconnect(
   const connections: Connection[] = []
   const providers: unknown[] = []
   for (const connector of sorted) {
-    const provider_ = await connector.getProvider()
+    const provider_ = await connector.getProvider().catch(() => undefined)
     if (!provider_) continue
 
     // If we already have an instance of this connector's provider,


### PR DESCRIPTION
### Description

Adds timeout `getInfo` called in `safe` connector since [non-Safe App iFrames cause it to not resolve](https://github.com/safe-global/safe-apps-sdk/issues/263#issuecomment-1029835840).

Fixes https://github.com/wevm/wagmi/issues/3961

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
