### PR TITLE
ZKsync: Add `sendEip712Transaction` action,  React hook and Vue composable

### DIFF
--- a/.changeset/nasty-dancers-hammer.md
+++ b/.changeset/nasty-dancers-hammer.md
@@ -1,0 +1,7 @@
+---
+"wagmi": minor
+"@wagmi/core": minor
+"@wagmi/vue": minor
+---
+
+Added `sendEip712Transaction` action and `useSendEip712Transaction` hooks for React and Vue.

--- a/packages/core/src/actions/sendEip712Transaction.test-d.ts
+++ b/packages/core/src/actions/sendEip712Transaction.test-d.ts
@@ -1,0 +1,44 @@
+import { http, parseEther } from 'viem'
+import { zksync } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+
+import { createConfig } from '../createConfig.js'
+import {
+  type SendEip712TransactionParameters,
+  sendEip712Transaction,
+} from './sendEip712Transaction.js'
+
+test('chain formatters', () => {
+  const config = createConfig({
+    chains: [zksync],
+    transports: { [zksync.id]: http() },
+  })
+
+  type Result = SendEip712TransactionParameters<typeof config>
+  expectTypeOf<Result>().toMatchTypeOf<{
+    chainId?: typeof zksync.id | undefined
+    feeCurrency?: `0x${string}` | undefined
+  }>()
+  sendEip712Transaction(config, {
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    value: parseEther('0.01'),
+    // @ts-expect-error
+    feeCurrency: '0x',
+  })
+
+  type Result2 = SendEip712TransactionParameters<
+    typeof config,
+    typeof zksync.id
+  >
+  // @ts-expect-error
+  expectTypeOf<Result2>().toMatchTypeOf<{
+    feeCurrency?: `0x${string}` | undefined
+  }>()
+  sendEip712Transaction(config, {
+    chainId: zksync.id,
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    value: parseEther('0.01'),
+    // @ts-expect-error
+    feeCurrency: '0x',
+  })
+})

