### PR TITLE
Add retry functionality to etherscan plugin

### DIFF
--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -3,7 +3,7 @@ import type { Abi } from 'abitype'
 import { Address as AddressSchema } from 'abitype/zod'
 import { camelCase } from 'change-case'
 import { join } from 'pathe'
-import { withRetry, type Address } from 'viem'
+import { type Address, withRetry } from 'viem'
 import { z } from 'zod'
 
 import type { ContractConfig } from '../config.js'
@@ -107,19 +107,22 @@ export function etherscan<chainId extends ChainId>(
       }
 
       let abi: Abi | undefined
-      const implementationAddress = await withRetry(async () => {
-        if (!tryFetchProxyImplementation) return
-        const json = await globalThis
-          .fetch(buildUrl({ ...options, action: 'getsourcecode' }))
-          .then((res) => res.json())
-        const parsed = await GetSourceCodeResponse.safeParseAsync(json)
-        if (!parsed.success)
-          throw fromZodError(parsed.error, { prefix: 'Invalid response' })
-        if (parsed.data.status === '0') throw new Error(parsed.data.result)
-        if (!parsed.data.result[0]) return
-        abi = parsed.data.result[0].ABI
-        return parsed.data.result[0].Implementation as Address
-      }, { delay: 1000, retryCount: 2 })
+      const implementationAddress = await withRetry(
+        async () => {
+          if (!tryFetchProxyImplementation) return
+          const json = await globalThis
+            .fetch(buildUrl({ ...options, action: 'getsourcecode' }))
+            .then((res) => res.json())
+          const parsed = await GetSourceCodeResponse.safeParseAsync(json)
+          if (!parsed.success)
+            throw fromZodError(parsed.error, { prefix: 'Invalid response' })
+          if (parsed.data.status === '0') throw new Error(parsed.data.result)
+          if (!parsed.data.result[0]) return
+          abi = parsed.data.result[0].ABI
+          return parsed.data.result[0].Implementation as Address
+        },
+        { delay: 1000, retryCount: 2 },
+      )
 
       if (abi) {
         const cacheDir = getCacheDir()


### PR DESCRIPTION
This PR fixes Etherscan API rate limiting issues for free tier tokens

Problem:
- Etherscan API calls were failing due to rate limits being exceeded with free tier API tokens
- This caused wagmi CLI invocation fail when trying to generate ABI for more than 5 contracts.

Solution:
- Used `withRetry` function exported by `viem` for requests made to etherscan.