### PR TITLE
Fix wrong import in docs code for useConnect in Vue

### DIFF
--- a/site/vue/api/composables/useConnect.md
+++ b/site/vue/api/composables/useConnect.md
@@ -29,7 +29,7 @@ import { useConnect } from '@wagmi/vue'
 ```vue [index.vue]
 <script setup lang="ts">
 import { useConnect } from '@wagmi/vue'
-import { injected } from 'wagmi/connectors'
+import { injected } from '@wagmi/connectors'
 
 const { connect } = useConnect()
 </script>


### PR DESCRIPTION
Fix a wrong import for the `useConnect` composable in Vue
