### PR TITLE
 Fix Broken Viem Documentation Links 

### DIFF
--- a/site/core/api/actions/readContracts.md
+++ b/site/core/api/actions/readContracts.md
@@ -359,5 +359,5 @@ import { type ReadContractsErrorType } from '@wagmi/core'
 
 ## Viem
 
-- [`multicall`](https://viem.sh/docs/actions/public/multicall.html) when supported by current chain.
+- [`multicall`](https://viem.sh/docs/contract/multicall.html) when supported by current chain.
 - [`readContract`](https://viem.sh/docs/contract/readContract.html) when multicall is not supported.


### PR DESCRIPTION
1. site/core/api/actions/readContracts.md
Fixed the multicall documentation link

Old URL: https://viem.sh/docs/actions/public/multicall.html
New URL: https://viem.sh/docs/contract/multicall.html
Reason: The old link was outdated and pointed to a non-existent page. The updated URL correctly directs users to the current documentation for multicall.
