### PR TITLE
fix: phantom wallet trying to make itself look like MetaMask

### DIFF
--- a/.changeset/short-icons-leave.md
+++ b/.changeset/short-icons-leave.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fixed phantom wallet trying to make itself look like MetaMask

--- a/.changeset/short-icons-leave.md
+++ b/.changeset/short-icons-leave.md
@@ -2,4 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Fixed phantom wallet trying to make itself look like MetaMask
+Added Phantom flag to Injected Connector.

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -568,6 +568,7 @@ const targetMap = {
           'isOneInchIOSWallet',
           'isOneInchAndroidWallet',
           'isOpera',
+          'isPhantom',
           'isPortal',
           'isRabby',
           'isTokenPocket',


### PR DESCRIPTION
“Phantom” try to fake MetaMask wallet extension with the `isMetaMask` boolean.

But it is not yet in the "fake" MetaMask list here: https://github.com/wevm/wagmi/blob/651aa72827a79f38a89f5a64209592816c8e6492/packages/core/src/connectors/injected.ts#L571
