### PR TITLE
fix: update metamask sdk and fix metadata handling for empty URL

### DIFF
--- a/.changeset/warm-melons-joke.md
+++ b/.changeset/warm-melons-joke.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/connectors": patch
+---
+
+Bumped MetaMask SDK.
+Fixed MetaMask SDK metadata handling for empty URL.

--- a/.changeset/warm-melons-joke.md
+++ b/.changeset/warm-melons-joke.md
@@ -2,5 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Bumped MetaMask SDK.
-Fixed MetaMask SDK metadata handling for empty URL.
+Bumped MetaMask SDK and fixed internal metadata handling.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "4.2.3",
-    "@metamask/sdk": "0.31.1",
+    "@metamask/sdk": "0.31.2",
     "@safe-global/safe-apps-provider": "0.18.4",
     "@safe-global/safe-apps-sdk": "9.1.0",
     "@walletconnect/ethereum-provider": "2.17.0",

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -260,11 +260,14 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           // Workaround cast since MetaMask SDK does not support `'exactOptionalPropertyTypes'`
           ...(parameters as RemoveUndefined<typeof parameters>),
           readonlyRPCMap,
-          dappMetadata:
-            parameters.dappMetadata ??
-            (typeof window !== 'undefined'
-              ? { url: window.location.origin }
-              : { name: 'wagmi', url: 'https://wagmi.sh' }),
+          dappMetadata: {
+            ...parameters.dappMetadata,
+            name: parameters.dappMetadata?.name || 'wagmi',
+            url:
+              parameters.dappMetadata?.url || typeof window !== 'undefined'
+                ? window.location.origin
+                : 'https://wagmi.sh',
+          },
           useDeeplink: parameters.useDeeplink ?? true,
         })
         const result = await sdk.init()

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -262,11 +262,12 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           readonlyRPCMap,
           dappMetadata: {
             ...parameters.dappMetadata,
-            name: parameters.dappMetadata?.name || 'wagmi',
+            name: parameters.dappMetadata?.name ?? 'wagmi',
             url:
-              parameters.dappMetadata?.url || typeof window !== 'undefined'
+              parameters.dappMetadata?.url ??
+              (typeof window !== 'undefined'
                 ? window.location.origin
-                : 'https://wagmi.sh',
+                : 'https://wagmi.sh'),
           },
           useDeeplink: parameters.useDeeplink ?? true,
         })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,39 +4,6 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@tanstack/query-core':
-      specifier: 5.49.1
-      version: 5.49.1
-    '@tanstack/react-query':
-      specifier: 5.49.2
-      version: 5.49.2
-    '@tanstack/vue-query':
-      specifier: 5.49.1
-      version: 5.49.1
-    '@testing-library/dom':
-      specifier: 10.4.0
-      version: 10.4.0
-    '@testing-library/react':
-      specifier: 16.0.1
-      version: 16.0.1
-    '@types/react':
-      specifier: 18.3.1
-      version: 18.3.1
-    '@types/react-dom':
-      specifier: 18.3.0
-      version: 18.3.0
-    react:
-      specifier: 18.3.1
-      version: 18.3.1
-    react-dom:
-      specifier: 18.3.1
-      version: 18.3.1
-    vue:
-      specifier: 3.4.27
-      version: 3.4.27
-
 importers:
 
   .:
@@ -184,8 +151,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3
       '@metamask/sdk':