--- a/packages/core/src/actions/sendEip712Transaction.test.ts
+++ b/packages/core/src/actions/sendEip712Transaction.test.ts
@@ -1,0 +1,105 @@
+import { config, privateKey, transactionHashRegex } from '@wagmi/test'
+import { parseEther } from 'viem'
+import { beforeEach, expect, test } from 'vitest'
+
+import { privateKeyToAccount } from 'viem/accounts'
+import { connect } from './connect.js'
+import { disconnect } from './disconnect.js'
+import { sendEip712Transaction } from './sendEip712Transaction.js'
+
+const connector = config.connectors[0]!
+
+beforeEach(async () => {
+  if (config.state.current === connector.uid)
+    await disconnect(config, { connector })
+})
+
+test('default', async () => {
+  const result = await connect(config, { connector })
+  config.state.connections.set(connector.uid, {
+    ...result,
+    // Switch up the current account because the default one is running out of funds somewhere
+    accounts: result.accounts.slice(1) as unknown as typeof result.accounts,
+    connector,
+  })
+  await expect(
+    sendEip712Transaction(config, {
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('0.0001'),
+    }),
+  ).resolves.toMatch(transactionHashRegex)
+  await disconnect(config, { connector })
+})
+
+test('behavior: connector not connected', async () => {
+  await connect(config, { connector })
+  await expect(
+    sendEip712Transaction(config, {
+      connector: config.connectors[1],
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('0.0001'),
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [ConnectorNotConnectedError: Connector not connected.
+
+    Version: @wagmi/core@x.y.z]
+  `)
+  await disconnect(config, { connector })
+})
+
+test('behavior: account does not exist on connector', async () => {
+  await connect(config, { connector })
+  await expect(
+    sendEip712Transaction(config, {
+      account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('0.0001'),
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [ConnectorAccountNotFoundError: Account "0xA0Cf798816D4b9b9866b5330EEa46a18382f251e" not found for connector "Mock Connector".
+
+    Version: @wagmi/core@x.y.z]
+  `)
+  await disconnect(config, { connector })
+})
+
+test('behavior: value exceeds balance', async () => {
+  await connect(config, { connector })
+  await expect(
+    sendEip712Transaction(config, {
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('99999'),
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [TransactionExecutionError: The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.
+
+    This error could arise when the account does not have enough funds to:
+     - pay for the total gas fee,
+     - pay for the value to send.
+
+    The cost of the transaction is calculated as \`gas * gas fee + value\`, where:
+     - \`gas\` is the amount of gas needed for transaction to execute,
+     - \`gas fee\` is the gas fee,
+     - \`value\` is the amount of ether to send to the recipient.
+
+    Request Arguments:
+      from:   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+      to:     0xd2135CfB216b74109775236E36d4b433F1DF507B
+      value:  99999 ETH
+
+    Details: Insufficient funds for gas * price + value
+    Version: 2.21.28]
+  `)
+  await disconnect(config, { connector })
+})
+
+test('behavior: local account', async () => {
+  const account = privateKeyToAccount(privateKey)
+  await expect(
+    sendEip712Transaction(config, {
+      account,
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('0.000001'),
+    }),
+  ).resolves.toMatch(transactionHashRegex)
+})

--- a/packages/core/src/actions/sendEip712Transaction.ts
+++ b/packages/core/src/actions/sendEip712Transaction.ts
@@ -1,0 +1,83 @@
+import type { Account, Client, TransactionRequest } from 'viem'
+import {
+  type ChainEIP712,
+  type SendTransactionErrorType as viem_SendTransactionErrorType,
+  type SendTransactionParameters as viem_SendTransactionParameters,
+  type SendTransactionReturnType as viem_SendTransactionReturnType,
+  sendTransaction as viem_sendTransaction,
+} from 'viem/zksync'
+import type { Config } from '../createConfig.js'
+import type { BaseErrorType, ErrorType } from '../errors/base.js'
+import type { SelectChains } from '../types/chain.js'
+import type {
+  ChainIdParameter,
+  ConnectorParameter,
+} from '../types/properties.js'
+import type { Compute } from '../types/utils.js'
+import { getAction } from '../utils/getAction.js'
+import {
+  type GetConnectorClientErrorType,
+  getConnectorClient,
+} from './getConnectorClient.js'
+
+export type SendEip712TransactionParameters<
+  config extends Config = Config,
+  chainId extends
+    config['chains'][number]['id'] = config['chains'][number]['id'],
+  ///
+  chains extends readonly ChainEIP712[] = SelectChains<config, chainId>,
+> = {
+  [key in keyof chains]: Compute<
+    Omit<
+      viem_SendTransactionParameters<chains[key], Account, chains[key]>,
+      'chain' | 'gas'
+    > &
+      ChainIdParameter<config, chainId> &
+      ConnectorParameter
+  >
+}[number] & {
+  /** Gas provided for transaction execution. */
+  gas?: TransactionRequest['gas'] | null
+}
+
+export type SendEip712TransactionReturnType = viem_SendTransactionReturnType
+
+export type SendEip712TransactionErrorType =
+  // getConnectorClient()
+  | GetConnectorClientErrorType
+  // base
+  | BaseErrorType
+  | ErrorType
+  // viem
+  | viem_SendTransactionErrorType
+
+/** https://wagmi.sh/core/api/actions/sendEip712Transaction */
+export async function sendEip712Transaction<
+  config extends Config,
+  chainId extends config['chains'][number]['id'],
+>(
+  config: config,
+  parameters: SendEip712TransactionParameters<config, chainId>,
+): Promise<SendEip712TransactionReturnType> {
+  const { account, chainId, connector, ...rest } = parameters
+
+  let client: Client
+  if (typeof account === 'object' && account?.type === 'local')
+    client = config.getClient({ chainId })
+  else
+    client = await getConnectorClient(config, {
+      account: account ?? undefined,
+      chainId,
+      connector,
+    })
+
+  const action = getAction(client, viem_sendTransaction, 'sendTransaction')
+  const hash = await action({
+    ...(rest as any),
+    ...(account ? { account } : {}),
+    chain: chainId ? { id: chainId } : undefined,
+    gas: rest.gas ?? undefined,
+  })
+
+  return hash
+}

--- a/packages/core/src/exports/actions.test.ts
+++ b/packages/core/src/exports/actions.test.ts
@@ -53,6 +53,7 @@ test('exports', () => {
       "readContract",
       "readContracts",
       "reconnect",
+      "sendEip712Transaction",
       "sendTransaction",
       "signMessage",
       "signTypedData",

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -287,6 +287,13 @@ export {
 } from '../actions/reconnect.js'
 
 export {
+  type SendEip712TransactionErrorType,
+  type SendEip712TransactionParameters,
+  type SendEip712TransactionReturnType,
+  sendEip712Transaction,
+} from '../actions/sendEip712Transaction.js'
+
+export {
   type SendTransactionErrorType,
   type SendTransactionParameters,
   type SendTransactionReturnType,

--- a/packages/core/src/exports/index.test.ts
+++ b/packages/core/src/exports/index.test.ts
@@ -53,6 +53,7 @@ test('exports', () => {
       "readContract",
       "readContracts",
       "reconnect",
+      "sendEip712Transaction",
       "sendTransaction",
       "signMessage",
       "signTypedData",

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -287,6 +287,13 @@ export {
 } from '../actions/reconnect.js'
 
 export {
+  type SendEip712TransactionErrorType,
+  type SendEip712TransactionParameters,
+  type SendEip712TransactionReturnType,
+  sendEip712Transaction,
+} from '../actions/sendEip712Transaction.js'
+
+export {
   type SendTransactionErrorType,
   type SendTransactionParameters,
   type SendTransactionReturnType,

--- a/packages/core/src/exports/query.test.ts
+++ b/packages/core/src/exports/query.test.ts
@@ -67,6 +67,7 @@ test('exports', () => {
       "readContractsQueryKey",
       "readContractsQueryOptions",
       "reconnectMutationOptions",
+      "sendEip712TransactionMutationOptions",
       "sendTransactionMutationOptions",
       "signMessageMutationOptions",
       "signTypedDataMutationOptions",

--- a/packages/core/src/exports/query.ts
+++ b/packages/core/src/exports/query.ts
@@ -297,6 +297,14 @@ export {
 } from '../query/reconnect.js'
 
 export {
+  type SendEip712TransactionData,
+  type SendEip712TransactionVariables,
+  type SendEip712TransactionMutate,
+  type SendEip712TransactionMutateAsync,
+  sendEip712TransactionMutationOptions,
+} from '../query/sendEip712Transaction.js'
+
+export {
   type SendTransactionData,
   type SendTransactionVariables,
   type SendTransactionMutate,

--- a/packages/core/src/query/sendEip712Transaction.test.ts
+++ b/packages/core/src/query/sendEip712Transaction.test.ts
@@ -1,0 +1,15 @@
+import { config } from '@wagmi/test'
+import { expect, test } from 'vitest'
+
+import { sendEip712TransactionMutationOptions } from './sendEip712Transaction.js'
+
+test('default', () => {
+  expect(sendEip712TransactionMutationOptions(config)).toMatchInlineSnapshot(`
+    {
+      "mutationFn": [Function],
+      "mutationKey": [
+        "sendEip712Transaction",
+      ],
+    }
+  `)
+})

--- a/packages/core/src/query/sendEip712Transaction.ts
+++ b/packages/core/src/query/sendEip712Transaction.ts
@@ -1,0 +1,66 @@
+import type { MutateOptions, MutationOptions } from '@tanstack/query-core'
+
+import {
+  type SendEip712TransactionErrorType,
+  type SendEip712TransactionParameters,
+  type SendEip712TransactionReturnType,
+  sendEip712Transaction,
+} from '../actions/sendEip712Transaction.js'
+import type { Config } from '../createConfig.js'
+import type { Compute } from '../types/utils.js'
+
+export function sendEip712TransactionMutationOptions<config extends Config>(
+  config: config,
+) {
+  return {
+    mutationFn(variables) {
+      return sendEip712Transaction(config, variables)
+    },
+    mutationKey: ['sendEip712Transaction'],
+  } as const satisfies MutationOptions<
+    SendEip712TransactionData,
+    SendEip712TransactionErrorType,
+    SendEip712TransactionVariables<config, config['chains'][number]['id']>
+  >
+}
+
+export type SendEip712TransactionData = Compute<SendEip712TransactionReturnType>
+
+export type SendEip712TransactionVariables<
+  config extends Config,
+  chainId extends config['chains'][number]['id'],
+> = SendEip712TransactionParameters<config, chainId>
+
+export type SendEip712TransactionMutate<
+  config extends Config,
+  context = unknown,
+> = <chainId extends config['chains'][number]['id']>(
+  variables: SendEip712TransactionVariables<config, chainId>,
+  options?:
+    | Compute<
+        MutateOptions<
+          SendEip712TransactionData,
+          SendEip712TransactionErrorType,
+          Compute<SendEip712TransactionVariables<config, chainId>>,
+          context
+        >
+      >
+    | undefined,
+) => void
+
+export type SendEip712TransactionMutateAsync<
+  config extends Config,
+  context = unknown,
+> = <chainId extends config['chains'][number]['id']>(
+  variables: SendEip712TransactionVariables<config, chainId>,
+  options?:
+    | Compute<
+        MutateOptions<
+          SendEip712TransactionData,
+          SendEip712TransactionErrorType,
+          Compute<SendEip712TransactionVariables<config, chainId>>,
+          context
+        >
+      >
+    | undefined,
+) => Promise<SendEip712TransactionData>

--- a/packages/react/src/exports/actions.test.ts
+++ b/packages/react/src/exports/actions.test.ts
@@ -53,6 +53,7 @@ test('exports', () => {
       "readContract",
       "readContracts",
       "reconnect",
+      "sendEip712Transaction",
       "sendTransaction",
       "signMessage",
       "signTypedData",

--- a/packages/react/src/exports/index.test.ts
+++ b/packages/react/src/exports/index.test.ts
@@ -50,6 +50,7 @@ test('exports', () => {
       "useReadContracts",
       "useContractReads",
       "useReconnect",
+      "useSendEip712Transaction",
       "useSendTransaction",
       "useSignMessage",
       "useSignTypedData",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -246,6 +246,12 @@ export {
 } from '../hooks/useReconnect.js'
 
 export {
+  type UseSendEip712TransactionParameters,
+  type UseSendEip712TransactionReturnType,
+  useSendEip712Transaction,
+} from '../hooks/useSendEip712Transaction.js'
+
+export {
   type UseSendTransactionParameters,
   type UseSendTransactionReturnType,
   useSendTransaction,

--- a/packages/react/src/exports/query.test.ts
+++ b/packages/react/src/exports/query.test.ts
@@ -67,6 +67,7 @@ test('exports', () => {
       "readContractsQueryKey",
       "readContractsQueryOptions",
       "reconnectMutationOptions",
+      "sendEip712TransactionMutationOptions",
       "sendTransactionMutationOptions",
       "signMessageMutationOptions",
       "signTypedDataMutationOptions",

--- a/packages/react/src/hooks/useSendEip712Transaction.test-d.ts
+++ b/packages/react/src/hooks/useSendEip712Transaction.test-d.ts
@@ -1,0 +1,82 @@
+import type { SendEip712TransactionErrorType } from '@wagmi/core'
+import type { Hash } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+
+import { useSendEip712Transaction } from './useSendEip712Transaction.js'
+
+const contextValue = { foo: 'bar' } as const
+
+test('context', () => {
+  const { context, data, error, sendEip712Transaction, variables } =
+    useSendEip712Transaction({
+      mutation: {
+        onMutate(variables) {
+          expectTypeOf(variables).toMatchTypeOf<
+            { chainId?: number | undefined } | undefined
+          >()
+          return contextValue
+        },
+        onError(error, variables, context) {
+          expectTypeOf(variables).toMatchTypeOf<{
+            chainId?: number | undefined
+          }>()
+          expectTypeOf(error).toEqualTypeOf<SendEip712TransactionErrorType>()
+          expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+        },
+        onSuccess(data, variables, context) {
+          expectTypeOf(variables).toMatchTypeOf<{
+            chainId?: number | undefined
+          }>()
+          expectTypeOf(data).toEqualTypeOf<Hash>()
+          expectTypeOf(context).toEqualTypeOf<typeof contextValue>()
+        },
+        onSettled(data, error, variables, context) {
+          expectTypeOf(data).toEqualTypeOf<Hash | undefined>()
+          expectTypeOf(
+            error,
+          ).toEqualTypeOf<SendEip712TransactionErrorType | null>()
+          expectTypeOf(variables).toMatchTypeOf<{
+            chainId?: number | undefined
+          }>()
+          expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+        },
+      },
+    })
+
+  expectTypeOf(data).toEqualTypeOf<Hash | undefined>()
+  expectTypeOf(error).toEqualTypeOf<SendEip712TransactionErrorType | null>()
+  expectTypeOf(variables).toMatchTypeOf<
+    { chainId?: number | undefined } | undefined
+  >()
+  expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+
+  sendEip712Transaction(
+    { to: '0x' },
+    {
+      onError(error, variables, context) {
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+        }>()
+        expectTypeOf(error).toEqualTypeOf<SendEip712TransactionErrorType>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+        }>()
+        expectTypeOf(data).toEqualTypeOf<Hash>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Hash | undefined>()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<SendEip712TransactionErrorType | null>()
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+        }>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+      },
+    },
+  )
+})

--- a/packages/react/src/hooks/useSendEip712Transaction.test.ts
+++ b/packages/react/src/hooks/useSendEip712Transaction.test.ts
@@ -1,0 +1,25 @@
+import { connect, disconnect } from '@wagmi/core'
+import { config, transactionHashRegex } from '@wagmi/test'
+import { renderHook, waitFor } from '@wagmi/test/react'
+import { parseEther } from 'viem'
+import { expect, test } from 'vitest'
+
+import { useSendEip712Transaction } from './useSendEip712Transaction.js'
+
+const connector = config.connectors[0]!
+
+test('default', async () => {
+  await connect(config, { connector })
+
+  const { result } = renderHook(() => useSendEip712Transaction())
+
+  result.current.sendEip712Transaction({
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    value: parseEther('0.01'),
+  })
+  await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+  expect(result.current.data).toMatch(transactionHashRegex)
+
+  await disconnect(config, { connector })
+})

--- a/packages/react/src/hooks/useSendEip712Transaction.ts
+++ b/packages/react/src/hooks/useSendEip712Transaction.ts
@@ -1,0 +1,86 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import type {
+  Config,
+  ResolvedRegister,
+  SendEip712TransactionErrorType,
+} from '@wagmi/core'
+import type { Compute } from '@wagmi/core/internal'
+import {
+  type SendEip712TransactionData,
+  type SendEip712TransactionMutate,
+  type SendEip712TransactionMutateAsync,
+  type SendEip712TransactionVariables,
+  sendEip712TransactionMutationOptions,
+} from '@wagmi/core/query'
+
+import type { ConfigParameter } from '../types/properties.js'
+import type {
+  UseMutationParameters,
+  UseMutationReturnType,
+} from '../utils/query.js'
+import { useConfig } from './useConfig.js'
+
+export type UseSendEip712TransactionParameters<
+  config extends Config = Config,
+  context = unknown,
+> = Compute<
+  ConfigParameter<config> & {
+    mutation?:
+      | UseMutationParameters<
+          SendEip712TransactionData,
+          SendEip712TransactionErrorType,
+          SendEip712TransactionVariables<
+            config,
+            config['chains'][number]['id']
+          >,
+          context
+        >
+      | undefined
+  }
+>
+
+export type UseSendEip712TransactionReturnType<
+  config extends Config = Config,
+  context = unknown,
+> = Compute<
+  UseMutationReturnType<
+    SendEip712TransactionData,
+    SendEip712TransactionErrorType,
+    SendEip712TransactionVariables<config, config['chains'][number]['id']>,
+    context
+  > & {
+    sendEip712Transaction: SendEip712TransactionMutate<config, context>
+    sendEip712TransactionAsync: SendEip712TransactionMutateAsync<
+      config,
+      context
+    >
+  }
+>
+
+/** https://wagmi.sh/react/api/hooks/useSendEip712Transaction */
+export function useSendEip712Transaction<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: UseSendEip712TransactionParameters<config, context> = {},
+): UseSendEip712TransactionReturnType<config, context> {
+  const { mutation } = parameters
+
+  const config = useConfig(parameters)
+
+  const mutationOptions = sendEip712TransactionMutationOptions(config)
+  const { mutate, mutateAsync, ...result } = useMutation({
+    ...mutation,
+    ...mutationOptions,
+  })
+
+  type Return = UseSendEip712TransactionReturnType<config, context>
+  return {
+    ...result,
+    sendEip712Transaction: mutate as Return['sendEip712Transaction'],
+    sendEip712TransactionAsync:
+      mutateAsync as Return['sendEip712TransactionAsync'],
+  }
+}

--- a/packages/test/src/chains.ts
+++ b/packages/test/src/chains.ts
@@ -3,6 +3,7 @@ import {
   type Chain as viem_Chain,
   mainnet as viem_mainnet,
   optimism as viem_optimism,
+  zksync as viem_zksync,
 } from 'viem/chains'
 
 import { getRpcUrls } from './utils.js'
@@ -44,8 +45,18 @@ export const optimism = {
   },
 } as const satisfies Chain
 
+export const zksync = {
+  ...getRpcUrls({ port: 8548 }),
+  ...viem_zksync,
+  fork: {
+    blockNumber: 25_734n,
+    url: process.env.VITE_ZKSYNC_FORK_URL ?? 'https://mainnet.era.zksync.io',
+  },
+} as const satisfies Chain
+
 export const chain = {
   mainnet,
   mainnet2,
   optimism,
+  zksync,
 }

--- a/packages/test/src/clients.ts
+++ b/packages/test/src/clients.ts
@@ -8,7 +8,7 @@ import {
   createTestClient,
 } from 'viem'
 
-import { type Chain, mainnet, mainnet2, optimism } from './chains.js'
+import { type Chain, mainnet, mainnet2, optimism, zksync } from './chains.js'
 
 export const mainnetTestClient = createTestClient({
   mode: 'anvil',

--- a/packages/vue/src/composables/useSendEip712Transaction.test-d.ts
+++ b/packages/vue/src/composables/useSendEip712Transaction.test-d.ts
@@ -1,0 +1,78 @@
+import type { SendTransactionErrorType } from '@wagmi/core'
+import type { Hash } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+
+import { useSendEip712Transaction } from './useSendEip712Transaction.js'
+
+const contextValue = { foo: 'bar' } as const
+
+test('context', () => {
+  const { context, data, error, sendEip712Transaction, variables } =
+    useSendEip712Transaction({
+      mutation: {
+        onMutate(variables) {
+          expectTypeOf(variables).toMatchTypeOf<
+            { chainId?: number | undefined } | undefined
+          >()
+          return contextValue
+        },
+        onError(error, variables, context) {
+          expectTypeOf(variables).toMatchTypeOf<{
+            chainId?: number | undefined
+          }>()
+          expectTypeOf(error).toEqualTypeOf<SendTransactionErrorType>()
+          expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+        },
+        onSuccess(data, variables, context) {
+          expectTypeOf(variables).toMatchTypeOf<{
+            chainId?: number | undefined
+          }>()
+          expectTypeOf(data).toEqualTypeOf<Hash>()
+          expectTypeOf(context).toEqualTypeOf<typeof contextValue>()
+        },
+        onSettled(data, error, variables, context) {
+          expectTypeOf(data).toEqualTypeOf<Hash | undefined>()
+          expectTypeOf(error).toEqualTypeOf<SendTransactionErrorType | null>()
+          expectTypeOf(variables).toMatchTypeOf<{
+            chainId?: number | undefined
+          }>()
+          expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+        },
+      },
+    })
+
+  expectTypeOf(data.value).toEqualTypeOf<Hash | undefined>()
+  expectTypeOf(error.value).toEqualTypeOf<SendTransactionErrorType | null>()
+  expectTypeOf(variables.value).toMatchTypeOf<
+    { chainId?: number | undefined } | undefined
+  >()
+  expectTypeOf(context.value).toEqualTypeOf<typeof contextValue | undefined>()
+
+  sendEip712Transaction(
+    { to: '0x' },
+    {
+      onError(error, variables, context) {
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+        }>()
+        expectTypeOf(error).toEqualTypeOf<SendTransactionErrorType>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+        }>()
+        expectTypeOf(data).toEqualTypeOf<Hash>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Hash | undefined>()
+        expectTypeOf(error).toEqualTypeOf<SendTransactionErrorType | null>()
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+        }>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+      },
+    },
+  )
+})

--- a/packages/vue/src/composables/useSendEip712Transaction.test.ts
+++ b/packages/vue/src/composables/useSendEip712Transaction.test.ts
@@ -1,0 +1,25 @@
+import { connect, disconnect } from '@wagmi/core'
+import { config, transactionHashRegex } from '@wagmi/test'
+import { renderComposable, waitFor } from '@wagmi/test/vue'
+import { parseEther } from 'viem'
+import { expect, test } from 'vitest'
+
+import { useSendEip712Transaction } from './useSendEip712Transaction.js'
+
+const connector = config.connectors[0]!
+
+test('default', async () => {
+  await connect(config, { connector })
+
+  const [result] = renderComposable(() => useSendEip712Transaction())
+
+  result.sendEip712Transaction({
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    value: parseEther('0.01'),
+  })
+  await waitFor(result.isSuccess)
+
+  expect(result.data.value).toMatch(transactionHashRegex)
+
+  await disconnect(config, { connector })
+})

--- a/packages/vue/src/composables/useSendEip712Transaction.ts
+++ b/packages/vue/src/composables/useSendEip712Transaction.ts
@@ -1,0 +1,82 @@
+import { useMutation } from '@tanstack/vue-query'
+import type {
+  Config,
+  ResolvedRegister,
+  SendEip712TransactionErrorType,
+} from '@wagmi/core'
+import type { Compute } from '@wagmi/core/internal'
+import {
+  type SendEip712TransactionData,
+  type SendEip712TransactionMutate,
+  type SendEip712TransactionMutateAsync,
+  type SendEip712TransactionVariables,
+  sendEip712TransactionMutationOptions,
+} from '@wagmi/core/query'
+
+import type { ConfigParameter } from '../types/properties.js'
+import type {
+  UseMutationParameters,
+  UseMutationReturnType,
+} from '../utils/query.js'
+import { useConfig } from './useConfig.js'
+
+export type UseSendEip712TransactionParameters<
+  config extends Config = Config,
+  context = unknown,
+> = Compute<
+  ConfigParameter<config> & {
+    mutation?:
+      | UseMutationParameters<
+          SendEip712TransactionData,
+          SendEip712TransactionErrorType,
+          SendEip712TransactionVariables<
+            config,
+            config['chains'][number]['id']
+          >,
+          context
+        >
+      | undefined
+  }
+>
+
+export type UseSendEip712TransactionReturnType<
+  config extends Config = Config,
+  context = unknown,
+> = Compute<
+  UseMutationReturnType<
+    SendEip712TransactionData,
+    SendEip712TransactionErrorType,
+    SendEip712TransactionVariables<config, config['chains'][number]['id']>,
+    context
+  > & {
+    sendEip712Transaction: SendEip712TransactionMutate<config, context>
+    sendEip712TransactionAsync: SendEip712TransactionMutateAsync<
+      config,
+      context
+    >
+  }
+>
+
+/** https://wagmi.sh/vue/api/composables/useSendEip712Transaction */
+export function useSendEip712Transaction<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: UseSendEip712TransactionParameters<config, context> = {},
+): UseSendEip712TransactionReturnType<config, context> {
+  const { mutation } = parameters
+
+  const config = useConfig(parameters)
+
+  const mutationOptions = sendEip712TransactionMutationOptions(config)
+  const { mutate, mutateAsync, ...result } = useMutation({
+    ...mutation,
+    ...mutationOptions,
+  })
+
+  return {
+    ...result,
+    sendEip712Transaction: mutate,
+    sendEip712TransactionAsync: mutateAsync,
+  } as UseSendEip712TransactionReturnType<config, context>
+}

--- a/packages/vue/src/exports/actions.test.ts
+++ b/packages/vue/src/exports/actions.test.ts
@@ -53,6 +53,7 @@ test('exports', () => {
       "readContract",
       "readContracts",
       "reconnect",
+      "sendEip712Transaction",
       "sendTransaction",
       "signMessage",
       "signTypedData",

--- a/packages/vue/src/exports/index.test.ts
+++ b/packages/vue/src/exports/index.test.ts
@@ -30,6 +30,7 @@ test('exports', () => {
       "useEstimateGas",
       "useReadContract",
       "useReconnect",
+      "useSendEip712Transaction",
       "useSendTransaction",
       "useSignMessage",
       "useSignTypedData",

--- a/packages/vue/src/exports/index.ts
+++ b/packages/vue/src/exports/index.ts
@@ -142,6 +142,12 @@ export {
 } from '../composables/useReconnect.js'
 
 export {
+  type UseSendEip712TransactionParameters,
+  type UseSendEip712TransactionReturnType,
+  useSendEip712Transaction,
+} from '../composables/useSendEip712Transaction.js'
+
+export {
   type UseSendTransactionParameters,
   type UseSendTransactionReturnType,
   useSendTransaction,

--- a/packages/vue/src/exports/query.test.ts
+++ b/packages/vue/src/exports/query.test.ts
@@ -67,6 +67,7 @@ test('exports', () => {
       "readContractsQueryKey",
       "readContractsQueryOptions",
       "reconnectMutationOptions",
+      "sendEip712TransactionMutationOptions",
       "sendTransactionMutationOptions",
       "signMessageMutationOptions",
       "signTypedDataMutationOptions",

--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -240,6 +240,10 @@ export function getSidebar() {
           },
           { text: 'useReconnect', link: '/react/api/hooks/useReconnect' },
           {
+            text: 'useSendEip712Transaction',
+            link: '/react/api/hooks/useSendEip712Transaction',
+          },
+          {
             text: 'useSendTransaction',
             link: '/react/api/hooks/useSendTransaction',
           },
@@ -561,6 +565,10 @@ export function getSidebar() {
             link: '/vue/api/composables/useReconnect',
           },
           {
+            text: 'useSendEip712Transaction',
+            link: '/vue/api/composables/useSendEip712Transaction',
+          },
+          {
             text: 'useSendTransaction',
             link: '/vue/api/composables/useSendTransaction',
           },
@@ -867,6 +875,10 @@ export function getSidebar() {
           {
             text: 'readContracts',
             link: '/core/api/actions/readContracts',
+          },
+          {
+            text: 'sendEip712Transaction',
+            link: '/core/api/actions/sendEip712Transaction',
           },
           {
             text: 'sendTransaction',

--- a/site/core/api/actions/sendEip712Transaction.md
+++ b/site/core/api/actions/sendEip712Transaction.md
@@ -1,0 +1,403 @@
+<script setup>
+const packageName = '@wagmi/core'
+const actionName = 'sendEip712Transaction'
+const typeName = 'SendEip712Transaction'
+</script>
+
+# sendEip712Transaction
+
+Action for creating, signing, and sending transactions to ZKsync networks.
+
+## Import
+
+```ts
+import { sendEip712Transaction } from '@wagmi/core'
+```
+
+## Usage
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type SendEip712TransactionParameters } from '@wagmi/core'
+```
+
+### account
+
+`Address | Account | undefined`
+
+Account to use when sending transaction. Throws if account is not found on [`connector`](#connector).
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+Chain ID to validate against before sending transaction.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { zksync } from '@wagmi/core/chains'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  chainId: zksync.id, // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### connector
+
+`Connector | undefined`
+
+- Connector to send transaction with.
+- Defaults to current connector.
+
+::: code-group
+```ts [index.ts]
+import { getConnections, sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const connections = getConnections(config)
+const result = await sendEip712Transaction(config, {
+  connector: connections[0]?.connector, // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### data
+
+`` `0x${string}` | undefined ``
+
+A contract hashed method call with encoded args.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### factoryDeps
+
+`[0x${string}]`
+
+Contains bytecode of the deployed contract.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther, parseGwei } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+  factoryDeps: ['0xcde...'], // [!code focus]  
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### gas
+
+`bigint | undefined | null`
+
+Gas provided for transaction execution.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther, parseGwei } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  gas: parseGwei('20'), // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+---
+
+### gasPrice
+
+`bigint | undefined`
+
+The price in wei to pay per gas. Only applies to [Legacy Transactions](https://viem.sh/docs/glossary/terms.html#legacy-transaction).
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther, parseGwei } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  gasPrice: parseGwei('20'), // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### gasPerPubdata
+
+`bigint`
+
+The amount of gas for publishing one byte of data on Ethereum.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  gasPerPubdata: 50_000n, // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### maxFeePerGas
+
+`bigint | undefined`
+
+Total fee per gas in wei, inclusive of [`maxPriorityFeePerGas`](#maxPriorityFeePerGas). Only applies to [EIP-1559 Transactions](https://viem.sh/docs/glossary/terms.html#eip-1559-transaction).
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther, parseGwei } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  maxFeePerGas: parseGwei('20'), // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### maxPriorityFeePerGas
+
+`bigint | undefined`
+
+Max priority fee per gas in wei. Only applies to [EIP-1559 Transactions](https://viem.sh/docs/glossary/terms.html#eip-1559-transaction).
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther, parseGwei } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  maxFeePerGas: parseGwei('20'),
+  maxPriorityFeePerGas: parseGwei('2'), // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+---
+
+### nonce
+
+`number`
+
+Unique number identifying this transaction.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  nonce: 123, // [!code focus]
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### to
+
+`Address`
+
+The transaction recipient or contract address.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', // [!code focus]
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### type
+
+`'legacy' | 'eip1559' | 'eip2930' | 'eip712' | undefined`
+
+Optional transaction request type to narrow parameters.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  type: 'eip1559', // [!code focus]
+  value: parseEther('0.01'),
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### value
+
+`bigint | undefined`
+
+Value in wei sent with this transaction.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+  value: parseEther('0.01'), // [!code focus]
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### paymaster
+
+`Account | Address`
+
+Address of the paymaster account that will pay the fees. The `paymasterInput` field is required with this one.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+  value: parseEther('0.01'),
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021', // [!code focus]
+  paymasterInput: '0x8c5a...' // [!code focus]  
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+### paymasterInput
+
+`0x${string}`
+
+Input data to the paymaster. The `paymaster` field is required with this one.
+
+::: code-group
+```ts [index.ts]
+import { sendEip712Transaction } from '@wagmi/core'
+import { parseEther } from 'viem'
+import { config } from './config'
+
+const result = await sendEip712Transaction(config, {
+  to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+  value: parseEther('0.01'),
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021', // [!code focus]
+  paymasterInput: '0x8c5a...' // [!code focus]  
+})
+```
+<<< @/snippets/core/config-zksync.ts[config.ts]
+:::
+
+## Return Type
+
+```ts
+import { type SendEip712TransactionReturnType } from '@wagmi/core'
+```
+
+[`Hash`](https://viem.sh/docs/glossary/types.html#hash)
+
+Transaction hash.
+
+## Error
+
+```ts
+import { type SendEip712TransactionErrorType } from '@wagmi/core'
+```
+
+<!--@include: @shared/mutation-imports.md-->
+
+## Viem
+
+- [`sendTransaction`](https://viem.sh/zksync/actions/sendTransaction.html)

--- a/site/react/api/hooks/useSendEip712Transaction.md
+++ b/site/react/api/hooks/useSendEip712Transaction.md
@@ -1,0 +1,95 @@
+---
+title: useSendTransaction
+description: Hook for creating, signing, and sending transactions to networks.
+---
+
+<script setup>
+const packageName = 'wagmi'
+const actionName = 'sendEip712Transaction'
+const typeName = 'SendEip712Transaction'
+const mutate = 'sendEip712Transaction'
+const TData = 'SendEip712TransactionData'
+const TError = 'SendEip712TransactionErrorType'
+const TVariables = 'SendEip712TransactionVariables'
+</script>
+
+# useSendEip712Transaction
+
+Hook for creating, signing, and sending transactions to ZKsync networks.
+
+## Import
+
+```ts
+import { useSendEip712Transaction } from 'wagmi'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useSendEip712Transaction } from 'wagmi'
+import { parseEther } from 'viem'
+
+function App() {
+  const { sendEip712Transaction } = useSendEip712Transaction()
+
+  return (
+    <button
+      onClick={() =>
+        sendEip712Transaction({
+          to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+          value: parseEther('0.01'),
+          paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+          paymasterInput: '0x8c5a...'  
+        })
+      }
+    >
+      Send transaction
+    </button>
+  )
+}
+```
+<<< @/snippets/react/config-zksync.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type UseSendEip712TransactionParameters } from 'wagmi'
+```
+
+### config
+
+`Config | undefined`
+
+[`Config`](/react/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/react/api/WagmiProvider).
+
+::: code-group
+```tsx [index.tsx]
+import { useSendEip712Transaction } from 'wagmi'
+import { config } from './config' // [!code focus]
+
+function App() {
+  const result = useSendEip712Transaction({
+    config, // [!code focus]
+  })
+}
+```
+<<< @/snippets/react/config-zksync.ts[config.ts]
+:::
+
+<!--@include: @shared/mutation-options.md-->
+
+## Return Type
+
+```ts
+import { type UseSendEip712TransactionReturnType } from 'wagmi'
+```
+
+<!--@include: @shared/mutation-result.md-->
+
+<!--@include: @shared/mutation-imports.md-->
+
+## Action
+
+- [`sendEip712Transaction`](/core/api/actions/sendEip712Transaction)

--- a/site/snippets/core/config-zksync.ts
+++ b/site/snippets/core/config-zksync.ts
@@ -1,0 +1,10 @@
+import { http, createConfig } from '@wagmi/core'
+import { zksync, zksyncSepoliaTestnet } from '@wagmi/core/chains'
+
+export const config = createConfig({
+  chains: [zksync, zksyncSepoliaTestnet],
+  transports: {
+    [zksync.id]: http(),
+    [zksyncSepoliaTestnet.id]: http(),
+  },
+})

--- a/site/snippets/react/config-zksync.ts
+++ b/site/snippets/react/config-zksync.ts
@@ -1,0 +1,10 @@
+import { http, createConfig } from 'wagmi'
+import { zksync, zksyncSepoliaTestnet } from 'wagmi/chains'
+
+export const config = createConfig({
+  chains: [zksync, zksyncSepoliaTestnet],
+  transports: {
+    [zksync.id]: http(),
+    [zksyncSepoliaTestnet.id]: http(),
+  },
+})

--- a/site/snippets/vue/config-zksync.ts
+++ b/site/snippets/vue/config-zksync.ts
@@ -1,0 +1,10 @@
+import { http, createConfig } from '@wagmi/vue'
+import { zksync, zksyncSepoliaTestnet } from '@wagmi/vue/chains'
+
+export const config = createConfig({
+  chains: [zksync, zksyncSepoliaTestnet],
+  transports: {
+    [zksync.id]: http(),
+    [zksyncSepoliaTestnet.id]: http(),
+  },
+})

--- a/site/vue/api/composables/useSendEip712Transaction.md
+++ b/site/vue/api/composables/useSendEip712Transaction.md
@@ -1,0 +1,105 @@
+---
+title: useSendTransaction
+description: Composable for creating, signing, and sending transactions to networks.
+---
+
+<script setup>
+const packageName = '@wagmi/vue'
+const actionName = 'sendEip712Transaction'
+const typeName = 'SendEip712Transaction'
+const mutate = 'sendEip712Transaction'
+const TData = 'SendEip712TransactionData'
+const TError = 'SendEip712TransactionErrorType'
+const TVariables = 'SendEip712TransactionVariables'
+</script>
+
+# useSendEip712Transaction
+
+Composable for creating, signing, and sending transactions to ZKsync networks.
+
+## Import
+
+```ts
+import { useSendEip712Transaction } from '@wagmi/vue'
+```
+
+## Usage
+
+::: code-group
+```vue [index.vue]
+<script setup lang="ts">
+import { useSendEip712Transaction } from '@wagmi/vue'
+import { parseEther } from 'viem'
+
+const { sendEip712Transaction } = useSendEip712Transaction()
+</script>
+
+<template>
+  <button
+    @click="sendEip712Transaction({
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      value: parseEther('0.01'),
+      paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021',
+      paymasterInput: '0x8c5a...',
+    })"
+  >
+    Send transaction
+  </button>
+</template>
+```
+<<< @/snippets/vue/config-zksync.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { type UseSendEip712TransactionParameters } from '@wagmi/vue'
+```
+
+### config
+
+`Config | undefined`
+
+[`Config`](/vue/api/createConfig#config) to use instead of retrieving from the [`WagmiPlugin`](/vue/api/WagmiPlugin).
+
+::: code-group
+```vue [index.vue]
+<script setup lang="ts">
+import { useSendEip712Transaction } from '@wagmi/vue'
+import { config } from './config' // [!code focus]
+
+const result = useSendEip712Transaction({
+  config, // [!code focus]
+})
+</script>
+```
+
+```ts [config.ts]
+import { http, createConfig } from '@wagmi/core'
+import { zksync, zkSyncSepoliaTestnet } from '@wagmi/core/chains'
+
+export const config = createConfig({
+  chains: [zksync, zkSyncSepoliaTestnet],
+  transports: {
+    [zksync.id]: http(),
+    [zkSyncSepoliaTestnet.id]: http(),
+  },
+})
+```
+:::
+
+<!--@include: @shared/mutation-options.md-->
+
+## Return Type
+
+```ts
+import { type UseSendEip712TransactionReturnType } from '@wagmi/vue'
+```
+
+<!--@include: @shared/mutation-result.md-->
+
+<!--@include: @shared/mutation-imports.md-->
+
+## Action
+
+- [`sendEip712Transaction`](/core/api/actions/sendEip712Transaction)


### PR DESCRIPTION
To enable the use of ZKsync account abstraction and paymaster, support for EIP-712 transactions is provided. This PR introduces the following:

- **core**: The `sendEip712Transaction` action, which utilizes the [sendTransaction](https://github.com/wevm/viem/blob/main/src/zksync/actions/sendTransaction.ts) action from the viem ZKsync extension.
- **react**: The `useSendEip712Transaction` hook, which leverages the `sendEip712Transaction` action.
- **vue**: The `useSendEip712Transaction` composable, which also utilizes the `sendEip712Transaction` action.