### PR TITLE
fix: compute proper chainId value on useReadConstracts to avoid unnecessary queryKey mutations

### DIFF
--- a/.changeset/sixty-mugs-serve.md
+++ b/.changeset/sixty-mugs-serve.md
@@ -1,0 +1,5 @@
+---
+"wagmi": minor
+---
+
+fix: compute proper chainId value on useReadConstracts to avoid unnecessary queryKey mutations

--- a/packages/react/src/hooks/useReadContracts.ts
+++ b/packages/react/src/hooks/useReadContracts.ts
@@ -5,7 +5,7 @@ import type {
   ReadContractsErrorType,
   ResolvedRegister,
 } from '@wagmi/core'
-import type { Compute } from '@wagmi/core/internal'
+import type { ChainIdParameter, Compute } from '@wagmi/core/internal'
 import {
   type ReadContractsData,
   type ReadContractsOptions,
@@ -62,10 +62,24 @@ export function useReadContracts<
 
   const config = useConfig(parameters)
   const chainId = useChainId({ config })
+  const contractsChainId: number | undefined = useMemo(() => {
+    if (contracts.length === 0) return undefined
+
+    // Get the chainId of the first contract (if any)
+    const firstChainId = (contracts[0] as ChainIdParameter<config>).chainId
+
+    // If all contracts have the same chainId as the first, return it
+    const allSameChainId = contracts.every(
+      (contract: ChainIdParameter<config>) =>
+        (contract as ChainIdParameter<config>).chainId === firstChainId,
+    )
+
+    return allSameChainId ? firstChainId : undefined
+  }, [contracts])
 
   const options = readContractsQueryOptions<config, contracts, allowFailure>(
     config,
-    { ...parameters, chainId },
+    { ...parameters, chainId: contractsChainId ?? chainId },
   )
 
   const enabled = useMemo(() => {


### PR DESCRIPTION
fix: compute proper chainId value on useReadConstracts to avoid unnecessary queryKey mutations

Derives a unified chainId from contracts when all share the same value, otherwise falls back to the default (chainId from useChainId).

This fixes 'queryKey' mutation when connecting or changing network despite all contracts sharing the same chainId, avoid unnecessary mutations and equating to the default behaviour on useReadContract.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
