### PR TITLE
fix: uniswap wallet trying to make itself look like MetaMask

### DIFF
--- a/.changeset/brave-students-give.md
+++ b/.changeset/brave-students-give.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Added deprecation notice to `injected` target flags.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -37,60 +37,6 @@ export type InjectedParameters = {
 // Regex of wallets/providers that can accurately simulate contract calls & display contract revert reasons.
 const supportsSimulationIdRegex = /(rabby|trustwallet)/
 
-const targetMap = {
-  coinbaseWallet: {
-    id: 'coinbaseWallet',
-    name: 'Coinbase Wallet',
-    provider(window) {
-      if (window?.coinbaseWalletExtension) return window.coinbaseWalletExtension
-      return findProvider(window, 'isCoinbaseWallet')
-    },
-  },
-  metaMask: {
-    id: 'metaMask',
-    name: 'MetaMask',
-    provider(window) {
-      return findProvider(window, (provider) => {
-        if (!provider.isMetaMask) return false
-        // Brave tries to make itself look like MetaMask
-        // Could also try RPC `web3_clientVersion` if following is unreliable
-        if (provider.isBraveWallet && !provider._events && !provider._state)
-          return false
-        // Other wallets that try to look like MetaMask
-        const flags: WalletProviderFlags[] = [
-          'isApexWallet',
-          'isAvalanche',
-          'isBitKeep',
-          'isBlockWallet',
-          'isKuCoinWallet',
-          'isMathWallet',
-          'isOkxWallet',
-          'isOKExWallet',
-          'isOneInchIOSWallet',
-          'isOneInchAndroidWallet',
-          'isOpera',
-          'isPortal',
-          'isRabby',
-          'isTokenPocket',
-          'isTokenary',
-          'isUniswapWallet',
-          'isZerion',
-        ]
-        for (const flag of flags) if (provider[flag]) return false
-        return true
-      })
-    },
-  },
-  phantom: {
-    id: 'phantom',
-    name: 'Phantom',
-    provider(window) {
-      if (window?.phantom?.ethereum) return window.phantom?.ethereum
-      return findProvider(window, 'isPhantom')
-    },
-  },
-} as const satisfies TargetMap
-
 injected.type = 'injected' as const
 export function injected(parameters: InjectedParameters = {}) {
   const { shimDisconnect = true, unstable_shimAsyncInject } = parameters
@@ -583,6 +529,62 @@ export function injected(parameters: InjectedParameters = {}) {
   }))
 }
 
+const targetMap = {
+  coinbaseWallet: {
+    id: 'coinbaseWallet',
+    name: 'Coinbase Wallet',
+    provider(window) {
+      if (window?.coinbaseWalletExtension) return window.coinbaseWalletExtension
+      return findProvider(window, 'isCoinbaseWallet')
+    },
+  },
+  metaMask: {
+    id: 'metaMask',
+    name: 'MetaMask',
+    provider(window) {
+      return findProvider(window, (provider) => {
+        if (!provider.isMetaMask) return false
+        // Brave tries to make itself look like MetaMask
+        // Could also try RPC `web3_clientVersion` if following is unreliable
+        if (provider.isBraveWallet && !provider._events && !provider._state)
+          return false
+        // Other wallets that try to look like MetaMask
+        const flags = [
+          'isApexWallet',
+          'isAvalanche',
+          'isBitKeep',
+          'isBlockWallet',
+          'isKuCoinWallet',
+          'isMathWallet',
+          'isOkxWallet',
+          'isOKExWallet',
+          'isOneInchIOSWallet',
+          'isOneInchAndroidWallet',
+          'isOpera',
+          'isPortal',
+          'isRabby',
+          'isTokenPocket',
+          'isTokenary',
+          'isUniswapWallet',
+          'isZerion',
+        ] satisfies WalletProviderFlags[]
+        for (const flag of flags) if (provider[flag]) return false
+        return true
+      })
+    },
+  },
+  phantom: {
+    id: 'phantom',
+    name: 'Phantom',
+    provider(window) {
+      if (window?.phantom?.ethereum) return window.phantom?.ethereum
+      return findProvider(window, 'isPhantom')
+    },
+  },
+} as const satisfies TargetMap
+
+type TargetMap = { [_ in TargetId]?: Target | undefined }
+
 type Target = {
   icon?: string | undefined
   id: string
@@ -600,9 +602,9 @@ type TargetId = Compute<WalletProviderFlags> extends `is${infer name}`
     : never
   : never
 
-type TargetMap = { [_ in TargetId]?: Target | undefined }
-
-/** @deprecated */
+/**
+ * @deprecated As of 2024/10/16, we are no longer accepting new provider flags as EIP-6963 should be used instead.
+ */
 type WalletProviderFlags =
   | 'isApexWallet'
   | 'isAvalanche'

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -73,6 +73,7 @@ const targetMap = {
           'isRabby',
           'isTokenPocket',
           'isTokenary',
+          'isUniswapWallet',
           'isZerion',
         ]
         for (const flag of flags) if (provider[flag]) return false
@@ -638,6 +639,7 @@ type WalletProviderFlags =
   | 'isTokenary'
   | 'isTrust'
   | 'isTrustWallet'
+  | 'isUniswapWallet'
   | 'isXDEFI'
   | 'isZerion'
 


### PR DESCRIPTION
“Uniswap Wallet” try to fake MetaMask wallet extension with the `isMetaMask` boolean.

But it is not yet in the "fake" MetaMask list here: https://github.com/EdouardBougon/wagmi/blob/a5e7927dfcb9b3930409056b50f810ed96ca4ffa/packages/core/src/connectors/injected.ts#L53-L81

Here the boolean used by Uniswap Wallet: 
<img width="985" alt="Screenshot 2024-10-14 at 11 09 05" src="https://github.com/user-attachments/assets/70883f3f-7679-4e29-9777-f244405e1057">
