### PR TITLE
FIX: useConnectorClient to be enabled only when connected or reconnecting

### DIFF
--- a/.changeset/short-eyes-hide.md
+++ b/.changeset/short-eyes-hide.md
@@ -1,5 +1,0 @@
----
-"wagmi": patch
----
-
-useConnectorClient only enabled when account status is 'connected'.

--- a/.changeset/short-eyes-hide.md
+++ b/.changeset/short-eyes-hide.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+useConnectorClient only enabled when account status is 'connected'.

--- a/.changeset/silent-countries-study.md
+++ b/.changeset/silent-countries-study.md
@@ -1,0 +1,6 @@
+---
+"wagmi": patch
+"@wagmi/vue": patch
+---
+
+Updated `useConnectorClient` to be enabled when status is `'reconnecting'` or `'connected'` (previously was also enabled when status was `'connecting'`).

--- a/packages/react/src/hooks/useConnectorClient.test.tsx
+++ b/packages/react/src/hooks/useConnectorClient.test.tsx
@@ -160,6 +160,18 @@ test('behavior: disabled when properties missing', async () => {
   await waitFor(() => expect(result.current.isPending).toBeTruthy())
 })
 
+test('behavior: disabled when connecting', async () => {
+  const { result } = renderHook(() => ({
+    useConnectorClient: useConnectorClient(),
+    useAccount: useAccount(),
+  }))
+
+  config.setState((x) => ({ ...x, status: 'connecting' }))
+
+  await wait(100)
+  expect(result.current.useConnectorClient.isLoading).not.toBeTruthy()
+})
+
 test('behavior: re-render does not invalidate query', async () => {
   const { getByTestId } = render(<Parent />)
 

--- a/packages/react/src/hooks/useConnectorClient.test.tsx
+++ b/packages/react/src/hooks/useConnectorClient.test.tsx
@@ -161,15 +161,12 @@ test('behavior: disabled when properties missing', async () => {
 })
 
 test('behavior: disabled when connecting', async () => {
-  const { result } = renderHook(() => ({
-    useConnectorClient: useConnectorClient(),
-    useAccount: useAccount(),
-  }))
+  const { result } = renderHook(() => useConnectorClient())
 
   config.setState((x) => ({ ...x, status: 'connecting' }))
 
   await wait(100)
-  expect(result.current.useConnectorClient.isLoading).not.toBeTruthy()
+  expect(result.current.isLoading).not.toBeTruthy()
 })
 
 test('behavior: re-render does not invalidate query', async () => {

--- a/packages/react/src/hooks/useConnectorClient.ts
+++ b/packages/react/src/hooks/useConnectorClient.ts
@@ -81,7 +81,7 @@ export function useConnectorClient<
     chainId: parameters.chainId ?? chainId,
     connector: parameters.connector ?? connector,
   })
-  const enabled = Boolean((status === 'connected')  && (query.enabled ?? true))
+  const enabled = Boolean(status === 'connected' && (query.enabled ?? true))
 
   const addressRef = useRef(address)
   // biome-ignore lint/correctness/useExhaustiveDependencies: `queryKey` not required

--- a/packages/react/src/hooks/useConnectorClient.ts
+++ b/packages/react/src/hooks/useConnectorClient.ts
@@ -81,7 +81,7 @@ export function useConnectorClient<
     chainId: parameters.chainId ?? chainId,
     connector: parameters.connector ?? connector,
   })
-  const enabled = Boolean(status !== 'disconnected' && (query.enabled ?? true))
+  const enabled = Boolean((status === 'connected')  && (query.enabled ?? true))
 
   const addressRef = useRef(address)
   // biome-ignore lint/correctness/useExhaustiveDependencies: `queryKey` not required

--- a/packages/react/src/hooks/useConnectorClient.ts
+++ b/packages/react/src/hooks/useConnectorClient.ts
@@ -81,7 +81,10 @@ export function useConnectorClient<
     chainId: parameters.chainId ?? chainId,
     connector: parameters.connector ?? connector,
   })
-  const enabled = Boolean(status === 'connected' && (query.enabled ?? true))
+  const enabled = Boolean(
+    (status === 'connected' || status === 'reconnecting') &&
+      (query.enabled ?? true),
+  )
 
   const addressRef = useRef(address)
   // biome-ignore lint/correctness/useExhaustiveDependencies: `queryKey` not required

--- a/packages/vue/src/composables/useConnectorClient.test.ts
+++ b/packages/vue/src/composables/useConnectorClient.test.ts
@@ -145,3 +145,12 @@ test('behavior: disabled when properties missing', async () => {
   await wait(100)
   expect(connectorClient.isPending.value).toBe(true)
 })
+
+test('behavior: disabled when connecting', async () => {
+  const [connectorClient] = renderComposable(() => useConnectorClient())
+
+  config.setState((x) => ({ ...x, status: 'connecting' }))
+
+  await wait(100)
+  expect(connectorClient.isLoading.value).not.toBeTruthy()
+})

--- a/packages/vue/src/composables/useConnectorClient.ts
+++ b/packages/vue/src/composables/useConnectorClient.ts
@@ -97,7 +97,8 @@ export function useConnectorClient<
       connector: connector as Connector,
     })
     const enabled = Boolean(
-      status.value !== 'disconnected' && (query.enabled ?? true),
+      (status.value === 'connected' || status.value === 'reconnecting') &&
+        (query.enabled ?? true),
     )
     return {
       ...query,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR aims to prevent `useConnectorClient` running when account is **not** in `connected` state.
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
Took this along as a quick fix, feel free to close if this is a desired behaviour. Cheers.
