### PR TITLE
fix: guard (get|use)ConnectorClient when reconnecting

### DIFF
--- a/.changeset/gentle-jobs-visit.md
+++ b/.changeset/gentle-jobs-visit.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Disabled `useConnectorClient` and `useWalletClient` during reconnection if connector is not fully restored.

--- a/.changeset/lazy-shrimps-occur.md
+++ b/.changeset/lazy-shrimps-occur.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Added guard to `getConnectorClient` when reconnecting to check if connector is fully restored.

--- a/.changeset/long-pears-behave.md
+++ b/.changeset/long-pears-behave.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/vue": patch
+---
+
+Disabled `useConnectorClient` during reconnection if connector is not fully restored.

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -1,10 +1,10 @@
 import { address, config } from '@wagmi/test'
 import { expect, test } from 'vitest'
 
+import type { Connector } from '../createConfig.js'
 import { connect } from './connect.js'
 import { disconnect } from './disconnect.js'
 import { getConnectorClient } from './getConnectorClient.js'
-import type { Connector } from '../createConfig.js'
 
 const connector = config.connectors[0]!
 

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from 'vitest'
 import { connect } from './connect.js'
 import { disconnect } from './disconnect.js'
 import { getConnectorClient } from './getConnectorClient.js'
+import type { Connector } from '../createConfig.js'
 
 const connector = config.connectors[0]!
 
@@ -81,4 +82,25 @@ test('behavior: account does not exist on connector', async () => {
     Version: @wagmi/core@x.y.z]
   `)
   await disconnect(config, { connector })
+})
+
+test('behavior: reconnecting', async () => {
+  config.setState((state) => ({ ...state, status: 'reconnecting' }))
+  const { id, name, type, uuid } = connector
+  await expect(
+    getConnectorClient(config, {
+      connector: {
+        id,
+        name,
+        type,
+        uuid,
+      } as unknown as Connector,
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [ConnectorUnavailableReconnectingError: Connector "Mock Connector" unavailable while reconnecting.
+
+    Details: During the reconnection step, the only connector methods guaranteed to be available are: \`id\`, \`name\`, \`type\`, \`uuid\`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
+    Version: @wagmi/core@x.y.z]
+  `)
+  config.setState((state) => ({ ...state, status: 'disconnected' }))
 })

--- a/packages/core/src/errors/config.test.ts
+++ b/packages/core/src/errors/config.test.ts
@@ -8,6 +8,7 @@ import {
   ConnectorChainMismatchError,
   ConnectorNotConnectedError,
   ConnectorNotFoundError,
+  ConnectorUnavailableReconnectingError,
 } from './config.js'
 
 test('constructors', () => {
@@ -52,6 +53,16 @@ test('constructors', () => {
     Current Chain ID:  123
     Expected Chain ID: 1
 
+    Version: @wagmi/core@x.y.z]
+  `)
+  expect(
+    new ConnectorUnavailableReconnectingError({
+      connector: { name: 'Rabby Wallet' },
+    }),
+  ).toMatchInlineSnapshot(`
+    [ConnectorUnavailableReconnectingError: Connector "Rabby Wallet" unavailable while reconnecting.
+
+    Details: During the reconnection step, the only connector methods guaranteed to be available are: \`id\`, \`name\`, \`type\`, \`uuid\`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
     Version: @wagmi/core@x.y.z]
   `)
 })

--- a/packages/core/src/errors/config.ts
+++ b/packages/core/src/errors/config.ts
@@ -84,3 +84,20 @@ export class ConnectorChainMismatchError extends BaseError {
     )
   }
 }
+
+export type ConnectorUnavailableReconnectingErrorType =
+  ConnectorUnavailableReconnectingError & {
+    name: 'ConnectorUnavailableReconnectingError'
+  }
+export class ConnectorUnavailableReconnectingError extends BaseError {
+  override name = 'ConnectorUnavailableReconnectingError'
+  constructor({ connector }: { connector: { name: string } }) {
+    super(`Connector "${connector.name}" unavailable while reconnecting.`, {
+      details: [
+        'During the reconnection step, the only connector methods guaranteed to be available are: `id`, `name`, `type`, `uuid`.',
+        'All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored.',
+        'This error commonly occurs for connectors that asynchronously inject after reconnection has already started.',
+      ].join(' '),
+    })
+  }
+}

