### PR TITLE
Fix chain switch: back to consistent switchChain before addChain

### DIFF
--- a/.changeset/eighty-socks-roll.md
+++ b/.changeset/eighty-socks-roll.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fixed MetaMask switchChain/addChain handling.


### PR DESCRIPTION
# Description

Rollback #4422. In this PR, `wallet_addEthereumChain` was called in the first place for all non-removable chains. This method has the side effect of requiring the user to update its MetaMask RPC when it's not matching the one specified in the request.

# Changes

In this PR, we're moving back to the regular flow: try `wallet_switchChain`, and if it fails because the chain doesn't exist, try `wallet_addEthereumChain`. This flow is more consistent and aligned with the consequences of each method.