### PR TITLE
fix: returning walletClient and reconnecting mock client

### DIFF
--- a/.changeset/strange-hounds-rest.md
+++ b/.changeset/strange-hounds-rest.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-Fixed the getAccounts method for the mock client.
+Fixed the getAccounts method and reconnecting logic for the mock client.

--- a/.changeset/strange-hounds-rest.md
+++ b/.changeset/strange-hounds-rest.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed the getAccounts method for the mock client.

--- a/.changeset/strange-hounds-rest.md
+++ b/.changeset/strange-hounds-rest.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-Fixed the getAccounts method and reconnecting logic for the mock client.
+Fixed getting wallet client and reconnecting logic for the mock client.

--- a/packages/core/src/connectors/mock.test.ts
+++ b/packages/core/src/connectors/mock.test.ts
@@ -1,12 +1,20 @@
 import { accounts, config } from '@wagmi/test'
 import { expect, test } from 'vitest'
-
+import { connect, getWalletClient } from '@wagmi/core'
 import { mock } from './mock.js'
 
 test('setup', () => {
   const connectorFn = mock({ accounts })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual('Mock Connector')
+})
+
+test('connector client is defined', async () => {
+  const connectorFn = mock({ accounts })
+  const connector = config._internal.connectors.setup(connectorFn)
+
+  await connect(config, { connector })
+  await expect(getWalletClient(config)).resolves.toBeDefined()
 })
 
 test('behavior: features.connectError', () => {

--- a/packages/core/src/connectors/mock.test.ts
+++ b/packages/core/src/connectors/mock.test.ts
@@ -1,6 +1,6 @@
+import { connect, getWalletClient } from '@wagmi/core'
 import { accounts, config } from '@wagmi/test'
 import { expect, test } from 'vitest'
-import { connect, getWalletClient } from '@wagmi/core'
 import { mock } from './mock.js'
 
 test('setup', () => {

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -45,13 +45,14 @@ export function mock(parameters: MockParameters) {
   type Provider = ReturnType<
     Transport<'custom', unknown, EIP1193RequestFn<WalletRpcSchema>>
   >
+  type Properties = Record<string, unknown>
   type StorageItem = {
     [_ in 'mock.connected']: true
   }
   let connected = false
   let connectedChainId: number
 
-  return createConnector<Provider, {}, StorageItem>((config) => ({
+  return createConnector<Provider, Properties, StorageItem>((config) => ({
     id: 'mock',
     name: 'Mock Connector',
     type: mock.type,

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -86,8 +86,9 @@ export function mock(parameters: MockParameters) {
     async getAccounts() {
       if (!connected) throw new ConnectorNotConnectedError()
       const provider = await this.getProvider()
-      const accounts = await provider.request({ method: 'eth_accounts' })
-      return accounts.map((x) => getAddress(x))
+      return provider.request({
+        method: 'eth_requestAccounts',
+      })
     },
     async getChainId() {
       const provider = await this.getProvider()

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -97,9 +97,7 @@ export function mock(parameters: MockParameters) {
     async getAccounts() {
       if (!connected) throw new ConnectorNotConnectedError()
       const provider = await this.getProvider()
-      const accounts = await provider
-        .request({ method: 'eth_accounts' })
-        .catch(() => [])
+      const accounts = await provider.request({ method: 'eth_accounts' })
       return accounts.map((x) => getAddress(x))
     },
     async getChainId() {
@@ -148,7 +146,8 @@ export function mock(parameters: MockParameters) {
       const request: EIP1193RequestFn = async ({ method, params }) => {
         // eth methods
         if (method === 'eth_chainId') return numberToHex(connectedChainId)
-        if (method === 'eth_requestAccounts') return parameters.accounts
+        if (method === 'eth_accounts' || method === 'eth_requestAccounts')
+          return parameters.accounts
         if (method === 'eth_signTypedData_v4')
           if (features.signTypedDataError) {
             if (typeof features.signTypedDataError === 'boolean')

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -86,7 +86,7 @@ export function mock(parameters: MockParameters) {
       await config.storage?.setItem('mock.connected', true)
 
       return {
-        accounts,
+        accounts: accounts.map((x) => getAddress(x)),
         chainId: currentChainId,
       }
     },

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -59,8 +59,10 @@ export function mock(parameters: MockParameters) {
     async setup() {
       connectedChainId = config.chains[0].id
 
-      const isConnected = await config.storage?.getItem('mock.connected')
-      if (isConnected && features.reconnect) {
+      const isConnected = Boolean(features.reconnect
+        ? await config.storage?.getItem('mock.connected')
+        : false)
+      if (isConnected) {
         this.connect()
       }
     },
@@ -83,7 +85,9 @@ export function mock(parameters: MockParameters) {
       }
 
       connected = true
-      await config.storage?.setItem('mock.connected', true)
+      if (features.reconnect) {
+        await config.storage?.setItem('mock.connected', true)
+      }
 
       return {
         accounts: accounts.map((x) => getAddress(x)),
@@ -92,7 +96,9 @@ export function mock(parameters: MockParameters) {
     },
     async disconnect() {
       connected = false
-      await config.storage?.removeItem('mock.connected')
+      if (features.reconnect) {
+        await config.storage?.removeItem('mock.connected')
+      }
     },
     async getAccounts() {
       if (!connected) throw new ConnectorNotConnectedError()
@@ -136,7 +142,9 @@ export function mock(parameters: MockParameters) {
     async onDisconnect(_error) {
       config.emitter.emit('disconnect')
       connected = false
-      await config.storage?.removeItem('mock.connected')
+      if (features.reconnect) {
+        await config.storage?.removeItem('mock.connected')
+      }
     },
     async getProvider({ chainId } = {}) {
       const chain =


### PR DESCRIPTION
Fixed #4317 by adding a catch on `getAccounts` method in the mock client and retrieving correctly a walletClient, and also fixed the reconnection behaviour of the mock client by using `config.storage`