### PR TITLE
Fixed wrongly passing 'abi' to 'useWriteContract'

### DIFF
--- a/site/react/guides/write-to-contract.md
+++ b/site/react/guides/write-to-contract.md
@@ -87,7 +87,7 @@ export function MintNFT() {
     const tokenId = formData.get('tokenId') as string 
     writeContract({ // [!code ++]
       address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2', // [!code ++]
-      abi, // [!code ++]
+      abi: abi, // [!code ++]
       functionName: 'mint', // [!code ++]
       args: [BigInt(tokenId)], // [!code ++]
     }) // [!code ++]
@@ -141,7 +141,7 @@ export function MintNFT() {
     const tokenId = formData.get('tokenId') as string 
     writeContract({
       address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      abi,
+      abi: abi,
       functionName: 'mint',
       args: [BigInt(tokenId)],
     })
@@ -204,7 +204,7 @@ export function MintNFT() {
     const tokenId = formData.get('tokenId') as string 
     writeContract({
       address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      abi,
+      abi: abi,
       functionName: 'mint',
       args: [BigInt(tokenId)],
     })
@@ -275,7 +275,7 @@ export function MintNFT() {
     const tokenId = formData.get('tokenId') as string 
     writeContract({
       address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      abi,
+      abi: abi,
       functionName: 'mint',
       args: [BigInt(tokenId)],
     })
@@ -368,7 +368,7 @@ export function MintNFT() {
     const tokenId = formData.get('tokenId') as string 
     writeContract({
       address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      abi,
+      abi: abi,
       functionName: 'mint',
       args: [BigInt(tokenId)],
     })


### PR DESCRIPTION
Fixed wrongly passing of parameter 'abi' to 'useWriteContract' hook.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
