### PR TITLE
fix: MetaMask disconnecting during the connection process.

### DIFF
--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -386,10 +386,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
       }
     },
     async onAccountsChanged(accounts) {
-      // Disconnect if there are no accounts
-      if (accounts.length === 0) this.onDisconnect()
+      // Do nothing if there are no accounts
+      if (accounts.length === 0) return
       // Connect if emitter is listening for connect event (e.g. is disconnected and connects through wallet interface)
-      else if (config.emitter.listenerCount('connect')) {
+      if (config.emitter.listenerCount('connect')) {
         const chainId = (await this.getChainId()).toString()
         this.onConnect({ chainId })
       }


### PR DESCRIPTION
In certain cases, the MetaMask SDK, when connected via mobile, may emit an `accountsChanged` event with an empty list, followed shortly by another event containing the correct account list.

In the current implementation of the MetaMask provider, receiving an empty list causes it to disconnect, leading to unintended side effects.
