### PR TITLE
feat: Improve chain switching via MetaMask connector

### DIFF
--- a/.changeset/thirty-icons-work.md
+++ b/.changeset/thirty-icons-work.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+feat: Improve chain switching via MetaMask connector

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -11,12 +11,7 @@ import {
   createConnector,
   extractRpcUrls,
 } from '@wagmi/core'
-import { 
-  linea,
-  lineaSepolia, 
-  mainnet, 
-  sepolia 
-} from '@wagmi/core/chains'
+import { linea, lineaSepolia, mainnet, sepolia } from '@wagmi/core/chains'
 import type {
   Compute,
   ExactPartial,

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -11,6 +11,12 @@ import {
   createConnector,
   extractRpcUrls,
 } from '@wagmi/core'
+import { 
+  linea,
+  lineaSepolia, 
+  mainnet, 
+  sepolia 
+} from '@wagmi/core/chains'
 import type {
   Compute,
   ExactPartial,
@@ -18,12 +24,6 @@ import type {
   RemoveUndefined,
   UnionCompute,
 } from '@wagmi/core/internal'
-import {
-  mainnet,
-  sepolia,
-  linea,
-  lineaSepolia
-} from '@wagmi/core/chains'
 import {
   type AddEthereumChainParameter,
   type Address,
@@ -317,60 +317,59 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
       // This avoids the need to react to the "unrecognized chain" error
       // and consequent back and forth between MetaMask and Wagmi.
       const metaMaskDefaultChains = [
-        mainnet.id, 
-        sepolia.id, 
-        linea.id, 
-        lineaSepolia.id
-      ];
+        mainnet.id,
+        sepolia.id,
+        linea.id,
+        lineaSepolia.id,
+      ]
       const isDefaultChain = metaMaskDefaultChains.find((x) => x === chainId)
 
       if (!isDefaultChain) {
-          try {
-              const { default: blockExplorer, ...blockExplorers } =
-                chain.blockExplorers ?? {}
-              let blockExplorerUrls: string[] | undefined
-              if (addEthereumChainParameter?.blockExplorerUrls)
-                blockExplorerUrls = addEthereumChainParameter.blockExplorerUrls
-              else if (blockExplorer)
-                blockExplorerUrls = [
-                  blockExplorer.url,
-                  ...Object.values(blockExplorers).map((x) => x.url),
-                ]
-  
-              let rpcUrls: readonly string[]
-              if (addEthereumChainParameter?.rpcUrls?.length)
-                rpcUrls = addEthereumChainParameter.rpcUrls
-              else rpcUrls = [chain.rpcUrls.default?.http[0] ?? '']
-  
-              const addEthereumChain = {
-                blockExplorerUrls,
-                chainId: numberToHex(chainId),
-                chainName: addEthereumChainParameter?.chainName ?? chain.name,
-                iconUrls: addEthereumChainParameter?.iconUrls,
-                nativeCurrency:
-                  addEthereumChainParameter?.nativeCurrency ??
-                  chain.nativeCurrency,
-                rpcUrls,
-              } satisfies AddEthereumChainParameter
-  
-              await provider.request({
-                method: 'wallet_addEthereumChain',
-                params: [addEthereumChain],
-              })
+        try {
+          const { default: blockExplorer, ...blockExplorers } =
+            chain.blockExplorers ?? {}
+          let blockExplorerUrls: string[] | undefined
+          if (addEthereumChainParameter?.blockExplorerUrls)
+            blockExplorerUrls = addEthereumChainParameter.blockExplorerUrls
+          else if (blockExplorer)
+            blockExplorerUrls = [
+              blockExplorer.url,
+              ...Object.values(blockExplorers).map((x) => x.url),
+            ]
 
-              const currentChainId = hexToNumber(
-                  // Call `'eth_chainId'` directly to guard against `this.state.chainId` (via `provider.getChainId`) being stale.
-                  (await provider.request({ method: 'eth_chainId' })) as Hex,
-                )
-                if (currentChainId !== chainId)
-                  throw new UserRejectedRequestError(
-                    new Error('User rejected switch after adding network.'),
-                  )
-    
-                return chain
-          } catch (error) {
-              throw new UserRejectedRequestError(error as Error)
-          }
+          let rpcUrls: readonly string[]
+          if (addEthereumChainParameter?.rpcUrls?.length)
+            rpcUrls = addEthereumChainParameter.rpcUrls
+          else rpcUrls = [chain.rpcUrls.default?.http[0] ?? '']
+
+          const addEthereumChain = {
+            blockExplorerUrls,
+            chainId: numberToHex(chainId),
+            chainName: addEthereumChainParameter?.chainName ?? chain.name,
+            iconUrls: addEthereumChainParameter?.iconUrls,
+            nativeCurrency:
+              addEthereumChainParameter?.nativeCurrency ?? chain.nativeCurrency,
+            rpcUrls,
+          } satisfies AddEthereumChainParameter
+
+          await provider.request({
+            method: 'wallet_addEthereumChain',
+            params: [addEthereumChain],
+          })
+
+          const currentChainId = hexToNumber(
+            // Call `'eth_chainId'` directly to guard against `this.state.chainId` (via `provider.getChainId`) being stale.
+            (await provider.request({ method: 'eth_chainId' })) as Hex,
+          )
+          if (currentChainId !== chainId)
+            throw new UserRejectedRequestError(
+              new Error('User rejected switch after adding network.'),
+            )
+
+          return chain
+        } catch (error) {
+          throw new UserRejectedRequestError(error as Error)
+        }
       }
 
       try {


### PR DESCRIPTION
This PR aims to solve an issue where the original logic of switchChain -> add if it's not present would cause an extra back and forth between dapp and the MetaMask wallet, particularly on Mobile to Mobile interactions.

- Adds a retry to the eth_chainId call to avoid a race condition

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
