### PR TITLE
Use Sourcify v2 API in sourcify plugin

### DIFF
--- a/.changeset/loose-mirrors-yawn.md
+++ b/.changeset/loose-mirrors-yawn.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": minor
 ---
 
-Use Sourcify v2 API in `sourcify` plugin
+Upgraded to Sourcify v2 API in `sourcify` plugin

--- a/.changeset/loose-mirrors-yawn.md
+++ b/.changeset/loose-mirrors-yawn.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": minor
+---
+
+Use Sourcify v2 API in `sourcify` plugin

--- a/packages/cli/src/plugins/sourcify.ts
+++ b/packages/cli/src/plugins/sourcify.ts
@@ -29,20 +29,7 @@ export type SourcifyConfig<chainId extends number> = {
 }
 
 const SourcifyResponse = z.object({
-  metadata: z.object({
-    compiler: z.object({
-      version: z.string(),
-    }),
-    language: z.string(),
-    output: z.object({
-      abi: AbiSchema,
-      devdoc: z.any(),
-      userdoc: z.any(),
-    }),
-    settings: z.any(),
-    sources: z.any(),
-    version: z.number(),
-  })
+  abi: AbiSchema,
 })
 
 /** Fetches contract ABIs from Sourcify. */
@@ -69,8 +56,8 @@ export function sourcify<chainId extends ChainId>(
       if (!parsed.success)
         throw fromZodError(parsed.error, { prefix: 'Invalid response' })
 
-      if (parsed.data.metadata.output.abi)
-        return parsed.data.metadata.output.abi as ContractConfig['abi']
+      if (parsed.data.abi)
+        return parsed.data.abi as ContractConfig['abi']
       throw new Error('contract not found')
     },
     request({ address }) {
@@ -86,7 +73,7 @@ export function sourcify<chainId extends ChainId>(
         )
 
       return {
-        url: `https://sourcify.dev/server/v2/contract/${chainId}/${contractAddress}/?fields=metadata`,
+        url: `https://sourcify.dev/server/v2/contract/${chainId}/${contractAddress}/?fields=abi`,
       }
     },
   })

--- a/packages/cli/src/plugins/sourcify.ts
+++ b/packages/cli/src/plugins/sourcify.ts
@@ -29,18 +29,20 @@ export type SourcifyConfig<chainId extends number> = {
 }
 
 const SourcifyResponse = z.object({
-  compiler: z.object({
-    version: z.string(),
-  }),
-  language: z.string(),
-  output: z.object({
-    abi: AbiSchema,
-    devdoc: z.any(),
-    userdoc: z.any(),
-  }),
-  settings: z.any(),
-  sources: z.any(),
-  version: z.number(),
+  metadata: z.object({
+    compiler: z.object({
+      version: z.string(),
+    }),
+    language: z.string(),
+    output: z.object({
+      abi: AbiSchema,
+      devdoc: z.any(),
+      userdoc: z.any(),
+    }),
+    settings: z.any(),
+    sources: z.any(),
+    version: z.number(),
+  })
 })
 
 /** Fetches contract ABIs from Sourcify. */
@@ -67,8 +69,8 @@ export function sourcify<chainId extends ChainId>(
       if (!parsed.success)
         throw fromZodError(parsed.error, { prefix: 'Invalid response' })
 
-      if (parsed.data.output.abi)
-        return parsed.data.output.abi as ContractConfig['abi']
+      if (parsed.data.metadata.output.abi)
+        return parsed.data.metadata.output.abi as ContractConfig['abi']
       throw new Error('contract not found')
     },
     request({ address }) {
@@ -84,7 +86,7 @@ export function sourcify<chainId extends ChainId>(
         )
 
       return {
-        url: `https://repo.sourcify.dev/contracts/full_match/${chainId}/${contractAddress}/metadata.json`,
+        url: `https://sourcify.dev/server/v2/contract/${chainId}/${contractAddress}/?fields=metadata`,
       }
     },
   })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR upgrades the Sourcify plugin API endpoint from the deprecated V1 to the V2 endpoint.

FYI, it should also solve an issue where it was not possible to fetch partial-matched contracts. I hope this doesn’t break anything, but the V2 API does not seem to make the distinction anymore.

See here: <https://docs.sourcify.dev/docs/api/>

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
