### PR TITLE
fix: Bump Metamask SDK version to fix webpack dynamic import issue

### DIFF
--- a/.changeset/late-hotels-report.md
+++ b/.changeset/late-hotels-report.md
@@ -1,5 +1,8 @@
 ---
 "@wagmi/connectors": patch
+"wagmi": patch
+"@wagmi/core": patch
+"@wagmi/vue": patch
 ---
 
-Bumped Metamask SDK version fixing webpack dynamic import issue
+Bumped Metamask SDK version to `0.31.1`.

--- a/.changeset/late-hotels-report.md
+++ b/.changeset/late-hotels-report.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Bumped Metamask SDK version fixing webpack dynamic import issue

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "4.2.3",
-    "@metamask/sdk": "0.31.0",
+    "@metamask/sdk": "0.31.1",
     "@safe-global/safe-apps-provider": "0.18.4",
     "@safe-global/safe-apps-sdk": "9.1.0",
     "@walletconnect/ethereum-provider": "2.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3
       '@metamask/sdk':
-        specifier: 0.31.0
-        version: 0.31.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        specifier: 0.31.1
+        version: 0.31.1(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider':
         specifier: 0.18.4
         version: 0.18.4(bufferutil@4.0.8)(encoding@0.1.13)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -1783,11 +1783,11 @@ packages:
       readable-stream: ^3.6.2
       socket.io-client: ^4.5.1
 
-  '@metamask/sdk-install-modal-web@0.31.0':
-    resolution: {integrity: sha512-nr8AZ+ccEfC3BmzTkT2wH16wOARqVrkhAFqsxYsnaozn+BAb+Hwo/GRhaIGzYgYFj/tTD3SM0UtXd6x2gzMDQw==}
+  '@metamask/sdk-install-modal-web@0.31.1':
+    resolution: {integrity: sha512-J83K6jN2V3xkTb+/5eyASatlgqHdpzjkTVU6cC+Z/YA9cE32zX8vE0EQweGmExgv+kJ5zz/BiqSZZbMfuilRfQ==}
 
-  '@metamask/sdk@0.31.0':
-    resolution: {integrity: sha512-L1TKg7NkgCJbjkJsDTC6ZEpjGdroxsFksm17eGWPmNqdPf561ujJkU3xWCUPxEvU0hI+Wz3y2GegJsNej9/jWw==}
+  '@metamask/sdk@0.31.1':
+    resolution: {integrity: sha512-olU3TYRAxIZP5ZXDmi5Y53zXikkPySNiTuBI4QD+2hWYomVlMV2SjOKHSRR6gPuI+fFEg/Z+ImrxDthQfMODwA==}
 
   '@metamask/utils@5.0.2':
     resolution: {integrity: sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==}
@@ -9675,17 +9675,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@metamask/sdk-install-modal-web@0.31.0':
+  '@metamask/sdk-install-modal-web@0.31.1':
     dependencies:
       '@paulmillr/qr': 0.2.1
 
-  '@metamask/sdk@0.31.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@metamask/sdk@0.31.1(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
       '@metamask/sdk-communication-layer': 0.31.0(cross-fetch@4.0.0(encoding@0.1.13))(eciesjs@0.4.12)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@metamask/sdk-install-modal-web': 0.31.0
+      '@metamask/sdk-install-modal-web': 0.31.1
       '@paulmillr/qr': 0.2.1
       bowser: 2.11.0
       cross-fetch: 4.0.0(encoding@0.1.13)


### PR DESCRIPTION
Bumps the metamask sdk version to 0.31.1 to fix the webpack dynamic import issue. Metamask SDK 0.31.0 has this issue and prevents @wagmi/connector from working in nextjs. See the next playground example on main to see the error. https://github.com/MetaMask/metamask-sdk/issues/1150

fixes #4432 