### PR TITLE
docs: update dead link `walletConnect.md`

### DIFF
--- a/site/shared/connectors/walletConnect.md
+++ b/site/shared/connectors/walletConnect.md
@@ -138,7 +138,7 @@ const connector = walletConnect({
 
 `string`
 
-WalletConnect Cloud project identifier. You can find your `projectId` on your [WalletConnect dashboard](https://cloud.walletconnect.com/sign-in).
+WalletConnect Cloud project identifier. You can find your `projectId` on your [WalletConnect dashboard](https://cloud.reown.com/sign-in).
 
 ```ts-vue
 import { walletConnect } from '{{connectorsPackageName}}'


### PR DESCRIPTION
Hi! I noticed a dead link in walletConnect.md pointing to the old WalletConnect dashboard URL.