### PR TITLE
feat(connectors): filter mipd by connector rdns

### DIFF
--- a/.changeset/curly-yaks-sin.md
+++ b/.changeset/curly-yaks-sin.md
@@ -1,6 +1,6 @@
 ---
-"@wagmi/connectors": patch
-"@wagmi/core": patch
+"@wagmi/connectors": minor
+"@wagmi/core": minor
 ---
 
-Added `rdns` property to connector interface. This is used to filter out duplicate [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected providers when `createConfig#multiInjectedProviderDiscovery` is enabled.
+Added `rdns` property to connector interface. This is used to filter out duplicate [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected providers when [`createConfig#multiInjectedProviderDiscovery`](https://wagmi.sh/core/api/createConfig#multiinjectedproviderdiscovery) is enabled and `createConfig#connectors` already matches EIP-6963 providers' `rdns` property.

--- a/.changeset/curly-yaks-sin.md
+++ b/.changeset/curly-yaks-sin.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/connectors": patch
+"@wagmi/core": patch
+---
+
+Added `rdns` property to connector interface. This is used to filter out duplicate [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected providers when `createConfig#multiInjectedProviderDiscovery` is enabled.

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -89,6 +89,7 @@ function version4(parameters: Version4Parameters) {
   return createConnector<Provider>((config) => ({
     id: 'coinbaseWalletSDK',
     name: 'Coinbase Wallet',
+    rdns: 'com.coinbase.wallet',
     supportsSimulation: true,
     type: coinbaseWallet.type,
     async connect({ chainId } = {}) {

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -263,7 +263,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
             parameters.dappMetadata ??
             (typeof window !== 'undefined'
               ? { url: window.location.origin }
-              : { name: 'wagmi' }),
+              : { name: 'wagmi', url: 'https://wagmi.sh' }),
           useDeeplink: parameters.useDeeplink ?? true,
         })
         await sdk.init()

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -93,6 +93,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'metaMaskSDK',
     name: 'MetaMask',
+    rdns: 'io.metamask',
     type: metaMask.type,
     async setup() {
       const provider = await this.getProvider()

--- a/packages/core/src/connectors/createConnector.ts
+++ b/packages/core/src/connectors/createConnector.ts
@@ -37,6 +37,7 @@ export type CreateConnectorFn<
     readonly icon?: string | undefined
     readonly id: string
     readonly name: string
+    readonly rdns?: string | undefined
     readonly supportsSimulation?: boolean | undefined
     readonly type: string
 

--- a/packages/core/src/createConfig.test.ts
+++ b/packages/core/src/createConfig.test.ts
@@ -1,4 +1,9 @@
 import { accounts, chain, wait } from '@wagmi/test'
+import {
+  type EIP1193Provider,
+  type EIP6963ProviderDetail,
+  announceProvider,
+} from 'mipd'
 import { http } from 'viem'
 import { expect, test, vi } from 'vitest'
 
@@ -352,4 +357,42 @@ test('behavior: setup connector', async () => {
   expect(config.state.current).toBe(connector.uid)
 
   await disconnect(config)
+})
+
+test('behavior: eip 6963 providers', async () => {
+  const detail_1 = {
+    info: {
+      icon: 'data:image/svg+xml,<svg width="32px" height="32px" viewBox="0 0 32 32"/>',
+      name: 'Example Wallet',
+      rdns: 'org.example',
+      uuid: '350670db-19fa-4704-a166-e52e178b59d2',
+    },
+    provider: '<EIP1193Provider_1>' as unknown as EIP1193Provider,
+  } as const satisfies EIP6963ProviderDetail
+  const detail_2 = {
+    info: {
+      icon: 'data:image/svg+xml,<svg width="32px" height="32px" viewBox="0 0 32 32"/>',
+      name: 'Foo Wallet',
+      rdns: 'org.foo',
+      uuid: '12345555-19fa-4704-a166-e52e178b59d2',
+    },
+    provider: '<EIP1193Provider_2>' as unknown as EIP1193Provider,
+  } as const satisfies EIP6963ProviderDetail
+
+  const config = createConfig({
+    chains: [mainnet],
+    transports: {
+      [mainnet.id]: http(),
+    },
+  })
+
+  await wait(100)
+  announceProvider(detail_1)()
+  await wait(100)
+  announceProvider(detail_1)()
+  await wait(100)
+  announceProvider(detail_2)()
+  await wait(100)
+
+  expect(config.connectors.length).toBe(2)
 })

--- a/packages/core/src/createConfig.test.ts
+++ b/packages/core/src/createConfig.test.ts
@@ -361,29 +361,6 @@ test('behavior: setup connector', async () => {
 })
 
 test('behavior: eip 6963 providers', async () => {
-  vi.mock(import('mipd'), async (importOriginal) => {
-    const mod = await importOriginal()
-
-    let _cache: typeof mod | undefined
-    if (!_cache)
-      _cache = {
-        ...mod,
-        createStore() {
-          const store = mod.createStore()
-          return {
-            ...store,
-            getProviders() {
-              return [
-                getProviderDetail({ name: 'Example', rdns: 'com.example' }),
-                getProviderDetail({ name: 'Mock', rdns: 'com.mock' }),
-              ]
-            },
-          }
-        },
-      }
-    return _cache
-  })
-
   const detail_1 = getProviderDetail({ name: 'Foo Wallet', rdns: 'com.foo' })
   const detail_2 = getProviderDetail({ name: 'Bar Wallet', rdns: 'com.bar' })
   const detail_3 = getProviderDetail({ name: 'Mock', rdns: 'com.mock' })
@@ -435,3 +412,26 @@ function getProviderDetail(
     provider: `<EIP1193Provider_${info.rdns}>` as unknown as EIP1193Provider,
   }
 }
+
+vi.mock(import('mipd'), async (importOriginal) => {
+  const mod = await importOriginal()
+
+  let _cache: typeof mod | undefined
+  if (!_cache)
+    _cache = {
+      ...mod,
+      createStore() {
+        const store = mod.createStore()
+        return {
+          ...store,
+          getProviders() {
+            return [
+              getProviderDetail({ name: 'Example', rdns: 'com.example' }),
+              getProviderDetail({ name: 'Mock', rdns: 'com.mock' }),
+            ]
+          },
+        }
+      },
+    }
+  return _cache
+})

--- a/packages/core/src/createConfig.test.ts
+++ b/packages/core/src/createConfig.test.ts
@@ -10,10 +10,10 @@ import { expect, test, vi } from 'vitest'
 import { connect } from './actions/connect.js'
 import { disconnect } from './actions/disconnect.js'
 import { switchChain } from './actions/switchChain.js'
+import { createConnector } from './connectors/createConnector.js'
 import { mock } from './connectors/mock.js'
 import { createConfig } from './createConfig.js'
 import { createStorage } from './createStorage.js'
-import { createConnector } from './connectors/createConnector.js'
 
 const { mainnet, optimism } = chain
 

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -322,18 +322,18 @@ export function createConfig<
 
   // EIP-6963 subscribe for new wallet providers
   mipd?.subscribe((providerDetails) => {
-    const currentConnectorIds = new Set()
-    const currentConnectorRdns = new Set()
+    const connectorIdSet = new Set()
+    const connectorRdnsSet = new Set()
     for (const connector of connectors.getState()) {
-      currentConnectorIds.add(connector.id)
-      if (connector.rdns) currentConnectorRdns.add(connector.rdns)
+      connectorIdSet.add(connector.id)
+      if (connector.rdns) connectorRdnsSet.add(connector.rdns)
     }
 
     const newConnectors: Connector[] = []
     for (const providerDetail of providerDetails) {
-      if (currentConnectorRdns.has(providerDetail.info.rdns)) continue
+      if (connectorRdnsSet.has(providerDetail.info.rdns)) continue
       const connector = setup(providerDetailToConnector(providerDetail))
-      if (currentConnectorIds.has(connector.id)) continue
+      if (connectorIdSet.has(connector.id)) continue
       newConnectors.push(connector)
     }
 

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -100,8 +100,8 @@ export function createConfig<
       collection.push(connector)
       if (!ssr && connector.rdns) rdnsSet.add(connector.rdns)
     }
-    if (!ssr) {
-      const providers = mipd?.getProviders() ?? []
+    if (!ssr && mipd) {
+      const providers = mipd.getProviders()
       for (const provider of providers) {
         if (rdnsSet.has(provider.info.rdns)) continue
         collection.push(setup(providerDetailToConnector(provider)))

--- a/packages/core/src/hydrate.ts
+++ b/packages/core/src/hydrate.ts
@@ -23,14 +23,24 @@ export function hydrate(config: Config, parameters: HydrateParameters) {
     async onMount() {
       if (config._internal.ssr) {
         await config._internal.store.persist.rehydrate()
-        const mipdConnectors = config._internal.mipd
-          ?.getProviders()
-          .map(config._internal.connectors.providerDetailToConnector)
-          .map(config._internal.connectors.setup)
-        config._internal.connectors.setState((connectors) => [
-          ...connectors,
-          ...(mipdConnectors ?? []),
-        ])
+        if (config._internal.mipd) {
+          config._internal.connectors.setState((connectors) => {
+            const rdnsSet = new Set<string>()
+            for (const connector of connectors ?? []) {
+              if (connector.rdns) rdnsSet.add(connector.rdns)
+            }
+            const mipdConnectors = []
+            const providers = config._internal.mipd?.getProviders() ?? []
+            for (const provider of providers) {
+              if (rdnsSet.has(provider.info.rdns)) continue
+              const connectorFn =
+                config._internal.connectors.providerDetailToConnector(provider)
+              const connector = config._internal.connectors.setup(connectorFn)
+              mipdConnectors.push(connector)
+            }
+            return [...connectors, ...mipdConnectors]
+          })
+        }
       }
 
       if (reconnectOnMount) reconnect(config)

--- a/playgrounds/next/src/app/page.tsx
+++ b/playgrounds/next/src/app/page.tsx
@@ -78,7 +78,7 @@ function Account() {
         status: {account.status}
       </div>
 
-      {account.status !== 'disconnected' && (
+      {account.status === 'connected' && (
         <button type="button" onClick={() => disconnect()}>
           Disconnect
         </button>

--- a/site/dev/creating-connectors.md
+++ b/site/dev/creating-connectors.md
@@ -54,6 +54,7 @@ The type error tells you what properties are missing from `createConnector`'s re
 - `icon`: Optional icon URL for the connector.
 - `id`: The ID for the connector. This should be camel-cased and as short as possible. Example: `fooBarBaz`.
 - `name`: Human-readable name for the connector. Example: `'Foo Bar Baz'`.
+- `rdns`: Optional reverse DNS for the connector. This is used to filter out duplicate [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected providers when `createConfig#multiInjectedProviderDiscovery` is enabled.
 - `supportsSimulation`: Whether the connector supports contract simulation. This should be disabled if a connector's wallet cannot accurately simulate contract writes or display contract revert messages. Defaults to `false`.
 
 #### Methods


### PR DESCRIPTION
Allows connectors to specify `rdns` property and filters out matching EIP 6963 connectors from being created.

Related https://github.com/wevm/wagmi/pull/4328

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
