### PR TITLE
fix(docs): update broken multicall link to current Viem documentation

### DIFF
--- a/site/core/api/actions/readContracts.md
+++ b/site/core/api/actions/readContracts.md
@@ -359,5 +359,5 @@ import { type ReadContractsErrorType } from '@wagmi/core'
 
 ## Viem
 
-- [`multicall`](https://viem.sh/docs/actions/public/multicall.html) when supported by current chain.
+- [`multicall`](https://viem.sh/docs/contract/multicall.html) when supported by current chain.
 - [`readContract`](https://viem.sh/docs/contract/readContract.html) when multicall is not supported.


### PR DESCRIPTION
Replaced the outdated link to the Viem multicall documentation with the correct and current URL (https://viem.sh/docs/contract/multicall.html) in the readContracts API docs. This ensures users are directed to the right resource for multicall usage details.