### PR TITLE
Fix Viem Multicall Documentation Links

### DIFF
--- a/site/core/api/actions/getBalance.md
+++ b/site/core/api/actions/getBalance.md
@@ -194,4 +194,4 @@ import { type GetBalanceErrorType } from '@wagmi/core'
 ## Viem
 
 - [`getBalance`](https://viem.sh/docs/actions/public/getBalance.html) for native currency balances
-- [`multicall`](https://viem.sh/docs/actions/public/multicall.html) for token balances
+- [`multicall`](https://viem.sh/docs/contract/multicall.html) for token balances

--- a/site/core/api/actions/multicall.md
+++ b/site/core/api/actions/multicall.md
@@ -352,4 +352,4 @@ import { type MulticallErrorType } from '@wagmi/core'
 
 ## Viem
 
-- [`multicall`](https://viem.sh/docs/actions/public/multicall.html)
+- [`multicall`](https://viem.sh/docs/contract/multicall.html)


### PR DESCRIPTION


**Description:**  
- Updated broken Viem `multicall` links in the documentation to point to the correct contract reference.

