### PR TITLE
docs: fixed broken links

### DIFF
--- a/site/core/guides/chain-properties.md
+++ b/site/core/guides/chain-properties.md
@@ -1,6 +1,6 @@
 # Chain Properties
 
-Some chains support additional properties related to blocks and transactions. This is powered by Viem's [formatters](https://viem.sh/docs/clients/chains.html#formatters) and [serializers](https://viem.sh/docs/clients/chains.html#serializers). For example, Celo, ZkSync, OP Stack chains support all additional properties. In order to use these properties in a type-safe way, there are a few things you should be aware of.
+Some chains support additional properties related to blocks and transactions. This is powered by Viem's [formatters](https://viem.sh/docs/chains/formatters) and [serializers](https://viem.sh/docs/chains/serializers). For example, Celo, ZkSync, OP Stack chains support all additional properties. In order to use these properties in a type-safe way, there are a few things you should be aware of.
 
 ## Narrowing Parameters
 

--- a/site/react/guides/chain-properties.md
+++ b/site/react/guides/chain-properties.md
@@ -1,6 +1,6 @@
 # Chain Properties
 
-Some chains support additional properties related to blocks and transactions. This is powered by Viem's [formatters](https://viem.sh/docs/clients/chains.html#formatters) and [serializers](https://viem.sh/docs/clients/chains.html#serializers). For example, Celo, ZkSync, OP Stack chains all support additional properties. In order to use these properties in a type-safe way, there are a few things you should be aware of.
+Some chains support additional properties related to blocks and transactions. This is powered by Viem's [formatters](https://viem.sh/docs/chains/formatters) and [serializers](https://viem.sh/docs/chains/serializers). For example, Celo, ZkSync, OP Stack chains all support additional properties. In order to use these properties in a type-safe way, there are a few things you should be aware of.
 
 <br/>
 

--- a/site/vue/guides/chain-properties.md
+++ b/site/vue/guides/chain-properties.md
@@ -1,6 +1,6 @@
 # Chain Properties
 
-Some chains support additional properties related to blocks and transactions. This is powered by Viem's [formatters](https://viem.sh/docs/clients/chains.html#formatters) and [serializers](https://viem.sh/docs/clients/chains.html#serializers). For example, Celo, ZkSync, OP Stack chains support all support additional properties. In order to use these properties in a type-safe way, there are a few things you should be aware of.
+Some chains support additional properties related to blocks and transactions. This is powered by Viem's [formatters](https://viem.sh/docs/chains/formatters) and [serializers](https://viem.sh/docs/chains/serializers). For example, Celo, ZkSync, OP Stack chains support all support additional properties. In order to use these properties in a type-safe way, there are a few things you should be aware of.
 
 <br/>
 


### PR DESCRIPTION
Hi there! I fixed broken links in the documentation, specifically in the `chain-properties.md` files for the `core`, `react`, and `vue` sections. The old links to Viem's documentation (formatters and serializers) were pointing to non-existent pages, so I updated them to the correct ones: