### PR TITLE
Fix: pass config parameter to useConnectorClient in useSimulateContract and useEstimateGas

### DIFF
--- a/.changeset/proud-knives-behave.md
+++ b/.changeset/proud-knives-behave.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Fixed config parameter passing in useSimulateContract and useEstimateGas

--- a/packages/react/src/hooks/useEstimateGas.ts
+++ b/packages/react/src/hooks/useEstimateGas.ts
@@ -51,6 +51,7 @@ export function useEstimateGas(
 
   const config = useConfig(parameters)
   const { data: connectorClient } = useConnectorClient({
+    config,
     connector,
     query: { enabled: parameters.account === undefined },
   })

--- a/packages/react/src/hooks/useSimulateContract.ts
+++ b/packages/react/src/hooks/useSimulateContract.ts
@@ -92,6 +92,7 @@ export function useSimulateContract<
 
   const config = useConfig(parameters)
   const { data: connectorClient } = useConnectorClient({
+    config,
     connector,
     query: { enabled: parameters.account === undefined },
   })


### PR DESCRIPTION
Added the config parameter to `useConnectorClient` parameters when used in `useSimulateContract` and `useEstimateGas`. `useConnectorClient` would always call `useConfig` as config wasn't provided in the parameters, this broke providing a config to either hook and would mean `useConfig` was triggered in both hooks. This caused an error when `WagmiProvider` wasn't available in the context, as `useConnectorClient` would call `useContext(WagmiContext)` even if a config parameter was provided to the parent hooks.