### PR TITLE
fix: add missing `from` address to the `sendCalls` handler in mock connector

### DIFF
--- a/.changeset/modern-ghosts-exercise.md
+++ b/.changeset/modern-ghosts-exercise.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Added missing `from` address to the `wallet_sendCalls` handler in the `mock` connector

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -208,11 +208,17 @@ export function mock(parameters: MockParameters) {
         if (method === 'wallet_sendCalls') {
           const hashes = []
           const calls = (params as any)[0].calls
+          const from = (params as any)[0].from
           for (const call of calls) {
             const { result, error } = await rpc.http(url, {
               body: {
                 method: 'eth_sendTransaction',
-                params: [call],
+                params: [
+                  {
+                    ...call,
+                    ...(typeof from !== 'undefined' ? { from } : {}),
+                  },
+                ],
               },
             })
             if (error)


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

### What does this PR do?
The mock connector's `wallet_sendCalls` handler reads the `calls` array received from the Viem `sendCalls` [action function](<https://github.com/wevm/viem/blob/main/src/actions/wallet/sendCalls.ts#L136>), but that function doesn't attach the `from` address inside the calls array, and instead sends it as a separate argument [here](<https://github.com/wevm/viem/blob/main/src/actions/wallet/sendCalls.ts#L139>). This causes all transactions sent from this handler in the mock connector to have the zero address as the `from` address.

This PR reads the `from` argument from the parameters and, if it exists, attaches it to the params sent to the `eth_sendTransaction` RPC request.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
