### PR TITLE
update useTransactionCount documentation

### DIFF
--- a/site/react/api/hooks/useTransactionCount.md
+++ b/site/react/api/hooks/useTransactionCount.md
@@ -13,7 +13,7 @@ const TError = 'GetTransactionCountErrorType'
 
 # useTransactionCount
 
-Hook for fetching the number of transactions an Account has broadcast / sent.
+Hook for fetching the number of transactions an Account has sent.
 
 ## Import
 


### PR DESCRIPTION
I believe the docs for `useTransactionCount` are not accurate, because the `eth_getTransactionCount` method returns only transactions that had been sent as per the spec: https://ethereum.github.io/execution-apis/api-documentation