### PR TITLE
chore: replaced link to downloads badge

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -29,7 +29,7 @@
       <img src="https://img.shields.io/npm/l/wagmi?colorA=f6f8fa&colorB=f6f8fa" alt="MIT License">
     </picture>
   </a>
-  <a href="https://www.npmjs.com/package/wagmi">
+  <a href="https://bundlephobia.com/package/wagmi@2.15.6">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/npm/dm/@wagmi/core?colorA=21262d&colorB=21262d">
       <img src="https://img.shields.io/npm/dm/@wagmi/core?colorA=f6f8fa&colorB=f6f8fa" alt="Downloads per month">


### PR DESCRIPTION
Decided to replace the link because npm is repeated twice

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
