### PR TITLE
fix: Remove duplicated Parameters from core doc in react useWaitForTransactionReceipt.md

### DIFF
--- a/site/react/api/hooks/useWaitForTransactionReceipt.md
+++ b/site/react/api/hooks/useWaitForTransactionReceipt.md
@@ -42,12 +42,6 @@ function App() {
 import { type UseWaitForTransactionReceiptParameters } from 'wagmi'
 ```
 
-## Parameters
-
-```ts
-import { type WaitForTransactionReceiptParameters } from '@wagmi/core'
-```
-
 ### chainId
 
 `config['chains'][number]['id'] | undefined`


### PR DESCRIPTION
There is 2 [Parameters](https://wagmi.sh/react/api/hooks/useWaitForTransactionReceipt#parameters-1) sections in `useWaitForTransactionReceipt` docs. The one using `core` should not be in `react` documentation.

This PR remove it.