### PR TITLE
Use new init method + expose preference object

### DIFF
--- a/.changeset/bright-suns-rush.md
+++ b/.changeset/bright-suns-rush.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": minor
+---
+
+Added `preference` object for Coinbase Wallet connector.

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -1,4 +1,5 @@
 import type {
+  Preference,
   ProviderInterface,
   createCoinbaseWalletSDK,
 } from '@coinbase/wallet-sdk'
@@ -63,7 +64,23 @@ type Version4Parameters = Mutable<
   Omit<
     Parameters<typeof createCoinbaseWalletSDK>[0],
     'appChainIds' // set via wagmi config
-  >
+  > & {
+    /**
+     * Preference for the type of wallet to display.
+     * @default 'all'
+     */
+    preference?: Preference['options'] | undefined
+    /**
+     * Attribution for smart wallet onchain analytics.
+     * @default undefined
+     */
+    attribution?: Preference['attribution'] | undefined
+    /**
+     * Keys URL of Coinbase smart wallet.
+     * @default 'https://keys.coinbase.com/connect'
+     */
+    keysUrl?: Preference['keysUrl'] | undefined
+  }
 >
 
 function version4(parameters: Version4Parameters) {
@@ -173,6 +190,11 @@ function version4(parameters: Version4Parameters) {
         const sdk = createCoinbaseWalletSDK({
           ...parameters,
           appChainIds: config.chains.map((x) => x.id),
+          preference: {
+            options: parameters.preference ?? 'all',
+            attribution: parameters.attribution,
+            keysUrl: parameters.keysUrl,
+          },
         })
 
         walletProvider = sdk.getProvider()

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -1,6 +1,6 @@
 import type {
-  createCoinbaseWalletSDK,
   ProviderInterface,
+  createCoinbaseWalletSDK,
 } from '@coinbase/wallet-sdk'
 import {
   ChainNotConfiguredError,

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -66,6 +66,7 @@ type Version4Parameters = Mutable<
     | 'appChainIds' // set via wagmi config
     | 'preference'
   > & {
+    // TODO(v3): Remove `Preference['options']`
     /**
      * Preference for the type of wallet to display.
      * @default 'all'

--- a/site/shared/connectors/coinbaseWallet.md
+++ b/site/shared/connectors/coinbaseWallet.md
@@ -106,7 +106,45 @@ const connector = coinbaseWallet({
 })
 ```
 
-### version <Badge text=">=2.9.0" />
+::: warning
+Passing `preference` as a string is deprecated and will be removed in the next major version. Instead you should use [`preference#options`](#options).
+:::
+
+```ts-vue
+import { coinbaseWallet } from '{{connectorsPackageName}}'
+
+const connector = coinbaseWallet({
+  appName: 'My Wagmi App',
+  preference: { // [!code focus]
+    options: 'smartWalletOnly' // [!code focus]
+  }, // [!code focus]
+})
+```
+
+#### attribution <Badge text=">=2.13.0" />
+
+`` { auto?: boolean | undefined; dataSuffix?: `0x${string}` | undefined } ``
+
+This option only applies to Coinbase Smart Wallet. When a valid data suffix is supplied, it is appended to the `initCode` and `executeBatch` calldata. Coinbase Smart Wallet expects a 16 byte hex string. If the data suffix is not a 16 byte hex string, the Smart Wallet will ignore the property. If auto is true, the Smart Wallet will generate a 16 byte hex string from the apps origin.
+
+#### keysUrl <Badge text=">=2.13.0" />
+
+`string`
+
+- The URL for the keys popup.
+- By default, `https://keys.coinbase.com/connect` is used for production. Use `https://keys-dev.coinbase.com/connect` for development environments.
+
+#### options <Badge text=">=2.13.0" />
+
+`"all" | "eoaOnly" | "smartWalletOnly"`
+
+Preference for the type of wallet to display.
+
+- `'eoaOnly'`: Uses EOA Browser Extension or Mobile Coinbase Wallet.
+- `'smartWalletOnly'`: Displays Smart Wallet popup.
+- `'all'` (default): Supports both `'eoaOnly'` and `'smartWalletOnly'` based on context.
+
+### version <Badge text=">=2.13.0" />
 
 - Coinbase Wallet SDK version
 - Defaults to `'4'`. If [`headlessMode: true`](#headlessmode), defaults to `'3'`.


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

In latest `@coinbase/wallet-sdk`, we enriched one of the config param, `preference`, to be able to take `attribution` for onchain analytics, `keysUrl` for testing against different smart wallet env. So updating `@wagmi/connectors` to expose this new preference object to end users.

* this preference object can take arbitrary param, so it provides more flexibility to end user as we push out more new params
* this PR also replaced the deprecated class `CoinbaseWalletSDK` with the newly-introduced `createCoinbaseWalletSDK` to better align w js norm

### Demo

https://github.com/user-attachments/assets/a8e0c81d-8f57-46de-b15a-8745b8c99d83




<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
