### PR TITLE
fix: metadata handling for empty URL

### DIFF
--- a/.changeset/nasty-planets-play.md
+++ b/.changeset/nasty-planets-play.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fixed metamask internal metadata handling.

--- a/.changeset/nasty-planets-play.md
+++ b/.changeset/nasty-planets-play.md
@@ -2,4 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Fixed metamask internal metadata handling.
+Fixed MetaMask internal metadata handling.

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -262,12 +262,15 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           readonlyRPCMap,
           dappMetadata: {
             ...parameters.dappMetadata,
-            name: parameters.dappMetadata?.name ?? 'wagmi',
-            url:
-              parameters.dappMetadata?.url ??
-              (typeof window !== 'undefined'
+            // Test if name and url are set AND not empty
+            name: parameters.dappMetadata?.name
+              ? parameters.dappMetadata?.name
+              : 'wagmi',
+            url: parameters.dappMetadata?.url
+              ? parameters.dappMetadata?.url
+              : typeof window !== 'undefined'
                 ? window.location.origin
-                : 'https://wagmi.sh'),
+                : 'https://wagmi.sh',
           },
           useDeeplink: parameters.useDeeplink ?? true,
         })


### PR DESCRIPTION
Fix metadata handling for empty URLs.

In my previous commit, I used `||` to test for an empty string, but you replaced it with `??`, which no longer allows testing for `''`.
I have updated the test to use a ternary operator.

Let me know if you prefer a more explicit test, such as `name === ''`.