### PR TITLE
fix: exclude forge-std Mock.sol files by default to prevent duplicate contract names

### DIFF
--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -14,6 +14,8 @@ import type { Evaluate, RequiredBy } from '../types.js'
 const defaultExcludes = [
   'Common.sol/**',
   'Components.sol/**',
+  'MockERC20.sol/**',
+  'MockERC721.sol/**',
   'Script.sol/**',
   'StdAssertions.sol/**',
   'StdInvariant.sol/**',


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

- Fixes #3951 
- Took this approach since the Mock files should probably be excluded anyway
- To prevent this from repeating in the future as `forge-std` drifts, might be a good idea to write a dedicated test to sanity check that the plugin works with `forge init`

### Note 
- An alternative is to use the `Mock*.sol/**` glob pattern, but to prevent some edge-case wonkiness down the line where the user introduces a `MockingBird.sol` or something and it doesn't get picked up

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
