### PR TITLE
Fix typo in description

### DIFF
--- a/site/react/api/hooks/useReadContract.md
+++ b/site/react/api/hooks/useReadContract.md
@@ -304,7 +304,7 @@ function App() {
 import { type UseReadContractReturnType } from 'wagmi'
 ```
 
-The return type's [`data`](#data) property is inferrable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/react/typescript#const-assert-abis-typed-data) for more info.
+The return type's [`data`](#data) property is inferable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/react/typescript#const-assert-abis-typed-data) for more info.
 
 <!--@include: @shared/query-result.md-->
 

--- a/site/react/api/hooks/useSimulateContract.md
+++ b/site/react/api/hooks/useSimulateContract.md
@@ -671,7 +671,7 @@ function App() {
 import { type UseSimulateContractReturnType } from 'wagmi'
 ```
 
-The return type's [`data`](#data) property is inferrable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/react/typescript#const-assert-abis-typed-data) for more info.
+The return type's [`data`](#data) property is inferable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/react/typescript#const-assert-abis-typed-data) for more info.
 
 <!--@include: @shared/query-result.md-->
 

--- a/site/react/api/hooks/useWriteContract.md
+++ b/site/react/api/hooks/useWriteContract.md
@@ -101,7 +101,7 @@ function App() {
 import { type UseWriteContractReturnType } from 'wagmi'
 ```
 
-The return type's [`data`](#data) property is inferrable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/react/typescript#const-assert-abis-typed-data) for more info.
+The return type's [`data`](#data) property is inferable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/react/typescript#const-assert-abis-typed-data) for more info.
 
 <!--@include: @shared/mutation-result.md-->
 


### PR DESCRIPTION
This PR fixes a typo in the documentation where "inferable" was incorrectly spelled as "inferrable" with two r's. The correct spelling is "inferable" with one r. The fix has been applied to both useReadContract.md and useSimulateContract.md files.