### PR TITLE
Added timeout while requesting accounts

### DIFF
--- a/.changeset/fresh-rings-juggle.md
+++ b/.changeset/fresh-rings-juggle.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Added timeout while requesting accounts to injected connector

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -398,10 +398,11 @@ export function injected(parameters: InjectedParameters = {}) {
 
         // Use retry strategy as some injected wallets (e.g. MetaMask) fail to
         // immediately resolve JSON-RPC requests on page load.
-        const accounts = await withRetry(() => 
-          withTimeout(() =>this.getAccounts(), {
+        const accounts = await withRetry(() =>
+          withTimeout(() => this.getAccounts(), {
             timeout: 1_000,
-          }).catch(() => []))
+          }).catch(() => []),
+        )
 
         return !!accounts.length
       } catch {

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -398,7 +398,11 @@ export function injected(parameters: InjectedParameters = {}) {
 
         // Use retry strategy as some injected wallets (e.g. MetaMask) fail to
         // immediately resolve JSON-RPC requests on page load.
-        const accounts = await withRetry(() => this.getAccounts())
+        const accounts = await withRetry(() => 
+          withTimeout(() =>this.getAccounts(), {
+            timeout: 1_000,
+          }).catch(() => []))
+
         return !!accounts.length
       } catch {
         return false


### PR DESCRIPTION
- closes #4236
- Phantom Wallet does not response `eth_accounts` request, thus this request was blocking [this line](https://github.com/wevm/wagmi/blob/7e9e5013a593f45a98b2ae86518e111298f14d75/packages/core/src/actions/reconnect.ts#L77) forever and other connector stucks as "reconnecting"

please let me know if we can better approach for this.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
