### PR TITLE
fix: metaMask dappMetadata add default value

### DIFF
--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -184,7 +184,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
               return [chain.id, url]
             }),
           ),
-          dappMetadata: parameters.dappMetadata ?? {},
+          dappMetadata: parameters.dappMetadata ?? { name: 'wagmi' },
           useDeeplink: parameters.useDeeplink ?? true,
         })
         await sdk.init()


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
This pr fixed the problem when using `import { metaMask } from 'wagmi/connectors'`.  If the user does not set the key `dappMetadata`, when building the package will report an error.
I find the latest readme in  the path `wagmi/site/shared/connectors/metaMask.md`   
It's shows that: 
```
dappMetadata
DappMetadata | undefined

Metadata about the dapp using the SDK.
Defaults to { name: 'wagmi' }.
```
But there is no synchronization in the code.  So I new the pull request to add this code into your repo. 

Without the code,  it will come out the error: 
`Error: You must provide dAppMetadata option (name and/or url)`
Which is checked by the metamask-sdk  [https://github.com/MetaMask/metamask-sdk/blob/a65d852432022906c1852168da7eadd4e26cf159/packages/sdk/src/sdk.test.ts#L151](url)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
