### PR TITLE
Fix bug when connector does not have any methods

### DIFF
--- a/packages/core/src/actions/disconnect.ts
+++ b/packages/core/src/actions/disconnect.ts
@@ -32,7 +32,7 @@ export async function disconnect(
 
   const connections = config.state.connections
 
-  if (connector) {
+  if (connector?.disconnect) {
     await connector.disconnect()
     connector.emitter.off('change', config._internal.events.change)
     connector.emitter.off('disconnect', config._internal.events.disconnect)


### PR DESCRIPTION
Sometimes connector does now have any methods, `connector.disconnect is not a function` thrown
![image](https://github.com/user-attachments/assets/e1052b97-2c0c-4e22-b991-362ae3bcb436)

This is how `config.state.connections[current].connector` look like (there is no other connections):
![image](https://github.com/user-attachments/assets/78a2ac6e-8cbe-4591-a0eb-7ec8e1b50df9)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
