### PR TITLE
fix(core): update chainId retrieval logic to consider syncConnectedChain configuration

### DIFF
--- a/packages/core/src/actions/codegen/createReadContract.ts
+++ b/packages/core/src/actions/codegen/createReadContract.ts
@@ -79,8 +79,9 @@ export function createReadContract<
       const account = getAccount(config)
       const chainId =
         (parameters as { chainId?: number })?.chainId ??
-        account.chainId ??
-        configChainId
+        (config._internal.syncConnectedChain
+          ? (account.chainId ?? configChainId)
+          : configChainId)
       return readContract(config, {
         ...(parameters as any),
         ...(c.functionName ? { functionName: c.functionName } : {}),

--- a/packages/core/src/actions/codegen/createSimulateContract.ts
+++ b/packages/core/src/actions/codegen/createSimulateContract.ts
@@ -101,8 +101,9 @@ export function createSimulateContract<
       const account = getAccount(config)
       const chainId =
         (parameters as { chainId?: number })?.chainId ??
-        account.chainId ??
-        configChainId
+        (config._internal.syncConnectedChain
+          ? (account.chainId ?? configChainId)
+          : configChainId)
       return simulateContract(config, {
         ...(parameters as any),
         ...(c.functionName ? { functionName: c.functionName } : {}),

--- a/packages/core/src/actions/codegen/createWatchContractEvent.ts
+++ b/packages/core/src/actions/codegen/createWatchContractEvent.ts
@@ -67,8 +67,9 @@ export function createWatchContractEvent<
       const account = getAccount(config)
       const chainId =
         (parameters as { chainId?: number })?.chainId ??
-        account.chainId ??
-        configChainId
+        (config._internal.syncConnectedChain
+          ? (account.chainId ?? configChainId)
+          : configChainId)
       return watchContractEvent(config, {
         ...(parameters as any),
         ...(c.eventName ? { eventName: c.eventName } : {}),

--- a/packages/react/src/hooks/codegen/createUseReadContract.ts
+++ b/packages/react/src/hooks/codegen/createUseReadContract.ts
@@ -106,8 +106,9 @@ export function createUseReadContract<
       const account = useAccount({ config })
       const chainId =
         (parameters as { chainId?: number })?.chainId ??
-        account.chainId ??
-        configChainId
+        (config._internal.syncConnectedChain
+          ? (account.chainId ?? configChainId)
+          : configChainId)
       return useReadContract({
         ...(parameters as any),
         ...(props.functionName ? { functionName: props.functionName } : {}),

--- a/packages/react/src/hooks/codegen/createUseSimulateContract.ts
+++ b/packages/react/src/hooks/codegen/createUseSimulateContract.ts
@@ -99,8 +99,9 @@ export function createUseSimulateContract<
       const account = useAccount({ config })
       const chainId =
         (parameters as { chainId?: number })?.chainId ??
-        account.chainId ??
-        configChainId
+        (config._internal.syncConnectedChain
+          ? (account.chainId ?? configChainId)
+          : configChainId)
       return useSimulateContract({
         ...(parameters as any),
         ...(props.functionName ? { functionName: props.functionName } : {}),

--- a/packages/react/src/hooks/codegen/createUseWatchContractEvent.ts
+++ b/packages/react/src/hooks/codegen/createUseWatchContractEvent.ts
@@ -80,8 +80,9 @@ export function createUseWatchContractEvent<
       const account = useAccount({ config })
       const chainId =
         (parameters as { chainId?: number })?.chainId ??
-        account.chainId ??
-        configChainId
+        (config._internal.syncConnectedChain
+          ? (account.chainId ?? configChainId)
+          : configChainId)
       return useWatchContractEvent({
         ...(parameters as any),
         ...(props.eventName ? { eventName: props.eventName } : {}),

--- a/packages/react/src/hooks/codegen/createUseWriteContract.ts
+++ b/packages/react/src/hooks/codegen/createUseWriteContract.ts
@@ -166,9 +166,17 @@ export function createUseWriteContract<
           (...args: Args) => {
             let chainId: number | undefined
             if (args[0].chainId) chainId = args[0].chainId
-            else if (args[0].account && args[0].account === account.address)
+            else if (
+              args[0].account &&
+              args[0].account === account.address &&
+              config._internal.syncConnectedChain
+            )
               chainId = account.chainId
-            else if (args[0].account === undefined) chainId = account.chainId
+            else if (
+              args[0].account === undefined &&
+              config._internal.syncConnectedChain
+            )
+              chainId = account.chainId
             else chainId = configChainId
 
             const variables = {
@@ -187,15 +195,24 @@ export function createUseWriteContract<
             props,
             configChainId,
             result.writeContract,
+            config._internal.syncConnectedChain,
           ],
         ),
         writeContractAsync: useCallback(
           (...args: Args) => {
             let chainId: number | undefined
             if (args[0].chainId) chainId = args[0].chainId
-            else if (args[0].account && args[0].account === account.address)
+            else if (
+              args[0].account &&
+              args[0].account === account.address &&
+              config._internal.syncConnectedChain
+            )
               chainId = account.chainId
-            else if (args[0].account === undefined) chainId = account.chainId
+            else if (
+              args[0].account === undefined &&
+              config._internal.syncConnectedChain
+            )
+              chainId = account.chainId
             else chainId = configChainId
 
             const variables = {
@@ -214,6 +231,7 @@ export function createUseWriteContract<
             props,
             configChainId,
             result.writeContractAsync,
+            config._internal.syncConnectedChain,
           ],
         ),
       }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
## Problem
Fixes #4680 
Generated hooks from wagmi-cli were ignoring the syncConnectedChain configuration setting and always prioritizing the connected account's chainId over the config's default chainId. This meant that setting syncConnectedChain: false had no effect on generated hooks, requiring users to explicitly provide a chainId parameter to every hook call when they wanted hooks to work regardless of the connected network.

## Solution
Updated the chainId resolution logic to respect the syncConnectedChain configuration:

### Behavior after fix:
```
When syncConnectedChain: true (default): Uses account.chainId if available, falls back to configChainId
When syncConnectedChain: false: Uses configChainId directly, ignoring connected account's chain
```
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
