### PR TITLE
Don't expose keysUrl

### DIFF
--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -69,7 +69,6 @@ type Version4Parameters = Mutable<
      * @default 'all'
      */
     preference?: Preference['options'] | undefined
-    keysUrl?: Preference['keysUrl'] | undefined
   }
 >
 


### PR DESCRIPTION
### Description

`keysUrl` is an option to open a url other than keys.coinbase.com in the popup. It's not useful to devs at this time.
