### PR TITLE
docs: Improve useReadContracts page with return type and Tanstack Query import details

### DIFF
--- a/site/react/api/hooks/useReadContracts.md
+++ b/site/react/api/hooks/useReadContracts.md
@@ -3,6 +3,14 @@ title: useReadContracts
 description: Hook for calling multiple read methods on a contract.
 ---
 
+<script setup>
+const packageName = 'wagmi'
+const actionName = 'readContracts'
+const typeName = 'ReadContracts'
+const TData = 'ReadContractsReturnType'
+const TError = 'ReadContractsErrorType'
+</script>
+
 # useReadContracts
 
 Hook for calling multiple read methods on a contract.
@@ -388,6 +396,8 @@ import { type UseReadContractsReturnType } from 'wagmi'
 ```
 
 <!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
 
 ## Action
 


### PR DESCRIPTION
This PR improves the `useReadContracts` documentation page by:

- Adding the missing script setup block
```md
<script setup>
const packageName = 'wagmi'
const actionName = 'readContracts'
const typeName = 'ReadContracts'
const TData = 'ReadContractsReturnType'
const TError = 'ReadContractsErrorType'
</script>
```

- Including shared query imports sections to match other hook docs
```md
<!--@include: @shared/query-imports.md-->
```