### PR TITLE
Coinbase Wallet: Add Support for Instant Onboarding mode

### DIFF
--- a/.changeset/big-radios-sip.md
+++ b/.changeset/big-radios-sip.md
@@ -1,5 +1,5 @@
 ---
-"@wagmi/connectors": patch
+"@wagmi/connectors": minor
 ---
 
-Supports Instant Onboarding mode of Coinbase Smart Wallet
+Added Coinbase Smart Wallet "Instant Onboarding" mode to `coinbaseWallet`.

--- a/.changeset/big-radios-sip.md
+++ b/.changeset/big-radios-sip.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Supports Instant Onboarding mode of Coinbase Smart Wallet

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest",
     "test:build": "bun scripts/generateProxyPackages.ts && pnpm run --r --parallel test:build",
     "test:cli": "vitest --project @wagmi/cli",
+    "test:connectors": "vitest --project @wagmi/connectors",
     "test:core": "vitest --project @wagmi/core",
     "test:create-wagmi": "vitest --project create-wagmi",
     "test:cov": "vitest run --coverage",

--- a/packages/connectors/src/coinbaseWallet.test.ts
+++ b/packages/connectors/src/coinbaseWallet.test.ts
@@ -1,10 +1,17 @@
 import { config } from '@wagmi/test'
-import { expect, test } from 'vitest'
+import { expect, expectTypeOf, test } from 'vitest'
 
 import { coinbaseWallet } from './coinbaseWallet.js'
 
 test('setup', () => {
-  const connectorFn = coinbaseWallet({ appName: 'wagmi' })
+  const connectorFn = coinbaseWallet({ appName: 'wagmi', version: '4' })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual('Coinbase Wallet')
+
+  type ConnectFnParameters = NonNullable<
+    Parameters<(typeof connector)['connect']>[0]
+  >
+  expectTypeOf<ConnectFnParameters['instantOnboarding']>().toMatchTypeOf<
+    boolean | undefined
+  >()
 })

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -87,6 +87,8 @@ function version4(parameters: Version4Parameters) {
   let chainChanged: Connector['onChainChanged'] | undefined
   let disconnect: Connector['onDisconnect'] | undefined
 
+  let instantOnboarding = false;
+
   return createConnector<Provider>((config) => ({
     id: 'coinbaseWalletSDK',
     name: 'Coinbase Wallet',
@@ -98,6 +100,7 @@ function version4(parameters: Version4Parameters) {
         const accounts = (
           (await provider.request({
             method: 'eth_requestAccounts',
+            params: instantOnboarding ? [{ onboarding: "instant" }] : [],
           })) as string[]
         ).map((x) => getAddress(x))
 
@@ -281,6 +284,9 @@ function version4(parameters: Version4Parameters) {
         provider.removeListener('disconnect', disconnect)
         disconnect = undefined
       }
+    },
+    setInstantOnboarding(value: boolean) {
+      instantOnboarding = value;
     },
   }))
 }

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -15,6 +15,7 @@ import type {
 } from 'cbw-sdk'
 import {
   type AddEthereumChainParameter,
+  type Address,
   type Hex,
   type ProviderRpcError,
   SwitchChainError,
@@ -80,6 +81,15 @@ function version4(parameters: Version4Parameters) {
     // for backwards compatibility
     close?(): void
   }
+  type Properties = {
+    connect(parameters?: {
+      chainId?: number | undefined
+      instantOnboarding?: boolean | undefined
+    }): Promise<{
+      accounts: readonly Address[]
+      chainId: number
+    }>
+  }
 
   let walletProvider: Provider | undefined
 
@@ -87,20 +97,21 @@ function version4(parameters: Version4Parameters) {
   let chainChanged: Connector['onChainChanged'] | undefined
   let disconnect: Connector['onDisconnect'] | undefined
 
-  let instantOnboarding = false;
-
-  return createConnector<Provider>((config) => ({
+  return createConnector<Provider, Properties>((config) => ({
     id: 'coinbaseWalletSDK',
     name: 'Coinbase Wallet',
     rdns: 'com.coinbase.wallet',
     type: coinbaseWallet.type,
-    async connect({ chainId } = {}) {
+    async connect({ chainId, ...rest } = {}) {
       try {
         const provider = await this.getProvider()
         const accounts = (
           (await provider.request({
             method: 'eth_requestAccounts',
-            params: instantOnboarding ? [{ onboarding: "instant" }] : [],
+            params:
+              'instantOnboarding' in rest && rest.instantOnboarding
+                ? [{ onboarding: 'instant' }]
+                : [],
           })) as string[]
         ).map((x) => getAddress(x))
 
@@ -284,9 +295,6 @@ function version4(parameters: Version4Parameters) {
         provider.removeListener('disconnect', disconnect)
         disconnect = undefined
       }
-    },
-    setInstantOnboarding(value: boolean) {
-      instantOnboarding = value;
     },
   }))
 }

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -78,7 +78,10 @@ export function walletConnect(parameters: WalletConnectParameters) {
 
   type Provider = Awaited<ReturnType<(typeof EthereumProvider)['init']>>
   type Properties = {
-    connect(parameters?: { chainId?: number; pairingTopic?: string }): Promise<{
+    connect(parameters?: {
+      chainId?: number | undefined
+      pairingTopic?: string | undefined
+    }): Promise<{
       accounts: readonly Address[]
       chainId: number
     }>


### PR DESCRIPTION
This PR adds support for the instant onboarding mode of Coinbase Smart Wallet. It enables the same behaviour of the `Create Wallet` button on https://wallet.coinbase.com and skipping the first screen, where around 50% of my userbase clicked the wrong button. 

Use like this:

```typescript
(coinbaseWalletConnector as any).setInstantOnboarding(true);
await connectAsync({ connector: coinbaseWalletConnector });
```

https://github.com/user-attachments/assets/1d38ad7d-e78a-42c1-84ce-aad1117fba41