### PR TITLE
chore: update 'useDeeplink' default state to 'false' in the Metamask-SDK connector

### DIFF
--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -185,7 +185,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
             }),
           ),
           dappMetadata: parameters.dappMetadata ?? {},
-          useDeeplink: parameters.useDeeplink ?? true,
+          useDeeplink: parameters.useDeeplink ?? false,
         })
         await sdk.init()
         return sdk.getProvider()!


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->

This PR updates the default state of the `useDeeplink` parameter in the MetaMask SDK connector.

Previously:
`useDeeplink: parameters.useDeeplink ?? true`

Now changed to:
`useDeeplink: parameters.useDeeplink ?? false`

This change ensures that the `useDeeplink` feature is disabled by default unless explicitly set in the parameters.
It improves the user experience on mobile iOS devices.