--- a/packages/core/src/exports/index.test.ts
+++ b/packages/core/src/exports/index.test.ts
@@ -90,6 +90,7 @@ test('exports', () => {
       "ConnectorNotFoundError",
       "ConnectorAccountNotFoundError",
       "ConnectorChainMismatchError",
+      "ConnectorUnavailableReconnectingError",
       "ProviderNotFoundError",
       "SwitchChainNotSupportedError",
       "custom",

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -456,6 +456,7 @@ export {
   type Connector,
   type Config,
   type CreateConfigParameters,
+  type PartializedState,
   type State,
   type Transport,
   createConfig,
@@ -498,6 +499,8 @@ export {
   ConnectorAccountNotFoundError,
   type ConnectorChainMismatchErrorType,
   ConnectorChainMismatchError,
+  type ConnectorUnavailableReconnectingErrorType,
+  ConnectorUnavailableReconnectingError,
 } from '../errors/config.js'
 
 export {

--- a/packages/react/src/exports/index.test.ts
+++ b/packages/react/src/exports/index.test.ts
@@ -80,6 +80,8 @@ test('exports', () => {
       "ConnectorAlreadyConnectedError",
       "ConnectorNotFoundError",
       "ConnectorAccountNotFoundError",
+      "ConnectorChainMismatchError",
+      "ConnectorUnavailableReconnectingError",
       "ProviderNotFoundError",
       "SwitchChainNotSupportedError",
       "createStorage",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -399,6 +399,7 @@ export {
   type Connector,
   type Config,
   type CreateConfigParameters,
+  type PartializedState,
   type State,
   createConfig,
   // Connector
@@ -414,6 +415,10 @@ export {
   ConnectorNotFoundError,
   type ConnectorAccountNotFoundErrorType,
   ConnectorAccountNotFoundError,
+  type ConnectorChainMismatchErrorType,
+  ConnectorChainMismatchError,
+  type ConnectorUnavailableReconnectingErrorType,
+  ConnectorUnavailableReconnectingError,
   type ProviderNotFoundErrorType,
   ProviderNotFoundError,
   type SwitchChainNotSupportedErrorType,

--- a/packages/react/src/hooks/useConnectorClient.ts
+++ b/packages/react/src/hooks/useConnectorClient.ts
@@ -72,6 +72,7 @@ export function useConnectorClient<
   const queryClient = useQueryClient()
   const { address, connector, status } = useAccount({ config })
   const chainId = useChainId({ config })
+  const activeConnector = parameters.connector ?? connector
 
   const { queryKey, ...options } = getConnectorClientQueryOptions<
     config,
@@ -79,10 +80,11 @@ export function useConnectorClient<
   >(config, {
     ...parameters,
     chainId: parameters.chainId ?? chainId,
-    connector: parameters.connector ?? connector,
+    connector: activeConnector,
   })
   const enabled = Boolean(
-    (status === 'connected' || status === 'reconnecting') &&
+    (status === 'connected' ||
+      (status === 'reconnecting' && activeConnector?.getProvider)) &&
       (query.enabled ?? true),
   )
 

--- a/packages/react/src/hooks/useWalletClient.ts
+++ b/packages/react/src/hooks/useWalletClient.ts
@@ -75,6 +75,7 @@ export function useWalletClient<
   const queryClient = useQueryClient()
   const { address, connector, status } = useAccount({ config })
   const chainId = useChainId({ config })
+  const activeConnector = parameters.connector ?? connector
 
   const { queryKey, ...options } = getWalletClientQueryOptions<config, chainId>(
     config,
@@ -84,7 +85,11 @@ export function useWalletClient<
       connector: parameters.connector ?? connector,
     },
   )
-  const enabled = Boolean(status !== 'disconnected' && (query.enabled ?? true))
+  const enabled = Boolean(
+    (status === 'connected' ||
+      (status === 'reconnecting' && activeConnector?.getProvider)) &&
+      (query.enabled ?? true),
+  )
 
   const addressRef = useRef(address)
   // biome-ignore lint/correctness/useExhaustiveDependencies: `queryKey` not required

--- a/packages/vue/src/composables/useConnectorClient.ts
+++ b/packages/vue/src/composables/useConnectorClient.ts
@@ -97,7 +97,8 @@ export function useConnectorClient<
       connector: connector as Connector,
     })
     const enabled = Boolean(
-      (status.value === 'connected' || status.value === 'reconnecting') &&
+      (status.value === 'connected' ||
+        (status.value === 'reconnecting' && connector?.getProvider)) &&
         (query.enabled ?? true),
     )
     return {

--- a/packages/vue/src/exports/index.test.ts
+++ b/packages/vue/src/exports/index.test.ts
@@ -49,6 +49,7 @@ test('exports', () => {
       "ConnectorNotFoundError",
       "ConnectorAccountNotFoundError",
       "ConnectorChainMismatchError",
+      "ConnectorUnavailableReconnectingError",
       "ProviderNotFoundError",
       "SwitchChainNotSupportedError",
       "createStorage",

--- a/packages/vue/src/exports/index.ts
+++ b/packages/vue/src/exports/index.ts
@@ -223,6 +223,7 @@ export {
   type Connector,
   type Config,
   type CreateConfigParameters,
+  type PartializedState,
   type State,
   createConfig,
   // Connector
@@ -240,6 +241,8 @@ export {
   ConnectorAccountNotFoundError,
   type ConnectorChainMismatchErrorType,
   ConnectorChainMismatchError,
+  type ConnectorUnavailableReconnectingErrorType,
+  ConnectorUnavailableReconnectingError,
   type ProviderNotFoundErrorType,
   ProviderNotFoundError,
   type SwitchChainNotSupportedErrorType,

--- a/site/shared/errors.md
+++ b/site/shared/errors.md
@@ -15,14 +15,6 @@ import { BaseError } from '{{packageName}}'
 
 ## Config
 
-### ChainNotConfiguredError
-
-When a chain is not configured. You likely need to add the chain to <a :href="`/${docsPath}/api/createConfig#chains`">`Config['chains']`</a>.
-
-```ts-vue
-import { ChainNotConfiguredError } from '{{packageName}}'
-```
-
 ### ConnectorAccountNotFoundError
 
 When an account does not exist on the connector or is unable to be used.
@@ -39,14 +31,6 @@ When a connector is already connected.
 import { ConnectorAlreadyConnectedError } from '{{packageName}}'
 ```
 
-### ConnectorNotConnectedError
-
-When a connector is not connected.
-
-```ts-vue
-import { ConnectorNotConnectedError } from '{{packageName}}'
-```
-
 ### ConnectorChainMismatchError
 
 When the Wagmi Config is out-of-sync with the connector's active chain ID. This is rare and likely an upstream wallet issue.
@@ -55,12 +39,36 @@ When the Wagmi Config is out-of-sync with the connector's active chain ID. This 
 import { ConnectorChainMismatchError } from '{{packageName}}'
 ```
 
+### ChainNotConfiguredError
+
+When a chain is not configured. You likely need to add the chain to <a :href="`/${docsPath}/api/createConfig#chains`">`Config['chains']`</a>.
+
+```ts-vue
+import { ChainNotConfiguredError } from '{{packageName}}'
+```
+
+### ConnectorNotConnectedError
+
+When a connector is not connected.
+
+```ts-vue
+import { ConnectorNotConnectedError } from '{{packageName}}'
+```
+
 ### ConnectorNotFoundError
 
 When a connector is not found or able to be used.
 
 ```ts-vue
 import { ConnectorNotFoundError } from '{{packageName}}'
+```
+
+### ConnectorUnavailableReconnectingError
+
+During the reconnection step, the only connector methods guaranteed to be available are: `id`, `name`, `type`, `uuid`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
+
+```ts-vue
+import { ConnectorUnavailableReconnectingError } from '{{packageName}}'
 ```
 
 ## Connector


### PR DESCRIPTION
Adds guard to `getConnectorClient` and disables `useConnectorClient` when reconnecting and connector is not fully restored (doesn't have access to properties other than `id`, `name`, `type`, `uuid`.).

Closes #4238

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
