### PR TITLE
fix: waitForTransactionReceipt proper eth_call usage

### DIFF
--- a/.changeset/red-trains-switch.md
+++ b/.changeset/red-trains-switch.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed bug in waitForTransactionReceipt where transaction data wasn't passed to eth_call method

--- a/.changeset/red-trains-switch.md
+++ b/.changeset/red-trains-switch.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-Fixed bug in waitForTransactionReceipt where transaction data wasn't passed to eth_call method
+Fixed bug in `waitForTransactionReceipt`, where transaction data wasn't passed to `'eth_call'` method as part of getting the revert reason.

--- a/packages/core/src/actions/waitForTransactionReceipt.ts
+++ b/packages/core/src/actions/waitForTransactionReceipt.ts
@@ -71,7 +71,9 @@ export async function waitForTransactionReceipt<
       maxFeePerGas: txn.type === 'eip1559' ? txn.maxFeePerGas : undefined,
       maxPriorityFeePerGas:
         txn.type === 'eip1559' ? txn.maxPriorityFeePerGas : undefined,
+      data: txn.input ? txn.input : undefined,
     })
+
     const reason = code?.data
       ? hexToString(`0x${code.data.substring(138)}`)
       : 'unknown reason'

--- a/packages/core/src/actions/waitForTransactionReceipt.ts
+++ b/packages/core/src/actions/waitForTransactionReceipt.ts
@@ -67,13 +67,12 @@ export async function waitForTransactionReceipt<
     const action_call = getAction(client, call, 'call')
     const code = await action_call({
       ...(txn as any),
+      data: txn.input,
       gasPrice: txn.type !== 'eip1559' ? txn.gasPrice : undefined,
       maxFeePerGas: txn.type === 'eip1559' ? txn.maxFeePerGas : undefined,
       maxPriorityFeePerGas:
         txn.type === 'eip1559' ? txn.maxPriorityFeePerGas : undefined,
-      data: txn.input ? txn.input : undefined,
     })
-
     const reason = code?.data
       ? hexToString(`0x${code.data.substring(138)}`)
       : 'unknown reason'


### PR DESCRIPTION
This PR addresses a bug in the @wagmi/core library, specifically in the waitForTransactionReceipt function. The bug occurs when arguments are provided to skip simulation and gas estimation. The data field was not being passed to the eth_call function, which resulted in unexpected errors.

I've made a simple repository that has a script that reproduces this issue: https://github.com/AndriyAntonenko/wagmi-waitfortransaction-bug-poc
