### PR TITLE
fix params of removeItem

### DIFF
--- a/.changeset/breezy-parrots-exist.md
+++ b/.changeset/breezy-parrots-exist.md
@@ -1,0 +1,8 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+"@wagmi/vue": patch
+"@wagmi/connectors": patch
+---
+
+Fixed invocation of default storage.

--- a/packages/core/src/createStorage.ts
+++ b/packages/core/src/createStorage.ts
@@ -96,12 +96,11 @@ export function getDefaultStorage() {
     return noopStorage
   })()
   return {
-    getItem: storage.getItem,
+    getItem(key) {
+      return storage.getItem(key)
+    },
     removeItem(key) {
-      try {
-        storage.removeItem(key);
-        // silence errors by default (QuotaExceededError, SecurityError, etc.)
-      } catch {}
+      storage.removeItem(key)
     },
     setItem(key, value) {
       try {

--- a/packages/core/src/createStorage.ts
+++ b/packages/core/src/createStorage.ts
@@ -97,7 +97,12 @@ export function getDefaultStorage() {
   })()
   return {
     getItem: storage.getItem,
-    removeItem: storage.removeItem,
+    removeItem(key) {
+      try {
+        storage.removeItem(key);
+        // silence errors by default (QuotaExceededError, SecurityError, etc.)
+      } catch {}
+    },
     setItem(key, value) {
       try {
         storage.setItem(key, value)


### PR DESCRIPTION
Fixes #4479 


# Description
After debug with wagmi@2.14.5, I noticed that there's no params for `removeItem`, which will lead to the error 'illegal invocation', like in the screenshot.
![image](https://github.com/user-attachments/assets/209d08c1-f4cc-43e6-95be-4b93095c74e2)
![image](https://github.com/user-attachments/assets/2aaac999-4700-45ac-9572-da8950995429)

# Solution
``` js
export function getDefaultStorage() {
  const storage = (() => {
    if (typeof window !== "undefined" && window.localStorage)
      return window.localStorage;
    return noopStorage;
  })();
  return {
    getItem: storage.getItem,
    removeItem(key) {
      try {
        storage.removeItem(key);
      } catch {}
    },
    setItem(key, value) {
      try {
        storage.setItem(key, value);
        // silence errors by default (QuotaExceededError, SecurityError, etc.)
      } catch {}
    },
  } satisfies BaseStorage;
}

```

I've already patched in my project, and it works well now.