### PR TITLE
replacing snowscan with snowtrace

### DIFF
--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -32,8 +32,8 @@ const apiUrls = {
   [250]: 'https://api.ftmscan.com/api',
   [4_002]: 'https://api-testnet.ftmscan.com/api',
   // Avalanche
-  [43_114]: 'https://api.snowscan.xyz/api',
-  [43_113]: 'https://api-testnet.snowscan.xyz/api',
+  [43_114]: 'https://api.snowtrace.io/api',
+  [43_113]: 'https://api-testnet.snowtrace.io/api',
   // Celo
   [42_220]: 'https://api.celoscan.io/api',
   [44_787]: 'https://api-alfajores.celoscan.io/api',
@@ -54,7 +54,7 @@ export type EtherscanConfig<chainId extends number> = {
    * API keys are specific per network and include testnets (e.g. Ethereum Mainnet and Goerli share same API key). Create or manage keys:
    * - [__Ethereum__](https://etherscan.io/myapikey)
    * - [__Arbitrum__](https://arbiscan.io/myapikey)
-   * - [__Avalanche__](https://snowscan.xyz/myapikey)
+   * - [__Avalanche__](https://snowtrace.io/documentation#api-plans)
    * - [__BNB Smart Chain__](https://bscscan.com/myapikey)
    * - [__Celo__](https://celoscan.io/myapikey)
    * - [__Fantom__](https://ftmscan.com/myapikey)


### PR DESCRIPTION
Description
According to the [Avalanche documentation](https://docs.avax.network/build/dapp/launch-dapp), Snowtrace and testnet-snowtrace are the officially recommended block explorers for the Avalanche network. This change ensures that our users are directed to the most reliable and feature-rich explorer available.

Snowtrace has a significantly higher number of verified contracts compared to Snowscan, providing more reliable and secure information for users. For example, yesterday on May 27, 75 contracts were verified on snowtrace.io compared to 12 on snowscan.xyz. You can observe the differences in the number of verified contracts:

[Snowtrace verified contracts](https://snowtrace.io/chart?id=verified-contracts&metrics=ecosystem%3Aavalanche%3AVerified+Contracts%3A%23ef9b20%3Aday%3Alinear%3Aline%3Avisible%3Ay1%2Cchain%3A43114%3AVerified+Contracts%3A%2327aeef%3Aday%3Alogarithmic%3Acolumn%3Avisible%3Ay1&zoom=1week)
[Snowscan verified contracts](https://snowscan.xyz/contractsVerified)
Same case for testnet-snowtrace For example, on May 27, 44 contracts were verified on testnet.snowtrace.io compared to 0 on testnet.snowscan.xyz You can observe the differences in the number of verified contracts:

[Testnet - Snowtrace verified contracts](https://testnet.snowtrace.io/chart?id=verified-contracts&metrics=chain%3A43113%3AVerified+Contracts%3A%2327aeef%3Aday%3Alogarithmic%3Acolumn%3Avisible%3Ay1&zoom=1week)
[Testnet - Snowscan verified contracts](https://testnet.snowscan.xyz/contractsVerified)

Moreover snowtrace.io is 100% compliant with Etherscan APIs and supports the endpoint used in the code, getabi (e.g., https://api.snowtrace.io/api?module=contract&action=getabi&address=0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7).

Based on the data, developers use Snowtrace significantly more than Snowscan to verify contracts. This trend indicates that Snowtrace is the preferred choice among developers for contract verification. Therefore, it is important to use Snowtrace as the default block explorer to ensure our users have access to the most reliable and widely supported platform.
