### PR TITLE
chore: update .connect to .mutate

### DIFF
--- a/packages/react/src/hooks/useAccountEffect.test.ts
+++ b/packages/react/src/hooks/useAccountEffect.test.ts
@@ -27,12 +27,12 @@ test('behavior: connect and disconnect called once', async () => {
     useDisconnect: useDisconnect(),
   }))
 
-  result.current.useConnect.connect({
+  result.current.useConnect.mutate({
     connector: result.current.useConnect.connectors[0]!,
   })
   await waitFor(() => expect(result.current.useConnect.isSuccess).toBeTruthy())
 
-  result.current.useConnect.connect({
+  result.current.useConnect.mutate({
     connector: result.current.useConnect.connectors[0]!,
   })
   await waitFor(() => expect(result.current.useConnect.isSuccess).toBeTruthy())

--- a/packages/react/src/hooks/useConnect.test.ts
+++ b/packages/react/src/hooks/useConnect.test.ts
@@ -22,7 +22,7 @@ test('default', async () => {
   expect(result.current.useAccount.address).not.toBeDefined()
   expect(result.current.useAccount.status).toEqual('disconnected')
 
-  result.current.useConnect.connect({
+  result.current.useConnect.mutate({
     connector: result.current.useConnect.connectors[0]!,
   })
 

--- a/packages/react/src/hooks/useConnect.ts
+++ b/packages/react/src/hooks/useConnect.ts
@@ -46,9 +46,13 @@ export type UseConnectReturnType<
     ConnectVariables<config, config['connectors'][number]>,
     context
   > & {
+    /** @deprecated use mutate */
     connect: ConnectMutate<config, context>
+    /** @deprecated use mutateAsync */
     connectAsync: ConnectMutateAsync<config, context>
     connectors: Compute<UseConnectorsReturnType> | config['connectors']
+    mutate: ConnectMutate<config, context>
+    mutateAsync: ConnectMutateAsync<config, context>
   }
 >
 

--- a/packages/react/src/hooks/useConnectorClient.test.tsx
+++ b/packages/react/src/hooks/useConnectorClient.test.tsx
@@ -108,7 +108,7 @@ test('behavior: connect and disconnect', async () => {
 
   expect(result.current.useConnectorClient.data).not.toBeDefined()
 
-  result.current.useConnect.connect({
+  result.current.useConnect.mutate({
     connector: result.current.useConnect.connectors[0]!,
   })
 

--- a/packages/react/src/hooks/useDisconnect.test.ts
+++ b/packages/react/src/hooks/useDisconnect.test.ts
@@ -21,7 +21,7 @@ test('default', async () => {
   expect(result.current.useAccount.address).toBeDefined()
   expect(result.current.useAccount.status).toEqual('connected')
 
-  result.current.useDisconnect.disconnect()
+  result.current.useDisconnect.mutate()
 
   await waitFor(() =>
     expect(result.current.useAccount.isDisconnected).toBeTruthy(),

--- a/packages/react/src/hooks/useDisconnect.ts
+++ b/packages/react/src/hooks/useDisconnect.ts
@@ -40,8 +40,12 @@ export type UseDisconnectReturnType<context = unknown> = Compute<
     context
   > & {
     connectors: readonly Connector[]
+    /** @deprecated use mutate */
     disconnect: DisconnectMutate<context>
+    /** @deprecated use mutateAsync */
     disconnectAsync: DisconnectMutateAsync<context>
+    mutate: DisconnectMutate<context>
+    mutateAsync: DisconnectMutateAsync<context>
   }
 >
 
@@ -66,5 +70,7 @@ export function useDisconnect<context = unknown>(
     ),
     disconnect: mutate,
     disconnectAsync: mutateAsync,
+    mutate,
+    mutateAsync,
   }
 }

--- a/packages/react/src/hooks/useWalletClient.test.tsx
+++ b/packages/react/src/hooks/useWalletClient.test.tsx
@@ -111,7 +111,7 @@ test('behavior: connect and disconnect', async () => {
 
   expect(result.current.useWalletClient.data).not.toBeDefined()
 
-  result.current.useConnect.connect({
+  result.current.useConnect.mutate({
     connector: result.current.useConnect.connectors[0]!,
   })
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

`useConnect()`:
- deprecate `.connect` and `.connectAsync`,
- add `.mutate` and `.mutateAsync`,
- updates tests to use `mutate`

`useDisconnect()`:
- deprecate `.disconnect` and `.disconnectAsync`,
- add `.mutate` and `.mutateAsync`,
- updates tests to use `mutate`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
