### PR TITLE
fix: fix chainId type in Sourcify API integration

### DIFF
--- a/scripts/updateBlockExplorerPluginChains.ts
+++ b/scripts/updateBlockExplorerPluginChains.ts
@@ -32,7 +32,7 @@ let count = 0
     res.json(),
   )) as {
     name: string
-    chainId: string
+    chainId: number
   }[]
 
   let content = 'type ChainId =\n'


### PR DESCRIPTION
Noticed that `chainId` was defined as a `string`, while Sourcify API expects a `number`.
This could cause issues downstream.
Updated `chainId` to be a `number` to align with the expected format.