### PR TITLE
feat: chain check

### DIFF
--- a/.changeset/fresh-pianos-prove.md
+++ b/.changeset/fresh-pianos-prove.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+"@wagmi/vue": patch
+---
+
+Added safety net for chain checks.

--- a/.changeset/fresh-pianos-prove.md
+++ b/.changeset/fresh-pianos-prove.md
@@ -1,7 +1,5 @@
 ---
 "@wagmi/core": patch
-"wagmi": patch
-"@wagmi/vue": patch
 ---
 
-Added safety net for chain checks.
+Added chain check to `getConnectorClient` since it's possible for connection state chain ID to get out of sync with the connector (e.g. [wallet bug](https://github.com/MetaMask/metamask-extension/issues/25097)).

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -45,6 +45,32 @@ test('behavior: not connected', async () => {
   `)
 })
 
+test('behavior: connector is on different chain', async () => {
+  await connect(config, { chainId: 1, connector })
+  config.setState((state) => {
+    const uid = state.current!
+    const connection = state.connections.get(uid)!
+    return {
+      ...state,
+      connections: new Map(state.connections).set(uid, {
+        ...connection,
+        chainId: 456,
+      }),
+    }
+  })
+  await expect(
+    getConnectorClient(config, { account: address.usdcHolder }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [ConnectorChainMismatchError: The current chain of the wallet (id: 1) does not match the target chain for the transaction (id: 456 – Ethereum).
+
+    Current Chain ID:  1
+    Expected Chain ID: 456 – Ethereum
+
+    Version: @wagmi/core@x.y.z]
+  `)
+  await disconnect(config, { connector })
+})
+
 test('behavior: account does not exist on connector', async () => {
   await connect(config, { connector })
   await expect(
@@ -56,3 +82,4 @@ test('behavior: account does not exist on connector', async () => {
   `)
   await disconnect(config, { connector })
 })
+

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -61,10 +61,10 @@ test('behavior: connector is on different chain', async () => {
   await expect(
     getConnectorClient(config, { account: address.usdcHolder }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [ConnectorChainMismatchError: The current chain of the wallet (id: 1) does not match the target chain for the transaction (id: 456 – Ethereum).
+    [ConnectorChainMismatchError: The current chain of the connector (id: 1) does not match the connection's chain (id: 456).
 
     Current Chain ID:  1
-    Expected Chain ID: 456 – Ethereum
+    Expected Chain ID: 456
 
     Version: @wagmi/core@x.y.z]
   `)
@@ -82,4 +82,3 @@ test('behavior: account does not exist on connector', async () => {
   `)
   await disconnect(config, { connector })
 })
-

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -79,6 +79,18 @@ export async function sendTransaction<
 
   const { connector: activeConnector } = getAccount(config)
 
+  const chain = (() => {
+    if (chainId) return { id: chainId }
+
+    // If the account type is local, skip chain validation in Viem by explicitly
+    // passing `null`.
+    if (typeof account === 'object' && account.type === 'local') return null
+
+    // Otherwise, an `undefined` value indicates default chain validation behavior will be performed
+    // against the Client's chain.
+    return undefined
+  })()
+
   const gas = await (async () => {
     // Skip gas estimation if `data` doesn't exist (not a contract interaction).
     if (!('data' in parameters) || !parameters.data) return undefined
@@ -95,7 +107,7 @@ export async function sendTransaction<
       return action({
         ...(rest as any),
         account,
-        chain: chainId ? { id: chainId } : null,
+        chain,
       })
     }
 
@@ -107,8 +119,8 @@ export async function sendTransaction<
   const hash = await action({
     ...(rest as any),
     ...(account ? { account } : {}),
+    chain,
     gas,
-    chain: chainId ? { id: chainId } : null,
   })
 
   return hash

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -79,18 +79,6 @@ export async function sendTransaction<
 
   const { connector: activeConnector } = getAccount(config)
 
-  const chain = (() => {
-    if (chainId) return { id: chainId }
-
-    // If the account type is local, skip chain validation in Viem by explicitly
-    // passing `null`.
-    if (typeof account === 'object' && account.type === 'local') return null
-
-    // Otherwise, an `undefined` value indicates default chain validation behavior will be performed
-    // against the Client's chain.
-    return undefined
-  })()
-
   const gas = await (async () => {
     // Skip gas estimation if `data` doesn't exist (not a contract interaction).
     if (!('data' in parameters) || !parameters.data) return undefined
@@ -107,7 +95,7 @@ export async function sendTransaction<
       return action({
         ...(rest as any),
         account,
-        chain,
+        chain: chainId ? { id: chainId } : null,
       })
     }
 
@@ -119,7 +107,7 @@ export async function sendTransaction<
   const hash = await action({
     ...(rest as any),
     ...(account ? { account } : {}),
-    chain,
+    chain: chainId ? { id: chainId } : null,
     gas,
   })
 

--- a/packages/core/src/actions/sendTransaction.ts
+++ b/packages/core/src/actions/sendTransaction.ts
@@ -107,8 +107,8 @@ export async function sendTransaction<
   const hash = await action({
     ...(rest as any),
     ...(account ? { account } : {}),
-    chain: chainId ? { id: chainId } : null,
     gas,
+    chain: chainId ? { id: chainId } : null,
   })
 
   return hash

--- a/packages/core/src/errors/config.test.ts
+++ b/packages/core/src/errors/config.test.ts
@@ -1,10 +1,12 @@
 import { config } from '@wagmi/test'
 import { expect, test } from 'vitest'
+import { mainnet } from 'viem/chains'
 
 import {
   ChainNotConfiguredError,
   ConnectorAccountNotFoundError,
   ConnectorAlreadyConnectedError,
+  ConnectorChainMismatchError,
   ConnectorNotConnectedError,
   ConnectorNotFoundError,
 } from './config.js'
@@ -37,6 +39,19 @@ test('constructors', () => {
     }),
   ).toMatchInlineSnapshot(`
     [ConnectorAccountNotFoundError: Account "0xA0Cf798816D4b9b9866b5330EEa46a18382f251e" not found for connector "Mock Connector".
+
+    Version: @wagmi/core@x.y.z]
+  `)
+  expect(
+    new ConnectorChainMismatchError({
+      chain: mainnet,
+      currentChainId: 123,
+    }),
+  ).toMatchInlineSnapshot(`
+    [ConnectorChainMismatchError: The current chain of the connector (id: 123) does not match the connection's chain (id: 1 – Ethereum).
+
+    Current Chain ID:  123
+    Expected Chain ID: 1 – Ethereum
 
     Version: @wagmi/core@x.y.z]
   `)

--- a/packages/core/src/errors/config.test.ts
+++ b/packages/core/src/errors/config.test.ts
@@ -1,6 +1,5 @@
 import { config } from '@wagmi/test'
 import { expect, test } from 'vitest'
-import { mainnet } from 'viem/chains'
 
 import {
   ChainNotConfiguredError,
@@ -44,15 +43,8 @@ test('constructors', () => {
   `)
   expect(
     new ConnectorChainMismatchError({
-      chain: mainnet,
-      currentChainId: 123,
+      connectionChainId: 1,
+      connectorChainId: 123,
     }),
-  ).toMatchInlineSnapshot(`
-    [ConnectorChainMismatchError: The current chain of the connector (id: 123) does not match the connection's chain (id: 1 – Ethereum).
-
-    Current Chain ID:  123
-    Expected Chain ID: 1 – Ethereum
-
-    Version: @wagmi/core@x.y.z]
-  `)
+  ).toMatchInlineSnapshot()
 })

--- a/packages/core/src/errors/config.test.ts
+++ b/packages/core/src/errors/config.test.ts
@@ -46,5 +46,12 @@ test('constructors', () => {
       connectionChainId: 1,
       connectorChainId: 123,
     }),
-  ).toMatchInlineSnapshot()
+  ).toMatchInlineSnapshot(`
+    [ConnectorChainMismatchError: The current chain of the connector (id: 123) does not match the connection's chain (id: 1).
+
+    Current Chain ID:  123
+    Expected Chain ID: 1
+
+    Version: @wagmi/core@x.y.z]
+  `)
 })

