### PR TITLE
fix: eventName not properly set in createWatchContractEvent

### DIFF
--- a/.changeset/perfect-tigers-raise.md
+++ b/.changeset/perfect-tigers-raise.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `createWatchContractEvent` internal wiring, where `eventName` was incorrectly `functionName`.

--- a/packages/core/src/actions/codegen/createWatchContractEvent.ts
+++ b/packages/core/src/actions/codegen/createWatchContractEvent.ts
@@ -71,7 +71,7 @@ export function createWatchContractEvent<
         configChainId
       return watchContractEvent(config, {
         ...(parameters as any),
-        ...(c.eventName ? { functionName: c.eventName } : {}),
+        ...(c.eventName ? { eventName: c.eventName } : {}),
         address: c.address?.[chainId],
         abi: c.abi,
       })
@@ -81,7 +81,7 @@ export function createWatchContractEvent<
     return watchContractEvent(config, {
       ...(parameters as any),
       ...(c.address ? { address: c.address } : {}),
-      ...(c.eventName ? { functionName: c.eventName } : {}),
+      ...(c.eventName ? { eventName: c.eventName } : {}),
       abi: c.abi,
     })
   }


### PR DESCRIPTION
`createWatchContractEvent` actual behavior don't take `eventName` in considreation because it use `functionName` instead of `eventName`, probably a typo.

This PR fix that.