### PR TITLE
Fix issue in CLI where the Foundry & Hardhat exclude patterns were ignored

### DIFF
--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -135,13 +135,14 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     }
   }
 
-  async function getArtifactPaths(artifactsDirectory: string) {
-    const crawler = new fdir()
-      .withBasePath()
-      .glob(
-        ...include.map((x) => `${artifactsDirectory}/**/${x}`),
-        ...exclude.map((x) => `!${artifactsDirectory}/**/${x}`),
-      )
+  function getArtifactPaths(artifactsDirectory: string) {
+    const crawler = new fdir().withBasePath().globWithOptions(
+      include.map((x) => `${artifactsDirectory}/**/${x}`),
+      {
+        dot: true,
+        ignore: exclude.map((x) => `${artifactsDirectory}/**/${x}`),
+      },
+    )
     return crawler.crawl(artifactsDirectory).withPromise()
   }
 

--- a/packages/cli/src/plugins/hardhat.ts
+++ b/packages/cli/src/plugins/hardhat.ts
@@ -92,13 +92,14 @@ export function hardhat(config: HardhatConfig): HardhatResult {
     }
   }
 
-  async function getArtifactPaths(artifactsDirectory: string) {
-    const crawler = new fdir()
-      .withBasePath()
-      .glob(
-        ...include.map((x) => `${artifactsDirectory}/**/${x}`),
-        ...exclude.map((x) => `!${artifactsDirectory}/**/${x}`),
-      )
+  function getArtifactPaths(artifactsDirectory: string) {
+    const crawler = new fdir().withBasePath().globWithOptions(
+      include.map((x) => `${artifactsDirectory}/**/${x}`),
+      {
+        dot: true,
+        ignore: exclude.map((x) => `${artifactsDirectory}/**/${x}`),
+      },
+    )
     return crawler.crawl(artifactsDirectory).withPromise()
   }
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

The glob pattern forwarded to `fdir` was incorrect. It used: `["patternA", "!patternB", "!patternC"]`, which matches `patternA`, or anything that _does not_ match `patternB`, _or_ anything that _does not_ match `patternC`. So when we were expecting to get anything that matches `patternA`, excluding `patternB` _and_ `patternC`, it basically allowed any file (and ironically, the bigger the `exclude` list, the higher the probability of it including anything).

This PR solves that. 

It should fix #4107, as well as older issues like #3752 and #1815.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
