### PR TITLE
refactor(cli): remove `fs-extra` and `find-up`

### DIFF
--- a/.changeset/plenty-ligers-smell.md
+++ b/.changeset/plenty-ligers-smell.md
@@ -1,0 +1,6 @@
+---
+"create-wagmi": patch
+"@wagmi/cli": patch
+---
+
+Removed internal usage of `fs-extra`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,10 +72,9 @@
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",
     "esbuild": "^0.19.0",
+    "escalade": "3.2.0",
     "execa": "^8.0.1",
     "fdir": "^6.1.1",
-    "find-up": "^6.3.0",
-    "fs-extra": "^11.2.0",
     "nanospinner": "1.2.2",
     "pathe": "^1.1.2",
     "picocolors": "^1.0.0",
@@ -86,7 +85,6 @@
   },
   "devDependencies": {
     "@types/dedent": "^0.7.2",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.12.10",
     "fixturez": "^1.1.0",
     "msw": "^2.4.9"

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent'
-import { readFile } from 'fs-extra'
 import { resolve } from 'pathe'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
+import { readFile } from 'node:fs/promises'
 import { createFixture, typecheck, watchConsole } from '../../test/utils.js'
 import { generate } from './generate.js'
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,10 +1,10 @@
+import { mkdir, writeFile } from 'node:fs/promises'
 import type { Abi } from 'abitype'
 import { Abi as AbiSchema } from 'abitype/zod'
 import { camelCase } from 'change-case'
 import type { ChokidarOptions, FSWatcher } from 'chokidar'
 import { watch } from 'chokidar'
 import { default as dedent } from 'dedent'
-import { default as fs } from 'fs-extra'
 import { basename, dirname, resolve } from 'pathe'
 import pc from 'picocolors'
 import { type Address, getAddress } from 'viem'
@@ -396,9 +396,9 @@ async function writeContracts({
   // Format and write output
   const cwd = process.cwd()
   const outPath = resolve(cwd, filename)
-  await fs.ensureDir(dirname(outPath))
+  await mkdir(dirname(outPath), { recursive: true })
   const formatted = await format(code)
-  await fs.writeFile(outPath, formatted)
+  await writeFile(outPath, formatted)
 }
 
 function getBannerContent({ name }: { name: string }) {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,10 +1,10 @@
-import { default as fs } from 'fs-extra'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile } from 'node:fs/promises'
 import { resolve } from 'pathe'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import { createFixture, watchConsole } from '../../test/utils.js'
 import { defaultConfig } from '../config.js'
-
 import { init } from './init.js'
 
 let console: ReturnType<typeof watchConsole>
@@ -23,8 +23,8 @@ test('creates config file', async () => {
 
   const configFile = await init()
 
-  expect(fs.existsSync(configFile)).toBeTruthy()
-  expect(await fs.readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
+  expect(existsSync(configFile)).toBeTruthy()
+  expect(await readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
       "// @ts-check
 
       /** @type {import('@wagmi/cli').Config} */
@@ -53,8 +53,8 @@ test('parameters: config', async () => {
     config: 'foo.config.ts',
   })
 
-  expect(fs.existsSync(configFile)).toBeTruthy()
-  expect(await fs.readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
+  expect(existsSync(configFile)).toBeTruthy()
+  expect(await readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
         "// @ts-check
 
         /** @type {import('@wagmi/cli').Config} */
@@ -90,8 +90,8 @@ test('parameters: content', async () => {
     },
   })
 
-  expect(fs.existsSync(configFile)).toBeTruthy()
-  expect(await fs.readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
+  expect(existsSync(configFile)).toBeTruthy()
+  expect(await readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
       "import { defineConfig } from '@wagmi/cli'
 
       export default defineConfig({
@@ -114,14 +114,14 @@ test('parameters: root', async () => {
   const { dir } = await createFixture()
   const spy = vi.spyOn(process, 'cwd')
   spy.mockImplementation(() => dir)
-  fs.mkdir(resolve(dir, 'foo'))
+  mkdir(resolve(dir, 'foo'))
 
   const configFile = await init({
     root: 'foo/',
   })
 
-  expect(fs.existsSync(configFile)).toBeTruthy()
-  expect(await fs.readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
+  expect(existsSync(configFile)).toBeTruthy()
+  expect(await readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
         "// @ts-check
 
         /** @type {import('@wagmi/cli').Config} */
@@ -152,8 +152,8 @@ test('behavior: creates config file in TypeScript format', async () => {
 
   const configFile = await init()
 
-  expect(fs.existsSync(configFile)).toBeTruthy()
-  expect(await fs.readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
+  expect(existsSync(configFile)).toBeTruthy()
+  expect(await readFile(configFile, 'utf-8')).toMatchInlineSnapshot(`
       "import { defineConfig } from '@wagmi/cli'
 
       export default defineConfig({

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,5 @@
+import { writeFile } from 'node:fs/promises'
 import dedent from 'dedent'
-import { default as fs } from 'fs-extra'
 import { relative, resolve } from 'pathe'
 import pc from 'picocolors'
 import { z } from 'zod'
@@ -85,7 +85,7 @@ export async function init(options: Init = {}) {
   }
 
   const formatted = await format(content)
-  await fs.writeFile(outPath, formatted)
+  await writeFile(outPath, formatted)
   spinner.success()
   logger.success(
     `Config created at ${pc.gray(relative(process.cwd(), outPath))}`,

--- a/packages/cli/src/plugins/fetch.test.ts
+++ b/packages/cli/src/plugins/fetch.test.ts
@@ -1,5 +1,5 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { default as fs } from 'fs-extra'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
 
@@ -72,7 +72,7 @@ test('aborts request', () => {
 
 test('reads from cache', async () => {
   const cacheDir = `${homedir}/.wagmi-cli/plugins/fetch/cache`
-  await fs.ensureDir(cacheDir)
+  await mkdir(cacheDir, { recursive: true })
 
   const contract = {
     name: 'WagmiMintExample',
@@ -80,18 +80,25 @@ test('reads from cache', async () => {
   } as const
   const cacheKey = JSON.stringify(contract)
   const cacheFilePath = `${cacheDir}/${cacheKey}.json`
-  await fs.writeJSON(cacheFilePath, {
-    abi: [
+  await writeFile(
+    cacheFilePath,
+    JSON.stringify(
       {
-        inputs: [],
-        name: 'mint',
-        outputs: [],
-        stateMutability: 'nonpayable',
-        type: 'function',
+        abi: [
+          {
+            inputs: [],
+            name: 'mint',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+        ],
+        timestamp: Date.now() + 30_000,
       },
-    ],
-    timestamp: Date.now() + 30_000,
-  })
+      null,
+      2,
+    ),
+  )
 
   await expect(
     fetch({
@@ -117,12 +124,12 @@ test('reads from cache', async () => {
       ]
     `)
 
-  await fs.rm(cacheDir, { recursive: true })
+  await rm(cacheDir, { recursive: true })
 })
 
 test('fails and reads from cache', async () => {
   const cacheDir = `${homedir}/.wagmi-cli/plugins/fetch/cache`
-  await fs.ensureDir(cacheDir)
+  await mkdir(cacheDir, { recursive: true })
 
   const contract = {
     name: 'WagmiMintExample',
@@ -130,18 +137,25 @@ test('fails and reads from cache', async () => {
   } as const
   const cacheKey = JSON.stringify(contract)
   const cacheFilePath = `${cacheDir}/${cacheKey}.json`
-  await fs.writeJSON(cacheFilePath, {
-    abi: [
+  await writeFile(
+    cacheFilePath,
+    JSON.stringify(
       {
-        inputs: [],
-        name: 'mint',
-        outputs: [],
-        stateMutability: 'nonpayable',
-        type: 'function',
+        abi: [
+          {
+            inputs: [],
+            name: 'mint',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+        ],
+        timestamp: Date.now() - 30_000,
       },
-    ],
-    timestamp: Date.now() - 30_000,
-  })
+      null,
+      2,
+    ),
+  )
 
   await expect(
     fetch({
@@ -168,5 +182,5 @@ test('fails and reads from cache', async () => {
       ]
     `)
 
-  await fs.rm(cacheDir, { recursive: true })
+  await rm(cacheDir, { recursive: true })
 })

--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -1,8 +1,8 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import dedent from 'dedent'
 import { execa, execaCommandSync } from 'execa'
 import { fdir } from 'fdir'
-import { default as fs } from 'fs-extra'
-
 import { basename, extname, join, resolve } from 'pathe'
 import pc from 'picocolors'
 import { z } from 'zod'
@@ -125,7 +125,7 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
   }
 
   async function getContract(artifactPath: string) {
-    const artifact = await fs.readJSON(artifactPath)
+    const artifact = await JSON.parse(await readFile(artifactPath, 'utf8'))
     return {
       abi: artifact.abi,
       address: (deployments as Record<string, ContractConfig['address']>)[
@@ -173,7 +173,7 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     async contracts() {
       if (clean) await execa(forgeExecutable, ['clean', '--root', project])
       if (build) await execa(forgeExecutable, ['build', '--root', project])
-      if (!fs.pathExistsSync(artifactsDirectory))
+      if (!existsSync(artifactsDirectory))
         throw new Error('Artifacts not found.')
 
       const artifactPaths = await getArtifactPaths(artifactsDirectory)
@@ -188,7 +188,7 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     name: 'Foundry',
     async validate() {
       // Check that project directory exists
-      if (!(await fs.pathExists(project)))
+      if (!existsSync(project))
         throw new Error(`Foundry project ${pc.gray(config.project)} not found.`)
 
       // Ensure forge is installed

--- a/packages/cli/src/plugins/hardhat.ts
+++ b/packages/cli/src/plugins/hardhat.ts
@@ -1,6 +1,7 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { execa } from 'execa'
 import { fdir } from 'fdir'
-import { default as fs } from 'fs-extra'
 import { basename, extname, join, resolve } from 'pathe'
 import pc from 'picocolors'
 
@@ -84,7 +85,7 @@ export function hardhat(config: HardhatConfig): HardhatResult {
   }
 
   async function getContract(artifactPath: string) {
-    const artifact = await fs.readJSON(artifactPath)
+    const artifact = await JSON.parse(await readFile(artifactPath, 'utf8'))
     return {
       abi: artifact.abi,
       address: deployments[artifact.contractName],
@@ -126,7 +127,7 @@ export function hardhat(config: HardhatConfig): HardhatResult {
         ).split(' ')
         await execa(command!, options, { cwd: project })
       }
-      if (!fs.pathExistsSync(artifactsDirectory))
+      if (!existsSync(artifactsDirectory))
         throw new Error('Artifacts not found.')
 
       const artifactPaths = await getArtifactPaths(artifactsDirectory)
@@ -141,7 +142,7 @@ export function hardhat(config: HardhatConfig): HardhatResult {
     name: 'Hardhat',
     async validate() {
       // Check that project directory exists
-      if (!(await fs.pathExists(project)))
+      if (!existsSync(project))
         throw new Error(`Hardhat project ${pc.gray(project)} not found.`)
 
       // Check that `hardhat` is installed

--- a/packages/cli/src/utils/findConfig.ts
+++ b/packages/cli/src/utils/findConfig.ts
@@ -1,5 +1,5 @@
-import { findUp } from 'find-up'
-import { default as fs } from 'fs-extra'
+import { existsSync } from 'node:fs'
+import escalade from 'escalade'
 import { resolve } from 'pathe'
 
 // Do not reorder
@@ -26,8 +26,13 @@ export async function findConfig(parameters: FindConfigParameters = {}) {
   const rootDir = resolve(root || process.cwd())
   if (config) {
     const path = resolve(rootDir, config)
-    if (fs.pathExistsSync(path)) return path
+    if (existsSync(path)) return path
     return
   }
-  return findUp(configFiles, { cwd: rootDir })
+  const configPath = await escalade(rootDir, (_dir, names) => {
+    for (const name of names) {
+      if (configFiles.includes(name)) return name
+    }
+  })
+  return configPath
 }

--- a/packages/cli/src/utils/findConfig.ts
+++ b/packages/cli/src/utils/findConfig.ts
@@ -33,6 +33,7 @@ export async function findConfig(parameters: FindConfigParameters = {}) {
     for (const name of names) {
       if (configFiles.includes(name)) return name
     }
+    return undefined
   })
   return configPath
 }

--- a/packages/cli/src/utils/getIsUsingTypeScript.ts
+++ b/packages/cli/src/utils/getIsUsingTypeScript.ts
@@ -13,6 +13,7 @@ export async function getIsUsingTypeScript() {
       for (const name of names) {
         if (files.includes(name)) return name
       }
+      return undefined
     })
     if (tsconfig) return true
 
@@ -21,6 +22,7 @@ export async function getIsUsingTypeScript() {
       for (const name of names) {
         if (files.includes(name)) return name
       }
+      return undefined
     })
     if (wagmiConfig) return true
 

--- a/packages/cli/src/utils/getIsUsingTypeScript.ts
+++ b/packages/cli/src/utils/getIsUsingTypeScript.ts
@@ -1,21 +1,26 @@
-import { findUp } from 'find-up'
+import escalade from 'escalade'
 
 export async function getIsUsingTypeScript() {
   try {
     const cwd = process.cwd()
-    const tsconfig = await findUp(
-      [
+    const tsconfig = await escalade(cwd, (_dir, names) => {
+      const files = [
         'tsconfig.json',
         'tsconfig.base.json',
         'tsconfig.lib.json',
         'tsconfig.node.json',
-      ],
-      { cwd },
-    )
+      ]
+      for (const name of names) {
+        if (files.includes(name)) return name
+      }
+    })
     if (tsconfig) return true
 
-    const wagmiConfig = await findUp(['wagmi.config.ts', 'wagmi.config.mts'], {
-      cwd,
+    const wagmiConfig = await escalade(cwd, (_dir, names) => {
+      const files = ['wagmi.config.ts', 'wagmi.config.mts']
+      for (const name of names) {
+        if (files.includes(name)) return name
+      }
     })
     if (wagmiConfig) return true
 

--- a/packages/cli/test/setup.ts
+++ b/packages/cli/test/setup.ts
@@ -1,11 +1,11 @@
+import { mkdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { default as fs } from 'fs-extra'
 import type { createSpinner as nanospinner_createSpinner } from 'nanospinner'
 import { join } from 'pathe'
 import { vi } from 'vitest'
 
 const cacheDir = join(homedir(), '.wagmi-cli/plugins/fetch/cache')
-await fs.ensureDir(cacheDir)
+await mkdir(cacheDir, { recursive: true })
 
 vi.mock('nanospinner', async (importOriginal) => {
   const mod = await importOriginal<{

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -1,6 +1,6 @@
+import { cp, mkdir, symlink, writeFile } from 'node:fs/promises'
 import { execa } from 'execa'
 import fixtures from 'fixturez'
-import { default as fs } from 'fs-extra'
 import { http, HttpResponse } from 'msw'
 import * as path from 'pathe'
 import { vi } from 'vitest'
@@ -27,7 +27,7 @@ export async function createFixture<
   } = {},
 ) {
   const dir = config.dir ?? f.temp()
-  await fs.ensureDir(dir)
+  await mkdir(dir, { recursive: true })
 
   // Create test files
   const paths: { [_ in keyof TFiles]: string } = {} as any
@@ -42,9 +42,9 @@ export async function createFixture<
         } else file = config.files![filename]
 
         const filePath = path.join(dir, filename.toString())
-        await fs.ensureDir(path.dirname(filePath))
+        await mkdir(path.dirname(filePath), { recursive: true })
 
-        await fs.writeFile(
+        await writeFile(
           filePath,
           typeof file === 'string' ? file : JSON.stringify(file, null, 2),
         )
@@ -54,12 +54,12 @@ export async function createFixture<
   )
 
   if (config.copyNodeModules) {
-    await fs.symlink(
+    await symlink(
       path.join(__dirname, '../node_modules'),
       path.join(dir, 'node_modules'),
       'dir',
     )
-    await fs.copy(
+    await cp(
       path.join(__dirname, '../package.json'),
       path.join(dir, 'package.json'),
     )

--- a/packages/create-wagmi/package.json
+++ b/packages/create-wagmi/package.json
@@ -40,11 +40,9 @@
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.12.10",
     "@types/prompts": "^2.4.9",
-    "execa": "^8.0.1",
-    "fs-extra": "^11.2.0"
+    "execa": "^8.0.1"
   },
   "contributors": ["awkweb.eth <t@wevm.dev>", "jxom.eth <j@wevm.dev>"],
   "funding": "https://github.com/sponsors/wevm",

--- a/packages/create-wagmi/src/cli.test.ts
+++ b/packages/create-wagmi/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readdirSync, writeFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { ExecaSyncReturnValue, SyncOptions } from 'execa'

--- a/packages/create-wagmi/src/cli.test.ts
+++ b/packages/create-wagmi/src/cli.test.ts
@@ -1,7 +1,8 @@
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { ExecaSyncReturnValue, SyncOptions } from 'execa'
 import { execaCommandSync } from 'execa'
-import fs from 'fs-extra'
 import pc from 'picocolors'
 import { afterEach, beforeAll, expect, test } from 'vitest'
 
@@ -17,16 +18,18 @@ function run(args: string[], options: SyncOptions = {}): ExecaSyncReturnValue {
 }
 
 function createNonEmptyDir() {
-  fs.mkdirpSync(genPath)
+  mkdirSync(genPath, { recursive: true })
   const file = join(genPath, 'foo')
-  fs.writeFileSync(file, 'bar')
+  writeFileSync(file, 'bar')
 }
 
-beforeAll(() => {
+beforeAll(async () => {
   execaCommandSync('pnpm --filter create-wagmi build')
-  fs.remove(genPath)
+  await rm(genPath, { recursive: true, force: true })
 })
-afterEach(() => fs.remove(genPath))
+afterEach(async () => {
+  await rm(genPath, { recursive: true, force: true })
+})
 
 test('prompts for the project name if none supplied', () => {
   const { stdout } = run([])
@@ -34,7 +37,7 @@ test('prompts for the project name if none supplied', () => {
 })
 
 test('prompts for the framework if none supplied when target dir is current directory', () => {
-  fs.mkdirpSync(genPath)
+  mkdirSync(genPath)
   const { stdout } = run(['.'], { cwd: genPath })
   expect(stdout).toContain('Select a framework:')
 })
@@ -68,8 +71,9 @@ test('asks to overwrite non-empty current directory', () => {
   expect(stdout).toContain('Current directory is not empty.')
 })
 
-const templateFiles = fs
-  .readdirSync(join(cliPath, '../../../templates/vite-react'))
+const templateFiles = readdirSync(
+  join(cliPath, '../../../templates/vite-react'),
+)
   .map((filePath) => {
     if (filePath === '_gitignore') return '.gitignore'
     if (filePath === '_env.local') return '.env.local'
@@ -79,29 +83,29 @@ const templateFiles = fs
   .sort()
 
 test('successfully scaffolds a project based on vite-react starter template', () => {
-  fs.ensureDirSync(genPath)
+  mkdirSync(genPath, { recursive: true })
   const { stdout } = run([projectName, '--template', 'vite-react'], {
     cwd: __dirname,
   })
-  const generatedFiles = fs.readdirSync(genPath).sort()
+  const generatedFiles = readdirSync(genPath).sort()
 
   expect(stdout).toContain(`Scaffolding project in ${genPath}`)
   expect(templateFiles).toEqual(generatedFiles)
 })
 
 test('works with the -t alias', () => {
-  fs.ensureDirSync(genPath)
+  mkdirSync(genPath, { recursive: true })
   const { stdout } = run([projectName, '-t', 'vite-react'], {
     cwd: __dirname,
   })
-  const generatedFiles = fs.readdirSync(genPath).sort()
+  const generatedFiles = readdirSync(genPath).sort()
 
   expect(stdout).toContain(`Scaffolding project in ${genPath}`)
   expect(templateFiles).toEqual(generatedFiles)
 })
 
 test('uses different package manager', () => {
-  fs.ensureDirSync(genPath)
+  mkdirSync(genPath, { recursive: true })
   const { stdout } = run([projectName, '--bun', '-t', 'vite-react'], {
     cwd: __dirname,
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,18 +128,15 @@ importers:
       esbuild:
         specifier: ^0.19.0
         version: 0.19.11
+      escalade:
+        specifier: 3.2.0
+        version: 3.2.0
       execa:
         specifier: ^8.0.1
         version: 8.0.1
       fdir:
         specifier: ^6.1.1
         version: 6.1.1(picomatch@3.0.1)
-      find-up:
-        specifier: ^6.3.0
-        version: 6.3.0
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
       nanospinner:
         specifier: 1.2.2
         version: 1.2.2
@@ -165,9 +162,6 @@ importers:
       '@types/dedent':
         specifier: ^0.7.2
         version: 0.7.2
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: ^20.12.10
         version: 20.12.10
@@ -246,9 +240,6 @@ importers:
       '@types/cross-spawn':
         specifier: ^6.0.6
         version: 6.0.6
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: ^20.12.10
         version: 20.12.10
@@ -258,9 +249,6 @@ importers:
       execa:
         specifier: ^8.0.1
         version: 8.0.1
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
 
   packages/react:
     dependencies:
@@ -2955,17 +2943,11 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/http-proxy@1.17.14':
     resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
-
-  '@types/jsonfile@6.1.2':
-    resolution: {integrity: sha512-8t92P+oeW4d/CRQfJaSqEwXujrhH4OEeHRjGU3v1Q8mUS8GPF3yiX26sw4svv6faL2HfBtGTe2xWIoVgN3dy9w==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -4606,12 +4588,8 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-
-  escalade@3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
@@ -4799,10 +4777,6 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
-
-  find-up@6.3.0:
-    resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   fixturez@1.1.0:
     resolution: {integrity: sha512-c4q9eZsAmCzj9gkrEO/YwIRlrHWt/TXQiX9jR9WeLFOqeeV6EyzdiiV28CpSzF6Ip+gyYrSv5UeOHqyzfcNTVA==}
@@ -5567,10 +5541,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  locate-path@7.2.0:
-    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
@@ -6300,10 +6270,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@4.0.0:
-    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -6315,10 +6281,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-locate@6.0.0:
-    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -6384,10 +6346,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-exists@5.0.0:
-    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -8312,10 +8270,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.0.0:
-    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
-    engines: {node: '>=12.20'}
 
   yoctocolors@2.0.2:
     resolution: {integrity: sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==}
@@ -11189,20 +11143,11 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.2
-      '@types/node': 20.12.10
-
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.2
 
   '@types/http-proxy@1.17.14':
-    dependencies:
-      '@types/node': 20.12.10
-
-  '@types/jsonfile@6.1.2':
     dependencies:
       '@types/node': 20.12.10
 
@@ -13547,9 +13492,7 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
-  escalade@3.1.1: {}
-
-  escalade@3.1.2: {}
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -13793,11 +13736,6 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-
-  find-up@6.3.0:
-    dependencies:
-      locate-path: 7.2.0
-      path-exists: 5.0.0
 
   fixturez@1.1.0:
     dependencies:
@@ -14659,10 +14597,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  locate-path@7.2.0:
-    dependencies:
-      p-locate: 6.0.0
 
   lodash-es@4.17.21: {}
 
@@ -15876,10 +15810,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@4.0.0:
-    dependencies:
-      yocto-queue: 1.0.0
-
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -15891,10 +15821,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-locate@6.0.0:
-    dependencies:
-      p-limit: 4.0.0
 
   p-map@2.1.0: {}
 
@@ -15963,8 +15889,6 @@ snapshots:
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
-
-  path-exists@5.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -17423,7 +17347,7 @@ snapshots:
   update-browserslist-db@1.0.15(browserslist@4.23.0):
     dependencies:
       browserslist: 4.23.0
-      escalade: 3.1.2
+      escalade: 3.2.0
       picocolors: 1.1.1
 
   uqr@0.1.2: {}
@@ -18131,7 +18055,7 @@ snapshots:
   yargs@16.2.0:
     dependencies:
       cliui: 7.0.4
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -18141,7 +18065,7 @@ snapshots:
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -18149,8 +18073,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.0.0: {}
 
   yoctocolors@2.0.2: {}
 


### PR DESCRIPTION
- Removed `fs-extra` for `node:fs`/`node:fs/promises`
- Removed `find-up` for [`escalade`](https://github.com/lukeed/escalade)

https://github.com/es-tooling/module-replacements/blob/main/docs/modules/README.md

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
