### PR TITLE
fix: type error for wc/reown project id

### DIFF
--- a/packages/create-wagmi/templates/next/src/wagmi.ts
+++ b/packages/create-wagmi/templates/next/src/wagmi.ts
@@ -8,7 +8,7 @@ export function getConfig() {
     connectors: [
       injected(),
       coinbaseWallet(),
-      walletConnect({ projectId: process.env.NEXT_PUBLIC_WC_PROJECT_ID }),
+      walletConnect({ projectId: process.env.NEXT_PUBLIC_WC_PROJECT_ID! }),
     ],
     storage: createStorage({
       storage: cookieStorage,


### PR DESCRIPTION
fixes #4659,
ideally user should verify env variable is defined at runtime. this just allows TS compilation without error.

https://nextjs.org/docs/pages/guides/environment-variables