### PR TITLE
cbw sdk version bump

### DIFF
--- a/.changeset/popular-files-worry.md
+++ b/.changeset/popular-files-worry.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Bump to @coinbase/wallet-sdk@4.0.3 with eth_chainId fix

--- a/.changeset/popular-files-worry.md
+++ b/.changeset/popular-files-worry.md
@@ -2,4 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Bump to @coinbase/wallet-sdk@4.0.3 with eth_chainId fix
+Bumped Coinbase Wallet SDK.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@coinbase/wallet-sdk": "4.0.2",
+    "@coinbase/wallet-sdk": "4.0.3",
     "@metamask/sdk": "0.20.3",
     "@safe-global/safe-apps-provider": "0.18.1",
     "@safe-global/safe-apps-sdk": "8.1.0",

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -18,7 +18,6 @@ import {
   type ProviderRpcError,
   SwitchChainError,
   UserRejectedRequestError,
-  fromHex,
   getAddress,
   numberToHex,
 } from 'viem'

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -18,6 +18,7 @@ import {
   type ProviderRpcError,
   SwitchChainError,
   UserRejectedRequestError,
+  fromHex,
   getAddress,
   numberToHex,
 } from 'viem'
@@ -163,10 +164,10 @@ function version4(parameters: Version4Parameters) {
     },
     async getChainId() {
       const provider = await this.getProvider()
-      const chainId = await provider.request<number>({
+      const chainId = await provider.request<`0x${string}`>({
         method: 'eth_chainId',
       })
-      return Number(chainId)
+      return fromHex(chainId, 'number')
     },
     async getProvider() {
       if (!walletProvider) {
@@ -401,8 +402,10 @@ function version3(parameters: Version3Parameters) {
     },
     async getChainId() {
       const provider = await this.getProvider()
-      const chainId = await provider.request<number>({ method: 'eth_chainId' })
-      return Number(chainId)
+      const chainId = await provider.request<`0x${string}`>({
+        method: 'eth_chainId',
+      })
+      return fromHex(chainId, 'number')
     },
     async getProvider() {
       if (!walletProvider) {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -167,7 +167,7 @@ function version4(parameters: Version4Parameters) {
       const chainId = await provider.request<`0x${string}`>({
         method: 'eth_chainId',
       })
-      return fromHex(chainId, 'number')
+      return Number(chainId)
     },
     async getProvider() {
       if (!walletProvider) {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -405,7 +405,7 @@ function version3(parameters: Version3Parameters) {
       const chainId = await provider.request<`0x${string}`>({
         method: 'eth_chainId',
       })
-      return fromHex(chainId, 'number')
+      return Number(chainId)
     },
     async getProvider() {
       if (!walletProvider) {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -15,6 +15,7 @@ import type {
 } from 'cbw-sdk'
 import {
   type AddEthereumChainParameter,
+  type Hex,
   type ProviderRpcError,
   SwitchChainError,
   UserRejectedRequestError,
@@ -163,7 +164,7 @@ function version4(parameters: Version4Parameters) {
     },
     async getChainId() {
       const provider = await this.getProvider()
-      const chainId = await provider.request<`0x${string}`>({
+      const chainId = await provider.request<Hex>({
         method: 'eth_chainId',
       })
       return Number(chainId)
@@ -401,7 +402,7 @@ function version3(parameters: Version3Parameters) {
     },
     async getChainId() {
       const provider = await this.getProvider()
-      const chainId = await provider.request<`0x${string}`>({
+      const chainId = await provider.request<Hex>({
         method: 'eth_chainId',
       })
       return Number(chainId)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
   packages/connectors:
     dependencies:
       '@coinbase/wallet-sdk':
-        specifier: 4.0.2
-        version: 4.0.2
+        specifier: 4.0.3
+        version: 4.0.3
       '@metamask/sdk':
         specifier: 0.20.3
         version: 0.20.3(bufferutil@4.0.8)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.17.2)(utf-8-validate@6.0.3)
@@ -998,8 +998,8 @@ packages:
   '@coinbase/wallet-sdk@3.9.3':
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
 
-  '@coinbase/wallet-sdk@4.0.2':
-    resolution: {integrity: sha512-WMUeFbtS0rn8zavjAmNhFWq1r3TV7E5KuSij1Sar0/XuOC+nhj96uqSlIApAHdhuScoKZBq39VYsAQCHzOC6/w==}
+  '@coinbase/wallet-sdk@4.0.3':
+    resolution: {integrity: sha512-y/OGEjlvosikjfB+wk+4CVb9OxD1ob9cidEBLI5h8Hxaf/Qoob2XoVT1uvhtAzBx34KpGYSd+alKvh/GCRre4Q==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -8807,7 +8807,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.0.2':
+  '@coinbase/wallet-sdk@4.0.3':
     dependencies:
       buffer: 6.0.3
       clsx: 1.2.1


### PR DESCRIPTION
v4.0.3 fixes the `eth_chainId` response to match the spec. It was returning a number and now returns a hex, in line with https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
