### PR TITLE
docs: getChainId/useChainId clarification

### DIFF
--- a/site/core/api/actions/getChainId.md
+++ b/site/core/api/actions/getChainId.md
@@ -2,11 +2,6 @@
 
 Action for getting current chain ID.
 
-This method returns chain IDs only for chains configured in your Wagmi 
-Config (via [createConfig#chains](/core/api/createConfig#chains)). If the connector 
-uses an unsupported chain, `getChainId` will return the last configured 
-chain ID. To retrieve the currently connected chain, including those not 
-specified in the Wagmi Config, use [getAccount#chainId](/core/api/actions/getAccount#chainid) instead.
 
 ## Import
 
@@ -35,3 +30,9 @@ import { type GetChainIdReturnType } from '@wagmi/core'
 `number`
 
 Current chain ID from [`config.state.chainId`](/core/api/createConfig#chainid).
+
+::: info
+Only returns chain IDs for chains configured via `createConfig`'s [`chains`](/core/api/createConfig#chains) parameter.
+
+If the active [connection](/core/api/createConfig#connection) [`chainId`](/core/api/createConfig#chainid-1) is not from a chain included in your Wagmi `Config`, `getChainId` will return the last configured chain ID.
+:::

--- a/site/core/api/actions/getChainId.md
+++ b/site/core/api/actions/getChainId.md
@@ -2,6 +2,12 @@
 
 Action for getting current chain ID.
 
+This method returns chain IDs only for chains configured in your Wagmi 
+Config (via [createConfig#chains](/core/api/createConfig#chains)). If the connector 
+uses an unsupported chain, `getChainId` will return the last configured 
+chain ID. To retrieve the currently connected chain, including those not 
+specified in the Wagmi Config, use [getAccount#chainId](/core/api/actions/getAccount#chainid) instead.
+
 ## Import
 
 ```ts

--- a/site/react/api/hooks/useChainId.md
+++ b/site/react/api/hooks/useChainId.md
@@ -7,6 +7,12 @@ description: Hook for getting current chain ID.
 
 Hook for getting current chain ID.
 
+This method returns chain IDs only for chains configured in your Wagmi 
+Config (via [createConfig#chains](/react/api/createConfig#chains)). If the connector 
+uses an unsupported chain, `useChainId` will return the last configured 
+chain ID. To retrieve the currently connected chain, including those not 
+specified in the Wagmi Config, use [useAccount#chainId](/react/api/hooks/useAccount#chainid) instead.
+
 ## Import
 
 ```ts

--- a/site/react/api/hooks/useChainId.md
+++ b/site/react/api/hooks/useChainId.md
@@ -7,12 +7,6 @@ description: Hook for getting current chain ID.
 
 Hook for getting current chain ID.
 
-This method returns chain IDs only for chains configured in your Wagmi 
-Config (via [createConfig#chains](/react/api/createConfig#chains)). If the connector 
-uses an unsupported chain, `useChainId` will return the last configured 
-chain ID. To retrieve the currently connected chain, including those not 
-specified in the Wagmi Config, use [useAccount#chainId](/react/api/hooks/useAccount#chainid) instead.
-
 ## Import
 
 ```ts
@@ -67,6 +61,12 @@ import { type UseChainIdReturnType } from 'wagmi'
 `number`
 
 Current chain ID from [`config.state.chainId`](/react/api/createConfig#chainid).
+
+::: info
+Only returns chain IDs for chains configured via `createConfig`'s [`chains`](/react/api/createConfig#chains) parameter.
+
+If the active [connection](/react/api/createConfig#connection) [`chainId`](/react/api/createConfig#chainid-1) is not from a chain included in your Wagmi `Config`, `useChainId` will return the last configured chain ID.
+:::
 
 ## Action
 

--- a/site/vue/api/composables/useChainId.md
+++ b/site/vue/api/composables/useChainId.md
@@ -7,12 +7,6 @@ description: Composable for getting current chain ID.
 
 Composable for getting current chain ID.
 
-This method returns chain IDs only for chains configured in your Wagmi 
-Config (via [createConfig#chains](/vue/api/createConfig#chains)). If the connector 
-uses an unsupported chain, `useChainId` will return the last configured 
-chain ID. To retrieve the currently connected chain, including those not 
-specified in the Wagmi Config, use [useAccount#chainId](/vue/api/composables/useAccount#chainid) instead.
-
 ## Import
 
 ```ts
@@ -67,6 +61,12 @@ import { type UseChainIdReturnType } from '@wagmi/vue'
 `number`
 
 Current chain ID from [`config.state.chainId`](/vue/api/createConfig#chainid).
+
+::: info
+Only returns chain IDs for chains configured via `createConfig`'s [`chains`](/vue/api/createConfig#chains) parameter.
+
+If the active [connection](/vue/api/createConfig#connection) [`chainId`](/vue/api/createConfig#chainid-1) is not from a chain included in your Wagmi `Config`, `useChainId` will return the last configured chain ID.
+:::
 
 ## Action
 

--- a/site/vue/api/composables/useChainId.md
+++ b/site/vue/api/composables/useChainId.md
@@ -7,6 +7,12 @@ description: Composable for getting current chain ID.
 
 Composable for getting current chain ID.
 
+This method returns chain IDs only for chains configured in your Wagmi 
+Config (via [createConfig#chains](/vue/api/createConfig#chains)). If the connector 
+uses an unsupported chain, `useChainId` will return the last configured 
+chain ID. To retrieve the currently connected chain, including those not 
+specified in the Wagmi Config, use [useAccount#chainId](/vue/api/composables/useAccount#chainid) instead.
+
 ## Import
 
 ```ts


### PR DESCRIPTION
Based on the discussion here https://github.com/wevm/wagmi/discussions/4030, I've updated docs for getChainId/useChainId to include explicit note that it should not be used as a method for getting the currently connected chain from connector, as it returns only the chains passed to the wagmi config.