### PR TITLE
fix(vue): update error documentation paths from placeholders to actual pages

### DIFF
--- a/packages/vue/src/composables/useConfig.test.ts
+++ b/packages/vue/src/composables/useConfig.test.ts
@@ -17,7 +17,7 @@ test('behavior: throws when not provided via WagmiPlugin', () => {
     expect(error).toMatchInlineSnapshot(`
       [WagmiPluginNotFoundError: No \`config\` found in Vue context, use \`WagmiPlugin\` to properly initialize the library.
 
-      Docs: https://wagmi.sh/vue/api/TODO.html
+      Docs: https://wagmi.sh/vue/api/WagmiPlugin.html
       Version: @wagmi/vue@x.y.z]
     `)
   }

--- a/packages/vue/src/errors/plugin.test.ts
+++ b/packages/vue/src/errors/plugin.test.ts
@@ -9,7 +9,7 @@ test('WagmiPluginNotFoundError', () => {
   expect(new WagmiPluginNotFoundError()).toMatchInlineSnapshot(`
     [WagmiPluginNotFoundError: No \`config\` found in Vue context, use \`WagmiPlugin\` to properly initialize the library.
 
-    Docs: https://wagmi.sh/vue/api/TODO.html
+    Docs: https://wagmi.sh/vue/api/WagmiPlugin.html
     Version: @wagmi/vue@x.y.z]
   `)
 })
@@ -18,7 +18,7 @@ test('WagmiInjectionContextError', () => {
   expect(new WagmiInjectionContextError()).toMatchInlineSnapshot(`
     [WagmiInjectionContextError: Wagmi composables can only be used inside \`setup()\` function or functions that support injection context.
 
-    Docs: https://wagmi.sh/vue/api/TODO.html
+    Docs: https://wagmi.sh/vue/api/composables.html
     Version: @wagmi/vue@x.y.z]
   `)
 })

--- a/packages/vue/src/errors/plugin.ts
+++ b/packages/vue/src/errors/plugin.ts
@@ -9,7 +9,7 @@ export class WagmiPluginNotFoundError extends BaseError {
     super(
       'No `config` found in Vue context, use `WagmiPlugin` to properly initialize the library.',
       {
-        docsPath: '/api/TODO',
+        docsPath: '/api/WagmiPlugin',
       },
     )
   }
@@ -24,7 +24,7 @@ export class WagmiInjectionContextError extends BaseError {
     super(
       'Wagmi composables can only be used inside `setup()` function or functions that support injection context.',
       {
-        docsPath: '/api/TODO',
+        docsPath: '/api/composables',
       },
     )
   }


### PR DESCRIPTION

# Fix Vue error documentation paths

This PR fixes the invalid documentation paths in Vue error messages that were previously set to placeholder `/api/TODO` paths. The errors now correctly point users to the appropriate documentation pages when they encounter WagmiPluginNotFoundError or WagmiInjectionContextError. This improves the developer experience by guiding users to relevant documentation that can help them solve their issues when using the Vue integration. The fix involved updating the docsPath values in the error classes and updating the corresponding test snapshots to reflect these changes. All tests now pass with the correct documentation URLs.
