### PR TITLE
feat: support multiple rdns values to prevent duplicate connectors

### DIFF
--- a/packages/core/src/connectors/createConnector.ts
+++ b/packages/core/src/connectors/createConnector.ts
@@ -37,7 +37,7 @@ export type CreateConnectorFn<
     readonly icon?: string | undefined
     readonly id: string
     readonly name: string
-    readonly rdns?: string | undefined
+    readonly rdns?: string | readonly string[] | undefined
     readonly supportsSimulation?: boolean | undefined
     readonly type: string
 

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -98,7 +98,14 @@ export function createConfig<
     for (const connectorFns of rest.connectors ?? []) {
       const connector = setup(connectorFns)
       collection.push(connector)
-      if (!ssr && connector.rdns) rdnsSet.add(connector.rdns)
+      if (!ssr && connector.rdns) {
+        const rdnsValues = Array.isArray(connector.rdns)
+          ? connector.rdns
+          : [connector.rdns]
+        for (const rdns of rdnsValues) {
+          rdnsSet.add(rdns)
+        }
+      }
     }
     if (!ssr && mipd) {
       const providers = mipd.getProviders()

--- a/packages/core/src/hydrate.ts
+++ b/packages/core/src/hydrate.ts
@@ -27,7 +27,14 @@ export function hydrate(config: Config, parameters: HydrateParameters) {
           config._internal.connectors.setState((connectors) => {
             const rdnsSet = new Set<string>()
             for (const connector of connectors ?? []) {
-              if (connector.rdns) rdnsSet.add(connector.rdns)
+              if (connector.rdns) {
+                const rdnsValues = Array.isArray(connector.rdns)
+                  ? connector.rdns
+                  : [connector.rdns]
+                for (const rdns of rdnsValues) {
+                  rdnsSet.add(rdns)
+                }
+              }
             }
             const mipdConnectors = []
             const providers = config._internal.mipd?.getProviders() ?? []


### PR DESCRIPTION
# Support multiple rdns values to prevent duplicate connectors

## Description
Modified the `rdns` property to accept both string and string array values, preventing duplicate MetaMask connectors when using mobile browser.

## Changes
- Updated `rdns` type to accept `string | readonly string[]`
- Modified connector setup to handle multiple rdns values
- Fixed duplicate MetaMask mobile connector issue (io.metamask.mobile)

Fixes #4404 