### PR TITLE
fix: set cookie path correctly

### DIFF
--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -10,7 +10,9 @@ export const cookieStorage = {
   },
   setItem(key, value) {
     if (typeof window === 'undefined') return
-    document.cookie = `${key}=${value};Path=/;SameSite=Lax`
+    const pathBits = window.location.pathname.split('/')
+    const path = pathBits.slice(0, pathBits.length - 1).concat('/')
+    document.cookie = `${key}=${value};Path=${path};SameSite=Lax`
   },
   removeItem(key) {
     if (typeof window === 'undefined') return


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

The path of the shimDisconnect cookie is being defaulted in all cases to `/`, this means that when wagmi is re-connected on the page `/a/b/c`, the cookie is not removed.  By setting the cookie path to `/a/b` upon disconnect,  the cookie is recognised when the app is re-connected.

Fixes #4097

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
