### PR TITLE
Filter duplicate EIP-6963 connectors

### DIFF
--- a/playgrounds/vite-react/src/wagmi.ts
+++ b/playgrounds/vite-react/src/wagmi.ts
@@ -18,6 +18,7 @@ const indexedDBStorage = {
 
 export const config = createConfig({
   chains: [mainnet, sepolia, optimism, celo],
+  preferSpecificConnectorOverInjected: true,
   connectors: [
     walletConnect({
       projectId: import.meta.env.VITE_WC_PROJECT_ID,


### PR DESCRIPTION
## Fix duplicate providers

By default, Wagmi allows the discovery of EIP-6963 compatible extensions. For each extension, it creates an `Injected` provider using the information “emitted” by each extension: `id`, `name`, and `logo`. Internally, they use their own library, [mipd](https://github.com/wevm/mipd)

This behavior is enabled by default but can be disabled with the `multiInjectedProviderDiscovery` option.
This feature is very useful and is never disabled by applications using Wagmi.

The problem arises when you add “external” providers to the Wagmi configuration, such as `MetamaskSDK` or `coinbaseWalletSDK`.

By default, Wagmi will add them to the list of providers it discovered via `mipd`.

So, in the case of the two providers mentioned above, you may end up with duplicates: an `Injected` provider representing the installed extension discovered via EIP-6963, and an “external” provider representing the SDK version.

Both will have the same name, logo, etc.

This forces apps to use different strategies either to filter out duplicates from the providers supplied by Wagmi, or to pre-filter the external providers that you want to add to Wagmi.

Example of filter out integration: [Uniswap](https://github.com/Uniswap/interface/blob/6bac24a44af922b6eca8e9b4f8c1c9b3455b57ea/apps/web/src/components/WalletModal/useOrderedConnections.tsx#L42-L57) 
Example of pre-filter integration: [carbondefi.xyz](https://github.com/bancorprotocol/carbon-app/blob/3d07e83b884b053e579ae75faba63295ac8eb100/src/libs/wagmi/connectors.ts#L148-L151)
 
–

What I propose is to integrate this logic directly into Wagmi, and by default, not to offer the `Injected` providers if the user supplies equivalent “external” providers.

This could applies to both Metamask and Coinbase Wallet.




