### PR TITLE
Introducing wagmi Guru on Gurubase.io

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -54,6 +54,7 @@
 ## Documentation
 
 For documentation and guides, visit [wagmi.sh](https://wagmi.sh).
+You can also [Ask wagmi Guru](https://gurubase.io/g/wagmi), it is a wagmi-focused AI to answer your questions.
 
 ## Community
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [wagmi Guru](https://gurubase.io/g/wagmi) to Gurubase. wagmi Guru uses the data from this repo and data from the [docs](https://wagmi.sh/) to answer questions by leveraging the LLM.

In this PR, I showcased the "wagmi Guru", which highlights that wagmi now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable wagmi Guru in Gurubase, just let me know that's totally fine.
