### PR TITLE
docs: fix description of 'value' in usePrepareTransactionRequest

### DIFF
--- a/site/react/api/hooks/usePrepareTransactionRequest.md
+++ b/site/react/api/hooks/usePrepareTransactionRequest.md
@@ -284,7 +284,7 @@ function App() {
 
 `bigint | undefined`
 
-The transaction recipient or contract address.
+The amount of ether (in wei) to send with the transaction.
 
 ::: code-group
 ```tsx [index.tsx]


### PR DESCRIPTION
Fix an issue in the documentation for the `usePrepareTransactionRequest` hook. Specifically, the description of the `value` parameter was incorrect. It previously stated:

> "The transaction recipient or contract address."

The correct description should be:

> "The amount of ether (in wei) to send with the transaction."