### PR TITLE
fix: `test.sol` should be `Test.sol`

### DIFF
--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -26,7 +26,7 @@ const defaultExcludes = [
   'Vm.sol/**',
   'console.sol/**',
   'console2.sol/**',
-  'test.sol/**',
+  'Test.sol/**',
   '**.s.sol/*.json',
   '**.t.sol/*.json',
 ]


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Based on [forge-std](https://github.com/foundry-rs/forge-std/tree/master/src)'s source, the file is pascal-case `Test.sol` instead of `test.sol`. As a result, the test artifact gets picked up by wagmi cli and its types are unnecessarily (?) generated.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