--- a/packages/core/src/errors/config.ts
+++ b/packages/core/src/errors/config.ts
@@ -1,4 +1,4 @@
-import type { Address, Chain } from 'viem'
+import type { Address } from 'viem'
 
 import type { Connector } from '../createConfig.js'
 import { BaseError } from './base.js'
@@ -67,18 +67,18 @@ export type ConnectorChainMismatchErrorType = ConnectorAccountNotFoundError & {
 export class ConnectorChainMismatchError extends BaseError {
   override name = 'ConnectorChainMismatchError'
   constructor({
-    chain,
-    currentChainId,
+    connectionChainId,
+    connectorChainId,
   }: {
-    chain: Chain
-    currentChainId: number
+    connectionChainId: number
+    connectorChainId: number
   }) {
     super(
-      `The current chain of the connector (id: ${currentChainId}) does not match the connection's chain (id: ${chain.id} – ${chain.name}).`,
+      `The current chain of the connector (id: ${connectorChainId}) does not match the connection's chain (id: ${connectionChainId}).`,
       {
         metaMessages: [
-          `Current Chain ID:  ${currentChainId}`,
-          `Expected Chain ID: ${chain.id} – ${chain.name}`,
+          `Current Chain ID:  ${connectorChainId}`,
+          `Expected Chain ID: ${connectionChainId}`,
         ],
       },
     )

--- a/packages/core/src/errors/config.ts
+++ b/packages/core/src/errors/config.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'viem'
+import type { Address, Chain } from 'viem'
 
 import type { Connector } from '../createConfig.js'
 import { BaseError } from './base.js'
@@ -58,5 +58,29 @@ export class ConnectorAccountNotFoundError extends BaseError {
     connector: Connector
   }) {
     super(`Account "${address}" not found for connector "${connector.name}".`)
+  }
+}
+
+export type ConnectorChainMismatchErrorType = ConnectorAccountNotFoundError & {
+  name: 'ConnectorChainMismatchError'
+}
+export class ConnectorChainMismatchError extends BaseError {
+  override name = 'ConnectorChainMismatchError'
+  constructor({
+    chain,
+    currentChainId,
+  }: {
+    chain: Chain
+    currentChainId: number
+  }) {
+    super(
+      `The current chain of the connector (id: ${currentChainId}) does not match the connection's chain (id: ${chain.id} – ${chain.name}).`,
+      {
+        metaMessages: [
+          `Current Chain ID:  ${currentChainId}`,
+          `Expected Chain ID: ${chain.id} – ${chain.name}`,
+        ],
+      },
+    )
   }
 }

--- a/packages/core/src/exports/index.test.ts
+++ b/packages/core/src/exports/index.test.ts
@@ -87,6 +87,7 @@ test('exports', () => {
       "ConnectorAlreadyConnectedError",
       "ConnectorNotFoundError",
       "ConnectorAccountNotFoundError",
+      "ConnectorChainMismatchError",
       "ProviderNotFoundError",
       "SwitchChainNotSupportedError",
       "custom",

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -482,6 +482,8 @@ export {
   ConnectorNotFoundError,
   type ConnectorAccountNotFoundErrorType,
   ConnectorAccountNotFoundError,
+  type ConnectorChainMismatchErrorType,
+  ConnectorChainMismatchError,
 } from '../errors/config.js'
 
 export {

--- a/packages/vue/src/exports/index.test.ts
+++ b/packages/vue/src/exports/index.test.ts
@@ -46,6 +46,7 @@ test('exports', () => {
       "ConnectorAlreadyConnectedError",
       "ConnectorNotFoundError",
       "ConnectorAccountNotFoundError",
+      "ConnectorChainMismatchError",
       "ProviderNotFoundError",
       "SwitchChainNotSupportedError",
       "createStorage",

--- a/packages/vue/src/exports/index.ts
+++ b/packages/vue/src/exports/index.ts
@@ -226,6 +226,8 @@ export {
   ConnectorNotFoundError,
   type ConnectorAccountNotFoundErrorType,
   ConnectorAccountNotFoundError,
+  type ConnectorChainMismatchErrorType,
+  ConnectorChainMismatchError,
   type ProviderNotFoundErrorType,
   ProviderNotFoundError,
   type SwitchChainNotSupportedErrorType,

--- a/site/shared/errors.md
+++ b/site/shared/errors.md
@@ -23,12 +23,12 @@ When a chain is not configured. You likely need to add the chain to <a :href="`/
 import { ChainNotConfiguredError } from '{{packageName}}'
 ```
 
-### ConnectorAccountNotFound
+### ConnectorAccountNotFoundError
 
 When an account does not exist on the connector or is unable to be used.
 
 ```ts-vue
-import { ConnectorAccountNotFound } from '{{packageName}}'
+import { ConnectorAccountNotFoundError } from '{{packageName}}'
 ```
 
 ### ConnectorAlreadyConnectedError
@@ -45,6 +45,14 @@ When a connector is not connected.
 
 ```ts-vue
 import { ConnectorNotConnectedError } from '{{packageName}}'
+```
+
+### ConnectorChainMismatchError
+
+When the Wagmi Config is out-of-sync with the connector's active chain ID. This is rare and likely an upstream wallet issue.
+
+```ts-vue
+import { ConnectorChainMismatchError } from '{{packageName}}'
 ```
 
 ### ConnectorNotFoundError


### PR DESCRIPTION
Adds a chain check to `getConnectorClient` since it's possible for connection state chain ID to get out of sync with the connector (e.g. [wallet bug](https://github.com/MetaMask/metamask-extension/issues/25097)).