### PR TITLE
feat: Soften duplicate contract name in the case contracts have identical ABIs

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -6,7 +6,7 @@ import { watch } from 'chokidar'
 import { default as dedent } from 'dedent'
 import { basename, dirname, resolve } from 'pathe'
 import pc from 'picocolors'
-import { type Abi, type Address, getAddress } from 'viem'
+import {type Abi, type Address, getAddress, keccak256} from 'viem'
 import { z } from 'zod'
 
 import type { Contract, ContractConfig, Plugin, Watch } from '../config.js'
@@ -98,10 +98,17 @@ export async function generate(options: Generate = {}) {
     const contractNames = new Set<string>()
     const contractMap = new Map<string, Contract>()
     for (const contractConfig of contractConfigs) {
-      if (contractNames.has(contractConfig.name))
+      const previouslySeenContract = contractMap.get(contractConfig.name)
+      if (previouslySeenContract) {
+        if (hashAbi(previouslySeenContract.abi) === hashAbi(contractConfig.abi)) {
+            // If the contract name and ABI match, skip adding it again, but allow it since this can occur when generating
+            // from sources that mutually import each other, such as peer Foundry projects.
+            continue
+        }
         throw new Error(
-          `Contract name "${contractConfig.name}" must be unique.`,
+            `Duplicate contract name "${contractConfig.name}" found with different ABI. Contract names must be unique up to ABI.`
         )
+      }
       const contract = await getContract({ ...contractConfig, isTypeScript })
       contractMap.set(contract.name, contract)
 
@@ -406,4 +413,10 @@ function getBannerContent({ name }: { name: string }) {
   // ${name}
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   `
+}
+
+function hashAbi(abi: Abi): string {
+  // Could use something faster, e.g. non-cryptographic hash or CRC32, but only called in the case
+  // we hit duplicate contract names, so probably not worth it.
+  return keccak256(Buffer.from(JSON.stringify(abi)))
 }


### PR DESCRIPTION
This is useful for instance when contracts appear as duplicates when ingesting from a single Foundry project that depends on others foundry projects.

In this case `getArtifactPaths()` in the Foundry plugin pick up the same contracts twice since they end up existing in both `out/` directories. I don't think there is a reliable to heuristic to de-duplicate them at this level.

It seems like duck-typing contracts by the ABI should be fine, it could always be enabled via an option.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
