### PR TITLE
Add wagmiContractConfig to example read-contract.tsx in read-from-contract.md

### DIFF
--- a/site/react/guides/read-from-contract.md
+++ b/site/react/guides/read-from-contract.md
@@ -8,6 +8,26 @@ The component below shows how to retrieve the token balance of an address from t
 ```tsx [read-contract.tsx]
 import { useReadContract } from 'wagmi'
 
+export const wagmiContractConfig = {
+    address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+    abi: [
+        {
+          type: 'function',
+          name: 'balanceOf',
+          stateMutability: 'view',
+          inputs: [{ name: 'account', type: 'address' }],
+          outputs: [{ type: 'uint256' }],
+        },
+        {
+          type: 'function',
+          name: 'totalSupply',
+          stateMutability: 'view',
+          inputs: [],
+          outputs: [{ name: 'supply', type: 'uint256' }],
+        },
+      ]
+} as const
+
 function ReadContract() {
   const { data: balance } = useReadContract({
     ...wagmiContractConfig,

--- a/site/react/guides/read-from-contract.md
+++ b/site/react/guides/read-from-contract.md
@@ -7,26 +7,7 @@ The component below shows how to retrieve the token balance of an address from t
 :::code-group
 ```tsx [read-contract.tsx]
 import { useReadContract } from 'wagmi'
-
-export const wagmiContractConfig = {
-    address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-    abi: [
-        {
-          type: 'function',
-          name: 'balanceOf',
-          stateMutability: 'view',
-          inputs: [{ name: 'account', type: 'address' }],
-          outputs: [{ type: 'uint256' }],
-        },
-        {
-          type: 'function',
-          name: 'totalSupply',
-          stateMutability: 'view',
-          inputs: [],
-          outputs: [{ name: 'supply', type: 'uint256' }],
-        },
-      ]
-} as const
+import { wagmiContractConfig } from './contracts'
 
 function ReadContract() {
   const { data: balance } = useReadContract({
@@ -39,6 +20,27 @@ function ReadContract() {
     <div>Balance: {balance?.toString()}</div>
   )
 }
+```
+```ts [contracts.ts]
+export const wagmiContractConfig = {
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: [
+    {
+      type: 'function',
+      name: 'balanceOf',
+      stateMutability: 'view',
+      inputs: [{ name: 'account', type: 'address' }],
+      outputs: [{ type: 'uint256' }],
+    },
+    {
+      type: 'function',
+      name: 'totalSupply',
+      stateMutability: 'view',
+      inputs: [],
+      outputs: [{ name: 'supply', type: 'uint256' }],
+    },
+  ],
+} as const
 ```
 :::
 

--- a/site/vue/guides/read-from-contract.md
+++ b/site/vue/guides/read-from-contract.md
@@ -11,6 +11,7 @@ The component below shows how to retrieve the token balance of an address from t
 ```vue [ReadContract.vue]
 <script setup lang="ts">
 import { useReadContract } from 'wagmi'
+import { wagmiContractConfig } from './contracts'
 
 const { data: balance } = useReadContract({
   ...wagmiContractConfig,
@@ -23,7 +24,27 @@ const { data: balance } = useReadContract({
   <div>Balance: {{ balance?.toString() }}</div>
 </template>
 ```
-
+```ts [contracts.ts]
+export const wagmiContractConfig = {
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: [
+    {
+      type: 'function',
+      name: 'balanceOf',
+      stateMutability: 'view',
+      inputs: [{ name: 'account', type: 'address' }],
+      outputs: [{ type: 'uint256' }],
+    },
+    {
+      type: 'function',
+      name: 'totalSupply',
+      stateMutability: 'view',
+      inputs: [],
+      outputs: [{ name: 'supply', type: 'uint256' }],
+    },
+  ],
+} as const
+```
 :::
 
 


### PR DESCRIPTION
The code will not run without a definition for this variable. I added a minimal config variable in-file so reader will know how to set one up for themselves.
