### PR TITLE
fix: MetaMask readonlyRPCMap type

### DIFF
--- a/.changeset/curvy-chefs-retire.md
+++ b/.changeset/curvy-chefs-retire.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fixed MetaMask connector internal logic.

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -1,6 +1,7 @@
 import type {
   MetaMaskSDK,
   MetaMaskSDKOptions,
+  RPC_URLS_MAP,
   SDKProvider,
 } from '@metamask/sdk'
 import {
@@ -250,15 +251,15 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           injectProvider: false,
           // Workaround cast since MetaMask SDK does not support `'exactOptionalPropertyTypes'`
           ...(parameters as RemoveUndefined<typeof parameters>),
-          readonlyRPCMap: Object.fromEntries(
-            config.chains.map((chain) => {
-              const [url] = extractRpcUrls({
-                chain,
-                transports: config.transports,
-              })
-              return [chain.id, url]
-            }),
-          ),
+          readonlyRPCMap: config.chains.reduce<RPC_URLS_MAP>((map, chain) => {
+            const [url] = extractRpcUrls({
+              chain,
+              transports: config.transports,
+            })
+            map[`0x${chain.id.toString(16)}`] = url
+
+            return map
+          }, {}),
           dappMetadata:
             parameters.dappMetadata ??
             (typeof window !== 'undefined'

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -244,6 +244,13 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           return SDK as unknown as typeof SDK.default
         })()
 
+        const readonlyRPCMap: RPC_URLS_MAP = {}
+        for (const chain of config.chains)
+          readonlyRPCMap[numberToHex(chain.id)] = extractRpcUrls({
+            chain,
+            transports: config.transports,
+          })?.[0]
+
         sdk = new MetaMaskSDK({
           _source: 'wagmi',
           forceDeleteProvider: false,
@@ -251,15 +258,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           injectProvider: false,
           // Workaround cast since MetaMask SDK does not support `'exactOptionalPropertyTypes'`
           ...(parameters as RemoveUndefined<typeof parameters>),
-          readonlyRPCMap: config.chains.reduce<RPC_URLS_MAP>((map, chain) => {
-            const [url] = extractRpcUrls({
-              chain,
-              transports: config.transports,
-            })
-            map[`0x${chain.id.toString(16)}`] = url
-
-            return map
-          }, {}),
+          readonlyRPCMap,
           dappMetadata:
             parameters.dappMetadata ??
             (typeof window !== 'undefined'


### PR DESCRIPTION
The option readonlyRPCMap should have a chainId in hexString as a key, not a number.