-        specifier: 0.31.1
-        version: 0.31.1(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        specifier: 0.31.2
+        version: 0.31.2(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider':
         specifier: 0.18.4
         version: 0.18.4(bufferutil@4.0.8)(encoding@0.1.13)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -1771,11 +1738,11 @@ packages:
       readable-stream: ^3.6.2
       socket.io-client: ^4.5.1
 
-  '@metamask/sdk-install-modal-web@0.31.1':
-    resolution: {integrity: sha512-J83K6jN2V3xkTb+/5eyASatlgqHdpzjkTVU6cC+Z/YA9cE32zX8vE0EQweGmExgv+kJ5zz/BiqSZZbMfuilRfQ==}
+  '@metamask/sdk-install-modal-web@0.31.2':
+    resolution: {integrity: sha512-KPv36kQjmTwErU8g2neuHHSgkD5+1hp4D6ERfk5Kc2r73aOYNCdG9wDGRUmFmcY2MKkeK1EuDyZfJ4FPU30fxQ==}
 
-  '@metamask/sdk@0.31.1':
-    resolution: {integrity: sha512-olU3TYRAxIZP5ZXDmi5Y53zXikkPySNiTuBI4QD+2hWYomVlMV2SjOKHSRR6gPuI+fFEg/Z+ImrxDthQfMODwA==}
+  '@metamask/sdk@0.31.2':
+    resolution: {integrity: sha512-6MWON2g1j7XwAHWam4trusGxeyhQweNLEHPsfuIxSwcsXoEm08Jj80OglJxQI4KwjcDnjSWBkQGG3mmK6ug/cA==}
 
   '@metamask/utils@5.0.2':
     resolution: {integrity: sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==}
@@ -8315,6 +8282,39 @@ packages:
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
+catalogs:
+  default:
+    '@tanstack/query-core':
+      specifier: 5.49.1
+      version: 5.49.1
+    '@tanstack/react-query':
+      specifier: 5.49.2
+      version: 5.49.2
+    '@tanstack/vue-query':
+      specifier: 5.49.1
+      version: 5.49.1
+    '@testing-library/dom':
+      specifier: 10.4.0
+      version: 10.4.0
+    '@testing-library/react':
+      specifier: 16.0.1
+      version: 16.0.1
+    '@types/react':
+      specifier: 18.3.1
+      version: 18.3.1
+    '@types/react-dom':
+      specifier: 18.3.0
+      version: 18.3.0
+    react:
+      specifier: 18.3.1
+      version: 18.3.1
+    react-dom:
+      specifier: 18.3.1
+      version: 18.3.1
+    vue:
+      specifier: 3.4.27
+      version: 3.4.27
+
 snapshots:
 
   '@adraffy/ens-normalize@1.10.0': {}
@@ -9476,7 +9476,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.23.4
+      '@babel/runtime': 7.26.0
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -9600,17 +9600,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@metamask/sdk-install-modal-web@0.31.1':
+  '@metamask/sdk-install-modal-web@0.31.2':
     dependencies:
       '@paulmillr/qr': 0.2.1
 
-  '@metamask/sdk@0.31.1(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@metamask/sdk@0.31.2(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
       '@metamask/sdk-communication-layer': 0.31.0(cross-fetch@4.0.0(encoding@0.1.13))(eciesjs@0.4.12)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@metamask/sdk-install-modal-web': 0.31.1
+      '@metamask/sdk-install-modal-web': 0.31.2
       '@paulmillr/qr': 0.2.1
       bowser: 2.11.0
       cross-fetch: 4.0.0(encoding@0.1.13)
@@ -9635,7 +9635,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       semver: 7.5.4
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -9660,7 +9660,7 @@ snapshots:
       '@motionone/easing': 10.15.1
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@motionone/dom@10.16.2':
     dependencies:
@@ -9669,23 +9669,23 @@ snapshots:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@motionone/easing@10.15.1':
     dependencies:
       '@motionone/utils': 10.15.1
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@motionone/generators@10.15.1':
     dependencies:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@motionone/svelte@10.16.2':
     dependencies:
       '@motionone/dom': 10.16.2
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@motionone/types@10.15.1': {}
 
@@ -9693,12 +9693,12 @@ snapshots:
     dependencies:
       '@motionone/types': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@motionone/vue@10.16.2':
     dependencies:
       '@motionone/dom': 10.16.2
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   '@mswjs/interceptors@0.27.2':
     dependencies:
@@ -10726,7 +10726,7 @@ snapshots:
     dependencies:
       '@noble/curves': 1.1.0
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.9
 
   '@scure/bip32@1.3.2':
     dependencies:
@@ -12609,7 +12609,7 @@ snapshots:
 
   async-mutex@0.2.6:
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   async-sema@3.1.1: {}
 
@@ -14253,7 +14253,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -16655,7 +16655,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17500,7 +17500,7 @@ snapshots:
   vite-node@1.6.0(@types/node@20.12.10)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.2.11(@types/node@20.12.10)(terser@5.31.0)
@@ -17578,7 +17578,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.8
       '@rollup/pluginutils': 5.1.0(rollup@4.24.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.1.0


### PR DESCRIPTION
This PR aims to solve an issue where an app provides an empty string as the app URL.

Updated MetaMask SDK to version 0.31.2.