### PR TITLE
fix: injected connector throws error after switching to a chain that was just added via `'wallet_addEthereumChain'`.

### DIFF
--- a/.changeset/unlucky-boats-dance.md
+++ b/.changeset/unlucky-boats-dance.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-Fixed injected connector throwing error after switching to a chain that was just added via 'wallet_addEthereumChain'
+Fixed `injected` connector race condition after calling `'wallet_addEthereumChain'` in `switchChain`.

--- a/.changeset/unlucky-boats-dance.md
+++ b/.changeset/unlucky-boats-dance.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed injected connector throwing error after switching to a chain that was just added via 'wallet_addEthereumChain'


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Fixes the same issue encountered in #4227 and #4223 where the connector throws an error after switching to a chain that was just added via `'wallet_addEthereumChain'` but for the injected connector.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
