### PR TITLE
Update `writeContracts` and `sendCalls` return types and meaning

### DIFF
--- a/site/core/api/actions/sendCalls.md
+++ b/site/core/api/actions/sendCalls.md
@@ -206,7 +206,7 @@ const id = await sendCalls(config, {
 import { type SendCallsReturnType } from '@wagmi/core'
 ```
 
-`string`
+`{ id: string; capabilities?: WalletCapabilities | undefined }`
 
 Identifier of the call batch.
 

--- a/site/core/api/actions/writeContracts.md
+++ b/site/core/api/actions/writeContracts.md
@@ -300,7 +300,7 @@ const id = await writeContracts(config, {
 import { type WriteContractsReturnType } from '@wagmi/core/experimental'
 ```
 
-`string`
+`{ id: string; capabilities?: WalletCapabilities | undefined }`
 
 Identifier of the call batch.
 


### PR DESCRIPTION
Update `writeContracts` and `sendCalls` return types and meaning.

Current documentation seems to be a C&P from `useBlockNumber` with some not changed information.
