### PR TITLE
chore(ci): bump changesets/action to v1.5.2

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,7 +34,7 @@ jobs:
         uses: wevm/actions/.github/actions/pnpm@main
 
       - name: PR or publish
-        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
+        uses: changesets/action@e0538e686673de0265c8a3e2904b8c76beaa43fd
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'


### PR DESCRIPTION
Switches to the latest stable commit e0538e686673de0265c8a3e2904b8c76beaa43fd (v1.5.2) for Node 20 compatibility and the sub-directory `git add` fix.  
Release notes: https://github.com/changesets/action/releases/tag/v1.5.2