### PR TITLE
feat(injected): reconnect timeout

### DIFF
--- a/.changeset/shaggy-pillows-fold.md
+++ b/.changeset/shaggy-pillows-fold.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Removed `injected` connector `isAuthorized` timeout.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -11,7 +11,6 @@ import {
   getAddress,
   numberToHex,
   withRetry,
-  withTimeout,
 } from 'viem'
 
 import type { Connector } from '../createConfig.js'

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -18,7 +18,7 @@ import type {
   ConnectorEventMap,
   CreateConnectorFn,
 } from './connectors/createConnector.js'
-import { type InjectedParameters, injected } from './connectors/injected.js'
+import { injected } from './connectors/injected.js'
 import { type Emitter, type EventData, createEmitter } from './createEmitter.js'
 import { type Storage, createStorage, noopStorage } from './createStorage.js'
 import { ChainNotConfiguredError } from './errors/config.js'
@@ -36,17 +36,7 @@ export type CreateConfigParameters<
   {
     chains: chains
     connectors?: CreateConnectorFn[] | undefined
-    multiInjectedProviderDiscovery?:
-      | boolean
-      | Evaluate<
-          Pick<
-            InjectedParameters,
-            | 'isAuthorizedTimeout'
-            | 'shimDisconnect'
-            | 'unstable_shimAsyncInject'
-          >
-        >
-      | undefined
+    multiInjectedProviderDiscovery?: boolean | undefined
     storage?: Storage | null | undefined
     ssr?: boolean | undefined
     syncConnectedChain?: boolean | undefined
@@ -122,12 +112,7 @@ export function createConfig<
   function providerDetailToConnector(providerDetail: EIP6963ProviderDetail) {
     const { info } = providerDetail
     const provider = providerDetail.provider as any
-    return injected({
-      ...(typeof multiInjectedProviderDiscovery === 'object'
-        ? multiInjectedProviderDiscovery
-        : {}),
-      target: { ...info, id: info.rdns, provider },
-    })
+    return injected({ target: { ...info, id: info.rdns, provider } })
   }
 
   const clients = new Map<number, Client<Transport, chains[number]>>()


### PR DESCRIPTION
Removes defensive [timeout](https://github.com/wevm/wagmi/blob/main/packages/core/src/connectors/injected.ts#L389-L391) for wallets delaying the reconnection process as it can cause unintended side effects https://github.com/wevm/wagmi/issues/4037. Moving forward, if a wallet hangs the reconnection process, it will be considered a wallet issue.

Closes #4037

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
