### PR TITLE
feat(core,react,vue): connect parameters

### DIFF
--- a/.changeset/spotty-kangaroos-approve.md
+++ b/.changeset/spotty-kangaroos-approve.md
@@ -1,0 +1,6 @@
+---
+"wagmi": minor
+"@wagmi/vue": minor
+---
+
+Added support to `useConnect` for custom `connector.connect` parameters.

--- a/.changeset/thirty-camels-exercise.md
+++ b/.changeset/thirty-camels-exercise.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/connectors": minor
+"@wagmi/core": minor
+---
+
+Added narrowing to `config.connectors`.
+

--- a/packages/connectors/src/walletConnect.test.ts
+++ b/packages/connectors/src/walletConnect.test.ts
@@ -1,7 +1,15 @@
 import { config, walletConnectProjectId } from '@wagmi/test'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  expect,
+  expectTypeOf,
+  test,
+  vi,
+} from 'vitest'
 
 import { walletConnect } from './walletConnect.js'
 
@@ -49,4 +57,11 @@ test('setup', () => {
   const connectorFn = walletConnect({ projectId: walletConnectProjectId })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual('WalletConnect')
+
+  type ConnectFnParameters = NonNullable<
+    Parameters<(typeof connector)['connect']>[0]
+  >
+  expectTypeOf<ConnectFnParameters['pairingTopic']>().toMatchTypeOf<
+    string | undefined
+  >()
 })

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -78,7 +78,11 @@ export function walletConnect(parameters: WalletConnectParameters) {
 
   type Provider = Awaited<ReturnType<(typeof EthereumProvider)['init']>>
   type Properties = {
-    connect(parameters?: { chainId?: number; pairingTopic?: string }): Promise<{
+    connect(parameters?: {
+      chainId?: number | undefined
+      isReconnecting?: boolean | undefined
+      pairingTopic?: string | undefined
+    }): Promise<{
       accounts: readonly Address[]
       chainId: number
     }>

--- a/packages/core/src/actions/connect.test-d.ts
+++ b/packages/core/src/actions/connect.test-d.ts
@@ -1,0 +1,48 @@
+import { accounts } from '@wagmi/test'
+import { http } from 'viem'
+import { mainnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+
+import type { CreateConnectorFn } from '../connectors/createConnector.js'
+import { mock } from '../connectors/mock.js'
+import { type Connector, createConfig } from '../createConfig.js'
+import { connect } from './connect.js'
+
+const config = createConfig({
+  chains: [mainnet],
+  transports: { [mainnet.id]: http() },
+})
+
+test('parameters: connector (ConnectorFn)', () => {
+  const connectorFn = mock({ accounts })
+
+  connect(config, {
+    connector: connectorFn,
+    foo: 'bar',
+  })
+  expectTypeOf<
+    typeof connectorFn extends CreateConnectorFn ? true : false
+  >().toEqualTypeOf<true>()
+
+  type Result = NonNullable<
+    Parameters<typeof connect<typeof config, typeof connectorFn>>[1]
+  >
+  expectTypeOf<Result['foo']>().toEqualTypeOf<string | undefined>()
+})
+
+test('parameters: connector (Connector)', () => {
+  const connector = config._internal.connectors.setup(mock({ accounts }))
+
+  connect(config, {
+    connector,
+    foo: 'bar',
+  })
+  expectTypeOf<
+    typeof connector extends Connector ? true : false
+  >().toEqualTypeOf<true>()
+
+  type Result = NonNullable<
+    Parameters<typeof connect<typeof config, typeof connector>>[1]
+  >
+  expectTypeOf<Result['foo']>().toEqualTypeOf<string | undefined>()
+})

--- a/packages/core/src/actions/connect.ts
+++ b/packages/core/src/actions/connect.ts
@@ -35,7 +35,7 @@ export type ConnectParameters<
         : never),
 > = Compute<
   ChainIdParameter<config> & {
-    connector: connector
+    connector: connector | CreateConnectorFn
   }
 > &
   parameters

--- a/packages/core/src/actions/connect.ts
+++ b/packages/core/src/actions/connect.ts
@@ -14,11 +14,28 @@ import {
 import type { ChainIdParameter } from '../types/properties.js'
 import type { Compute } from '../types/utils.js'
 
-export type ConnectParameters<config extends Config = Config> = Compute<
+export type ConnectParameters<
+  config extends Config = Config,
+  connector extends Connector | CreateConnectorFn =
+    | Connector
+    | CreateConnectorFn,
+  ///
+  parameters extends unknown | undefined =
+    | (connector extends CreateConnectorFn
+        ? Omit<
+            Parameters<ReturnType<connector>['connect']>[0],
+            'isReconnecting'
+          >
+        : never)
+    | (connector extends Connector
+        ? Omit<Parameters<connector['connect']>[0], 'isReconnecting'>
+        : never),
+> = Compute<
   ChainIdParameter<config> & {
-    connector: Connector | CreateConnectorFn
+    connector: connector | Connector | CreateConnectorFn
   }
->
+> &
+  parameters
 
 export type ConnectReturnType<config extends Config = Config> = {
   accounts: readonly [Address, ...Address[]]
@@ -37,9 +54,12 @@ export type ConnectErrorType =
   | ErrorType
 
 /** https://wagmi.sh/core/api/actions/connect */
-export async function connect<config extends Config>(
+export async function connect<
+  config extends Config,
+  connector extends Connector | CreateConnectorFn,
+>(
   config: config,
-  parameters: ConnectParameters<config>,
+  parameters: ConnectParameters<config, connector>,
 ): Promise<ConnectReturnType<config>> {
   // "Register" connector if not already created
   let connector: Connector

--- a/packages/core/src/actions/connect.ts
+++ b/packages/core/src/actions/connect.ts
@@ -23,16 +23,19 @@ export type ConnectParameters<
   parameters extends unknown | undefined =
     | (connector extends CreateConnectorFn
         ? Omit<
-            Parameters<ReturnType<connector>['connect']>[0],
+            NonNullable<Parameters<ReturnType<connector>['connect']>[0]>,
             'isReconnecting'
           >
         : never)
     | (connector extends Connector
-        ? Omit<Parameters<connector['connect']>[0], 'isReconnecting'>
+        ? Omit<
+            NonNullable<Parameters<connector['connect']>[0]>,
+            'isReconnecting'
+          >
         : never),
 > = Compute<
   ChainIdParameter<config> & {
-    connector: connector | Connector | CreateConnectorFn
+    connector: connector
   }
 > &
   parameters

--- a/packages/core/src/actions/getConnectorClient.test.ts
+++ b/packages/core/src/actions/getConnectorClient.test.ts
@@ -86,20 +86,20 @@ test('behavior: account does not exist on connector', async () => {
 
 test('behavior: reconnecting', async () => {
   config.setState((state) => ({ ...state, status: 'reconnecting' }))
-  const { id, name, type, uuid } = connector
+  const { id, name, type, uid } = connector
   await expect(
     getConnectorClient(config, {
       connector: {
         id,
         name,
         type,
-        uuid,
+        uid,
       } as unknown as Connector,
     }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`
     [ConnectorUnavailableReconnectingError: Connector "Mock Connector" unavailable while reconnecting.
 
-    Details: During the reconnection step, the only connector methods guaranteed to be available are: \`id\`, \`name\`, \`type\`, \`uuid\`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
+    Details: During the reconnection step, the only connector methods guaranteed to be available are: \`id\`, \`name\`, \`type\`, \`uid\`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
     Version: @wagmi/core@x.y.z]
   `)
   config.setState((state) => ({ ...state, status: 'disconnected' }))

--- a/packages/core/src/actions/getConnectors.ts
+++ b/packages/core/src/actions/getConnectors.ts
@@ -1,12 +1,15 @@
 import type { Config, Connector } from '../createConfig.js'
 import { deepEqual } from '../utils/deepEqual.js'
 
-export type GetConnectorsReturnType = readonly Connector[]
+export type GetConnectorsReturnType<config extends Config = Config> =
+  config['connectors']
 
 let previousConnectors: readonly Connector[] = []
 
 /** https://wagmi.sh/core/api/actions/getConnectors */
-export function getConnectors(config: Config): GetConnectorsReturnType {
+export function getConnectors<config extends Config>(
+  config: config,
+): GetConnectorsReturnType<config> {
   const connectors = config.connectors
   if (deepEqual(previousConnectors, connectors)) return previousConnectors
   previousConnectors = connectors

--- a/packages/core/src/actions/watchConnectors.ts
+++ b/packages/core/src/actions/watchConnectors.ts
@@ -1,19 +1,19 @@
 import type { Config } from '../createConfig.js'
 import type { GetConnectorsReturnType } from './getConnectors.js'
 
-export type WatchConnectorsParameters = {
+export type WatchConnectorsParameters<config extends Config = Config> = {
   onChange(
-    connections: GetConnectorsReturnType,
-    prevConnectors: GetConnectorsReturnType,
+    connections: GetConnectorsReturnType<config>,
+    prevConnectors: GetConnectorsReturnType<config>,
   ): void
 }
 
 export type WatchConnectorsReturnType = () => void
 
 /** https://wagmi.sh/core/api/actions/watchConnectors */
-export function watchConnectors(
-  config: Config,
-  parameters: WatchConnectorsParameters,
+export function watchConnectors<config extends Config>(
+  config: config,
+  parameters: WatchConnectorsParameters<config>,
 ): WatchConnectorsReturnType {
   const { onChange } = parameters
   return config._internal.connectors.subscribe((connectors, prevConnectors) => {

--- a/packages/core/src/connectors/createConnector.ts
+++ b/packages/core/src/connectors/createConnector.ts
@@ -82,6 +82,12 @@ export function createConnector<
   provider,
   properties extends Record<string, unknown> = Record<string, unknown>,
   storageItem extends Record<string, unknown> = Record<string, unknown>,
->(createConnectorFn: CreateConnectorFn<provider, properties, storageItem>) {
+  ///
+  createConnectorFn extends CreateConnectorFn<
+    provider,
+    properties,
+    storageItem
+  > = CreateConnectorFn<provider, properties, storageItem>,
+>(createConnectorFn: createConnectorFn) {
   return createConnectorFn
 }

--- a/packages/core/src/connectors/mock.test.ts
+++ b/packages/core/src/connectors/mock.test.ts
@@ -1,12 +1,26 @@
 import { accounts, config } from '@wagmi/test'
-import { expect, test } from 'vitest'
+import { expect, expectTypeOf, test } from 'vitest'
 
+import type { Connector } from '../createConfig.js'
+import type { CreateConnectorFn } from './createConnector.js'
 import { mock } from './mock.js'
 
 test('setup', () => {
   const connectorFn = mock({ accounts })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual('Mock Connector')
+
+  expectTypeOf<
+    typeof connectorFn extends CreateConnectorFn ? true : false
+  >().toEqualTypeOf<true>()
+  expectTypeOf<
+    typeof connector extends Connector ? true : false
+  >().toEqualTypeOf<true>()
+
+  type ConnectFnParameters = NonNullable<
+    Parameters<(typeof connector)['connect']>[0]
+  >
+  expectTypeOf<ConnectFnParameters['foo']>().toMatchTypeOf<string | undefined>()
 })
 
 test('behavior: features.connectError', () => {

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -48,10 +48,20 @@ export function mock(parameters: MockParameters) {
   type Provider = ReturnType<
     Transport<'custom', unknown, EIP1193RequestFn<WalletRpcSchema>>
   >
+  type Properties = {
+    connect(parameters?: {
+      chainId?: number | undefined
+      isReconnecting?: boolean | undefined
+      foo?: string | undefined
+    }): Promise<{
+      accounts: readonly Address[]
+      chainId: number
+    }>
+  }
   let connected = features.defaultConnected
   let connectedChainId: number
 
-  return createConnector<Provider>((config) => ({
+  return createConnector<Provider, Properties>((config) => ({
     id: 'mock',
     name: 'Mock Connector',
     type: mock.type,

--- a/packages/core/src/createConfig.test-d.ts
+++ b/packages/core/src/createConfig.test-d.ts
@@ -86,3 +86,25 @@ test('behavior: parameters should not include certain client config properties',
     'transport' extends Result ? true : false
   >().toEqualTypeOf<false>()
 })
+
+test('narrow connectors', () => {
+  const connectorFn = mock({ accounts })
+  const config = createConfig({
+    chains: [mainnet, sepolia],
+    connectors: [connectorFn],
+    transports: {
+      [mainnet.id]: webSocket(),
+      [sepolia.id]: http(),
+    },
+  })
+
+  const connector = config.connectors[0]!
+  expectTypeOf(connector).toEqualTypeOf(
+    config._internal.connectors.setup(connectorFn),
+  )
+
+  type ConnectFnParameters = NonNullable<
+    Parameters<(typeof connector)['connect']>[0]
+  >
+  expectTypeOf<ConnectFnParameters['foo']>().toMatchTypeOf<string | undefined>()
+})

--- a/packages/core/src/createConfig.test-d.ts
+++ b/packages/core/src/createConfig.test-d.ts
@@ -87,7 +87,7 @@ test('behavior: parameters should not include certain client config properties',
   >().toEqualTypeOf<false>()
 })
 
-test('narrow connectors', () => {
+test('infer connectors', () => {
   const connectorFn = mock({ accounts })
   const config = createConfig({
     chains: [mainnet, sepolia],

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -532,7 +532,7 @@ export type Config<
     readonly CreateConnectorFn[] = readonly CreateConnectorFn[],
 > = {
   readonly chains: chains
-  readonly connectors: Connector<connectorFns[number]>[]
+  readonly connectors: readonly Connector<connectorFns[number]>[]
   readonly storage: Storage | null
 
   readonly state: State<chains>

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -33,42 +33,13 @@ import type {
 import { uid } from './utils/uid.js'
 import { version } from './version.js'
 
-export type CreateConfigParameters<
-  chains extends readonly [Chain, ...Chain[]] = readonly [Chain, ...Chain[]],
-  transports extends Record<chains[number]['id'], Transport> = Record<
-    chains[number]['id'],
-    Transport
-  >,
-> = Compute<
-  {
-    chains: chains
-    connectors?: CreateConnectorFn[] | undefined
-    multiInjectedProviderDiscovery?: boolean | undefined
-    storage?: Storage | null | undefined
-    ssr?: boolean | undefined
-    syncConnectedChain?: boolean | undefined
-  } & OneOf<
-    | ({ transports: transports } & {
-        [key in keyof ClientConfig]?:
-          | ClientConfig[key]
-          | { [_ in chains[number]['id']]?: ClientConfig[key] | undefined }
-          | undefined
-      })
-    | {
-        client(parameters: { chain: chains[number] }): Client<
-          transports[chains[number]['id']],
-          chains[number]
-        >
-      }
-  >
->
-
 export function createConfig<
   const chains extends readonly [Chain, ...Chain[]],
   transports extends Record<chains[number]['id'], Transport>,
+  const connectorFns extends readonly CreateConnectorFn[],
 >(
-  parameters: CreateConfigParameters<chains, transports>,
-): Config<chains, transports> {
+  parameters: CreateConfigParameters<chains, transports, connectorFns>,
+): Config<chains, transports, connectorFns> {
   const {
     multiInjectedProviderDiscovery = true,
     storage = createStorage({
@@ -442,7 +413,7 @@ export function createConfig<
       return chains.getState() as chains
     },
     get connectors() {
-      return connectors.getState()
+      return connectors.getState() as Connector<connectorFns[number]>[]
     },
     storage,
 
@@ -497,7 +468,9 @@ export function createConfig<
       },
       connectors: {
         providerDetailToConnector,
-        setup,
+        setup: setup as <connectorFn extends CreateConnectorFn>(
+          connectorFn: connectorFn,
+        ) => Connector<connectorFn>,
         setState(value) {
           return connectors.setState(
             typeof value === 'function' ? value(connectors.getState()) : value,
@@ -517,15 +490,49 @@ export function createConfig<
 // Types
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+export type CreateConfigParameters<
+  chains extends readonly [Chain, ...Chain[]] = readonly [Chain, ...Chain[]],
+  transports extends Record<chains[number]['id'], Transport> = Record<
+    chains[number]['id'],
+    Transport
+  >,
+  connectorFns extends
+    readonly CreateConnectorFn[] = readonly CreateConnectorFn[],
+> = Compute<
+  {
+    chains: chains
+    connectors?: connectorFns | undefined
+    multiInjectedProviderDiscovery?: boolean | undefined
+    storage?: Storage | null | undefined
+    ssr?: boolean | undefined
+    syncConnectedChain?: boolean | undefined
+  } & OneOf<
+    | ({ transports: transports } & {
+        [key in keyof ClientConfig]?:
+          | ClientConfig[key]
+          | { [_ in chains[number]['id']]?: ClientConfig[key] | undefined }
+          | undefined
+      })
+    | {
+        client(parameters: { chain: chains[number] }): Client<
+          transports[chains[number]['id']],
+          chains[number]
+        >
+      }
+  >
+>
+
 export type Config<
   chains extends readonly [Chain, ...Chain[]] = readonly [Chain, ...Chain[]],
   transports extends Record<chains[number]['id'], Transport> = Record<
     chains[number]['id'],
     Transport
   >,
+  connectorFns extends
+    readonly CreateConnectorFn[] = readonly CreateConnectorFn[],
 > = {
   readonly chains: chains
-  readonly connectors: readonly Connector[]
+  readonly connectors: Connector<connectorFns[number]>[]
   readonly storage: Storage | null
 
   readonly state: State<chains>
@@ -586,7 +593,9 @@ type Internal<
     providerDetailToConnector(
       providerDetail: EIP6963ProviderDetail,
     ): CreateConnectorFn
-    setup(connectorFn: CreateConnectorFn): Connector
+    setup<connectorFn extends CreateConnectorFn>(
+      connectorFn: connectorFn,
+    ): Connector<connectorFn>
     setState(value: Connector[] | ((state: Connector[]) => Connector[])): void
     subscribe(
       listener: (state: Connector[], prevState: Connector[]) => void,
@@ -618,7 +627,9 @@ export type Connection = {
   connector: Connector
 }
 
-export type Connector = ReturnType<CreateConnectorFn> & {
+export type Connector<
+  createConnectorFn extends CreateConnectorFn = CreateConnectorFn,
+> = ReturnType<createConnectorFn> & {
   emitter: Emitter<ConnectorEventMap>
   uid: string
 }

--- a/packages/core/src/errors/config.test.ts
+++ b/packages/core/src/errors/config.test.ts
@@ -62,7 +62,7 @@ test('constructors', () => {
   ).toMatchInlineSnapshot(`
     [ConnectorUnavailableReconnectingError: Connector "Rabby Wallet" unavailable while reconnecting.
 
-    Details: During the reconnection step, the only connector methods guaranteed to be available are: \`id\`, \`name\`, \`type\`, \`uuid\`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
+    Details: During the reconnection step, the only connector methods guaranteed to be available are: \`id\`, \`name\`, \`type\`, \`uid\`. All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored. This error commonly occurs for connectors that asynchronously inject after reconnection has already started.
     Version: @wagmi/core@x.y.z]
   `)
 })

--- a/packages/core/src/errors/config.ts
+++ b/packages/core/src/errors/config.ts
@@ -94,7 +94,7 @@ export class ConnectorUnavailableReconnectingError extends BaseError {
   constructor({ connector }: { connector: { name: string } }) {
     super(`Connector "${connector.name}" unavailable while reconnecting.`, {
       details: [
-        'During the reconnection step, the only connector methods guaranteed to be available are: `id`, `name`, `type`, `uuid`.',
+        'During the reconnection step, the only connector methods guaranteed to be available are: `id`, `name`, `type`, `uid`.',
         'All other methods are not guaranteed to be available until reconnection completes and connectors are fully restored.',
         'This error commonly occurs for connectors that asynchronously inject after reconnection has already started.',
       ].join(' '),

--- a/packages/core/src/query/connect.ts
+++ b/packages/core/src/query/connect.ts
@@ -1,4 +1,4 @@
-import type { MutationOptions } from '@tanstack/query-core'
+import type { MutateOptions, MutationOptions } from '@tanstack/query-core'
 
 import {
   type ConnectErrorType,
@@ -6,9 +6,10 @@ import {
   type ConnectReturnType,
   connect,
 } from '../actions/connect.js'
-import type { Config } from '../createConfig.js'
+import type { Config, Connector } from '../createConfig.js'
 
-import type { Mutate, MutateAsync } from './types.js'
+import type { CreateConnectorFn } from '../connectors/createConnector.js'
+import type { Compute } from '../types/utils.js'
 
 export function connectMutationOptions<config extends Config>(config: config) {
   return {
@@ -19,27 +20,45 @@ export function connectMutationOptions<config extends Config>(config: config) {
   } as const satisfies MutationOptions<
     ConnectData<config>,
     ConnectErrorType,
-    ConnectVariables<config>
+    ConnectVariables<config, Connector | CreateConnectorFn>
   >
 }
 
 export type ConnectData<config extends Config> = ConnectReturnType<config>
 
-export type ConnectVariables<config extends Config> = ConnectParameters<config>
-
-export type ConnectMutate<config extends Config, context = unknown> = Mutate<
-  ConnectData<config>,
-  ConnectErrorType,
-  ConnectVariables<config>,
-  context
->
-
-export type ConnectMutateAsync<
+export type ConnectVariables<
   config extends Config,
-  context = unknown,
-> = MutateAsync<
-  ConnectData<config>,
-  ConnectErrorType,
-  ConnectVariables<config>,
-  context
->
+  connector extends Connector | CreateConnectorFn,
+> = ConnectParameters<config, connector>
+
+export type ConnectMutate<config extends Config, context = unknown> = <
+  connector extends Connector | CreateConnectorFn,
+>(
+  variables: ConnectVariables<config, connector>,
+  options?:
+    | Compute<
+        MutateOptions<
+          ConnectData<config>,
+          ConnectErrorType,
+          Compute<ConnectVariables<config, connector>>,
+          context
+        >
+      >
+    | undefined,
+) => void
+
+export type ConnectMutateAsync<config extends Config, context = unknown> = <
+  connector extends Connector | CreateConnectorFn,
+>(
+  variables: ConnectVariables<config, connector>,
+  options?:
+    | Compute<
+        MutateOptions<
+          ConnectData<config>,
+          ConnectErrorType,
+          Compute<ConnectVariables<config, connector>>,
+          context
+        >
+      >
+    | undefined,
+) => Promise<ConnectData<config>>

--- a/packages/core/src/query/connect.ts
+++ b/packages/core/src/query/connect.ts
@@ -32,7 +32,10 @@ export type ConnectVariables<
 > = ConnectParameters<config, connector>
 
 export type ConnectMutate<config extends Config, context = unknown> = <
-  connector extends Connector | CreateConnectorFn,
+  connector extends
+    | config['connectors'][number]
+    | Connector
+    | CreateConnectorFn,
 >(
   variables: ConnectVariables<config, connector>,
   options?:
@@ -48,7 +51,10 @@ export type ConnectMutate<config extends Config, context = unknown> = <
 ) => void
 
 export type ConnectMutateAsync<config extends Config, context = unknown> = <
-  connector extends Connector | CreateConnectorFn,
+  connector extends
+    | config['connectors'][number]
+    | Connector
+    | CreateConnectorFn,
 >(
   variables: ConnectVariables<config, connector>,
   options?:

--- a/packages/react/src/hooks/useConnect.test-d.ts
+++ b/packages/react/src/hooks/useConnect.test-d.ts
@@ -67,10 +67,10 @@ test('context', () => {
     | undefined
   >()
   expectTypeOf(error).toEqualTypeOf<ConnectErrorType | null>()
-  expectTypeOf(variables).toEqualTypeOf<
+  expectTypeOf(variables).toMatchTypeOf<
     | {
         chainId?: number | undefined
-        connector: Connector | CreateConnectorFn
+        connector: CreateConnectorFn | Connector
       }
     | undefined
   >()
@@ -85,7 +85,8 @@ test('context', () => {
       onError(error, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: Connector | CreateConnectorFn
+          connector: typeof connector
+          foo?: string | undefined
         }>()
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType>()
         expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
@@ -93,7 +94,8 @@ test('context', () => {
       onSuccess(data, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: Connector | CreateConnectorFn
+          connector: typeof connector
+          foo?: string | undefined
         }>()
         expectTypeOf(data).toEqualTypeOf<{
           accounts: readonly [Address, ...Address[]]
@@ -112,7 +114,8 @@ test('context', () => {
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType | null>()
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: Connector | CreateConnectorFn
+          connector: typeof connector
+          foo?: string | undefined
         }>()
         expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
       },

--- a/packages/react/src/hooks/useConnect.test-d.ts
+++ b/packages/react/src/hooks/useConnect.test-d.ts
@@ -77,7 +77,10 @@ test('context', () => {
   expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
 
   connect(
-    { connector },
+    {
+      connector,
+      foo: 'bar',
+    },
     {
       onError(error, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{

--- a/packages/react/src/hooks/useConnect.test-d.ts
+++ b/packages/react/src/hooks/useConnect.test-d.ts
@@ -85,7 +85,7 @@ test('context', () => {
       onError(error, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: typeof connector
+          connector: typeof connector | CreateConnectorFn
           foo?: string | undefined
         }>()
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType>()
@@ -94,7 +94,7 @@ test('context', () => {
       onSuccess(data, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: typeof connector
+          connector: typeof connector | CreateConnectorFn
           foo?: string | undefined
         }>()
         expectTypeOf(data).toEqualTypeOf<{
@@ -114,7 +114,7 @@ test('context', () => {
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType | null>()
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: typeof connector
+          connector: typeof connector | CreateConnectorFn
           foo?: string | undefined
         }>()
         expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()

--- a/packages/react/src/hooks/useConnect.ts
+++ b/packages/react/src/hooks/useConnect.ts
@@ -1,7 +1,13 @@
 'use client'
 
 import { useMutation } from '@tanstack/react-query'
-import type { Config, ConnectErrorType, ResolvedRegister } from '@wagmi/core'
+import type {
+  Config,
+  ConnectErrorType,
+  Connector,
+  CreateConnectorFn,
+  ResolvedRegister,
+} from '@wagmi/core'
 import type { Compute } from '@wagmi/core/internal'
 import {
   type ConnectData,
@@ -29,7 +35,7 @@ export type UseConnectParameters<
       | UseMutationParameters<
           ConnectData<config>,
           ConnectErrorType,
-          ConnectVariables<config>,
+          ConnectVariables<config, Connector | CreateConnectorFn>,
           context
         >
       | undefined
@@ -43,7 +49,7 @@ export type UseConnectReturnType<
   UseMutationReturnType<
     ConnectData<config>,
     ConnectErrorType,
-    ConnectVariables<config>,
+    ConnectVariables<config, Connector | CreateConnectorFn>,
     context
   > & {
     connect: ConnectMutate<config, context>

--- a/packages/react/src/hooks/useConnect.ts
+++ b/packages/react/src/hooks/useConnect.ts
@@ -1,13 +1,7 @@
 'use client'
 
 import { useMutation } from '@tanstack/react-query'
-import type {
-  Config,
-  ConnectErrorType,
-  Connector,
-  CreateConnectorFn,
-  ResolvedRegister,
-} from '@wagmi/core'
+import type { Config, ConnectErrorType, ResolvedRegister } from '@wagmi/core'
 import type { Compute } from '@wagmi/core/internal'
 import {
   type ConnectData,
@@ -35,7 +29,7 @@ export type UseConnectParameters<
       | UseMutationParameters<
           ConnectData<config>,
           ConnectErrorType,
-          ConnectVariables<config, Connector | CreateConnectorFn>,
+          ConnectVariables<config, config['connectors'][number]>,
           context
         >
       | undefined
@@ -49,12 +43,12 @@ export type UseConnectReturnType<
   UseMutationReturnType<
     ConnectData<config>,
     ConnectErrorType,
-    ConnectVariables<config, Connector | CreateConnectorFn>,
+    ConnectVariables<config, config['connectors'][number]>,
     context
   > & {
     connect: ConnectMutate<config, context>
     connectAsync: ConnectMutateAsync<config, context>
-    connectors: Compute<UseConnectorsReturnType>
+    connectors: Compute<UseConnectorsReturnType> | config['connectors']
   }
 >
 
@@ -88,7 +82,7 @@ export function useConnect<
 
   type Return = UseConnectReturnType<config, context>
   return {
-    ...result,
+    ...(result as Return),
     connect: mutate as Return['connect'],
     connectAsync: mutateAsync as Return['connectAsync'],
     connectors: useConnectors({ config }),

--- a/packages/react/src/hooks/useConnect.ts
+++ b/packages/react/src/hooks/useConnect.ts
@@ -86,10 +86,11 @@ export function useConnect<
     )
   }, [config, result.reset])
 
+  type Return = UseConnectReturnType<config, context>
   return {
     ...result,
-    connect: mutate,
-    connectAsync: mutateAsync,
+    connect: mutate as Return['connect'],
+    connectAsync: mutateAsync as Return['connectAsync'],
     connectors: useConnectors({ config }),
   }
 }

--- a/packages/react/src/hooks/useConnectors.ts
+++ b/packages/react/src/hooks/useConnectors.ts
@@ -1,7 +1,9 @@
 'use client'
 
 import {
+  type Config,
   type GetConnectorsReturnType,
+  type ResolvedRegister,
   getConnectors,
   watchConnectors,
 } from '@wagmi/core'
@@ -10,14 +12,18 @@ import { useSyncExternalStore } from 'react'
 import type { ConfigParameter } from '../types/properties.js'
 import { useConfig } from './useConfig.js'
 
-export type UseConnectorsParameters = ConfigParameter
+export type UseConnectorsParameters<config extends Config = Config> =
+  ConfigParameter<config>
 
-export type UseConnectorsReturnType = GetConnectorsReturnType
+export type UseConnectorsReturnType<config extends Config = Config> =
+  GetConnectorsReturnType<config>
 
 /** https://wagmi.sh/react/api/hooks/useConnectors */
-export function useConnectors(
-  parameters: UseConnectorsParameters = {},
-): UseConnectorsReturnType {
+export function useConnectors<
+  config extends Config = ResolvedRegister['config'],
+>(
+  parameters: UseConnectorsParameters<config> = {},
+): UseConnectorsReturnType<config> {
   const config = useConfig(parameters)
 
   return useSyncExternalStore(

--- a/packages/register-tests/react/src/config.ts
+++ b/packages/register-tests/react/src/config.ts
@@ -1,9 +1,10 @@
 import { http } from 'viem'
-import { createConfig } from 'wagmi'
+import { createConfig, mock } from 'wagmi'
 import { celo, mainnet, optimism, zkSync } from 'wagmi/chains'
 
 export const config = createConfig({
   chains: [celo, mainnet, optimism, zkSync],
+  connectors: [mock({ accounts: ['0x'] })],
   transports: {
     [celo.id]: http(),
     [mainnet.id]: http(),

--- a/packages/register-tests/react/src/useConnect.test-d.ts
+++ b/packages/register-tests/react/src/useConnect.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf, test } from 'vitest'
+import { useConnect } from 'wagmi'
+
+test('infers connect parameters', () => {
+  const { connect, connectors, variables } = useConnect()
+  const connector = connectors[0]!
+
+  expectTypeOf(variables?.foo).toEqualTypeOf<string | undefined>()
+  connect({
+    connector,
+    foo: 'bar',
+  })
+})

--- a/packages/register-tests/vue/src/config.ts
+++ b/packages/register-tests/vue/src/config.ts
@@ -1,9 +1,10 @@
-import { createConfig } from '@wagmi/vue'
+import { createConfig, mock } from '@wagmi/vue'
 import { celo, mainnet, optimism, zkSync } from '@wagmi/vue/chains'
 import { http } from 'viem'
 
 export const config = createConfig({
   chains: [celo, mainnet, optimism, zkSync],
+  connectors: [mock({ accounts: ['0x'] })],
   transports: {
     [celo.id]: http(),
     [mainnet.id]: http(),

--- a/packages/register-tests/vue/src/useConnect.test-d.ts
+++ b/packages/register-tests/vue/src/useConnect.test-d.ts
@@ -1,0 +1,13 @@
+import { useConnect } from '@wagmi/vue'
+import { expectTypeOf, test } from 'vitest'
+
+test('infers connect parameters', () => {
+  const { connect, connectors, variables } = useConnect()
+  const connector = connectors[0]!
+
+  expectTypeOf(variables.value?.foo).toEqualTypeOf<string | undefined>()
+  connect({
+    connector,
+    foo: 'bar',
+  })
+})

--- a/packages/vue/src/composables/useConnect.test-d.ts
+++ b/packages/vue/src/composables/useConnect.test-d.ts
@@ -82,7 +82,7 @@ test('context', () => {
       onError(error, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: typeof connector
+          connector: typeof connector | CreateConnectorFn
           foo?: string | undefined
         }>()
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType>()
@@ -91,7 +91,7 @@ test('context', () => {
       onSuccess(data, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: typeof connector
+          connector: typeof connector | CreateConnectorFn
           foo?: string | undefined
         }>()
         expectTypeOf(data).toEqualTypeOf<{
@@ -111,7 +111,7 @@ test('context', () => {
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType | null>()
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: typeof connector
+          connector: typeof connector | CreateConnectorFn
           foo?: string | undefined
         }>()
         expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()

--- a/packages/vue/src/composables/useConnect.test-d.ts
+++ b/packages/vue/src/composables/useConnect.test-d.ts
@@ -67,7 +67,7 @@ test('context', () => {
     | undefined
   >()
   expectTypeOf(error.value).toEqualTypeOf<ConnectErrorType | null>()
-  expectTypeOf(variables.value).toEqualTypeOf<
+  expectTypeOf(variables.value).toMatchTypeOf<
     | {
         chainId?: number | undefined
         connector: Connector | CreateConnectorFn
@@ -82,7 +82,8 @@ test('context', () => {
       onError(error, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: Connector | CreateConnectorFn
+          connector: typeof connector
+          foo?: string | undefined
         }>()
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType>()
         expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
@@ -90,7 +91,8 @@ test('context', () => {
       onSuccess(data, variables, context) {
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: Connector | CreateConnectorFn
+          connector: typeof connector
+          foo?: string | undefined
         }>()
         expectTypeOf(data).toEqualTypeOf<{
           accounts: readonly [Address, ...Address[]]
@@ -109,7 +111,8 @@ test('context', () => {
         expectTypeOf(error).toEqualTypeOf<ConnectErrorType | null>()
         expectTypeOf(variables).toEqualTypeOf<{
           chainId?: number | undefined
-          connector: Connector | CreateConnectorFn
+          connector: typeof connector
+          foo?: string | undefined
         }>()
         expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
       },

--- a/packages/vue/src/composables/useConnect.ts
+++ b/packages/vue/src/composables/useConnect.ts
@@ -2,8 +2,6 @@ import { useMutation } from '@tanstack/vue-query'
 import type {
   Config,
   ConnectErrorType,
-  Connector,
-  CreateConnectorFn,
   GetConnectorsReturnType,
   ResolvedRegister,
 } from '@wagmi/core'
@@ -34,7 +32,7 @@ export type UseConnectParameters<
       | UseMutationParameters<
           ConnectData<config>,
           ConnectErrorType,
-          ConnectVariables<config, Connector | CreateConnectorFn>,
+          ConnectVariables<config, config['connectors'][number]>,
           context
         >
       | undefined
@@ -48,12 +46,12 @@ export type UseConnectReturnType<
   UseMutationReturnType<
     ConnectData<config>,
     ConnectErrorType,
-    ConnectVariables<config, Connector | CreateConnectorFn>,
+    ConnectVariables<config, config['connectors'][number]>,
     context
   > & {
     connect: ConnectMutate<config, context>
     connectAsync: ConnectMutateAsync<config, context>
-    connectors: Compute<GetConnectorsReturnType>
+    connectors: Compute<GetConnectorsReturnType> | config['connectors']
   }
 >
 
@@ -86,7 +84,7 @@ export function useConnect<
 
   type Return = UseConnectReturnType<config, context>
   return {
-    ...result,
+    ...(result as Return),
     connect: mutate as Return['connect'],
     connectAsync: mutateAsync as Return['connectAsync'],
     connectors: useConnectors({ config }).value,

--- a/packages/vue/src/composables/useConnect.ts
+++ b/packages/vue/src/composables/useConnect.ts
@@ -2,6 +2,8 @@ import { useMutation } from '@tanstack/vue-query'
 import type {
   Config,
   ConnectErrorType,
+  Connector,
+  CreateConnectorFn,
   GetConnectorsReturnType,
   ResolvedRegister,
 } from '@wagmi/core'
@@ -32,7 +34,7 @@ export type UseConnectParameters<
       | UseMutationParameters<
           ConnectData<config>,
           ConnectErrorType,
-          ConnectVariables<config>,
+          ConnectVariables<config, Connector | CreateConnectorFn>,
           context
         >
       | undefined
@@ -46,7 +48,7 @@ export type UseConnectReturnType<
   UseMutationReturnType<
     ConnectData<config>,
     ConnectErrorType,
-    ConnectVariables<config>,
+    ConnectVariables<config, Connector | CreateConnectorFn>,
     context
   > & {
     connect: ConnectMutate<config, context>
@@ -82,10 +84,11 @@ export function useConnect<
   )
   onScopeDispose(() => unsubscribe())
 
+  type Return = UseConnectReturnType<config, context>
   return {
     ...result,
-    connect: mutate,
-    connectAsync: mutateAsync,
+    connect: mutate as Return['connect'],
+    connectAsync: mutateAsync as Return['connectAsync'],
     connectors: useConnectors({ config }).value,
   }
 }

--- a/packages/vue/src/composables/useConnectors.ts
+++ b/packages/vue/src/composables/useConnectors.ts
@@ -1,5 +1,7 @@
 import {
+  type Config,
   type GetConnectorsReturnType,
+  type ResolvedRegister,
   getConnectors,
   watchConnectors,
 } from '@wagmi/core'
@@ -8,20 +10,25 @@ import { type Ref, onScopeDispose, ref } from 'vue'
 import type { ConfigParameter } from '../types/properties.js'
 import { useConfig } from './useConfig.js'
 
-export type UseConnectorsParameters = ConfigParameter
+export type UseConnectorsParameters<config extends Config = Config> =
+  ConfigParameter<config>
 
-export type UseConnectorsReturnType = Ref<GetConnectorsReturnType>
+export type UseConnectorsReturnType<config extends Config = Config> = Ref<
+  GetConnectorsReturnType<config>
+>
 
 /** https://wagmi.sh/vue/api/composables/useConnectors */
-export function useConnectors(
-  parameters: UseConnectorsParameters = {},
-): UseConnectorsReturnType {
+export function useConnectors<
+  config extends Config = ResolvedRegister['config'],
+>(
+  parameters: UseConnectorsParameters<config> = {},
+): UseConnectorsReturnType<config> {
   const config = useConfig(parameters)
 
   const connectors = ref(getConnectors(config))
   const unsubscribe = watchConnectors(config, {
     onChange(data) {
-      connectors.value = data
+      connectors.value = data as never
     },
   })
   onScopeDispose(() => unsubscribe())

--- a/playgrounds/vite-react/src/App.tsx
+++ b/playgrounds/vite-react/src/App.tsx
@@ -92,7 +92,12 @@ function Connect() {
       {connectors.map((connector) => (
         <button
           key={connector.uid}
-          onClick={() => connect({ connector, chainId })}
+          onClick={() =>
+            connect({
+              connector,
+              chainId,
+            })
+          }
           type="button"
         >
           {connector.name}


### PR DESCRIPTION
Infer `config.connectors` so connector properties work with `useConnect()`/`connect`.

Related https://github.com/wevm/wagmi/discussions/4441

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
