### PR TITLE
fix: prevent timeout memory leak in fetch plugin

### DIFF
--- a/.changeset/tricky-papayas-sparkle.md
+++ b/.changeset/tricky-papayas-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+`fetch` plugin: cleared timeout on fetch error

--- a/packages/cli/src/plugins/fetch.ts
+++ b/packages/cli/src/plugins/fetch.ts
@@ -105,6 +105,7 @@ export function fetch(config: FetchConfig): FetchResult {
               `${JSON.stringify({ abi, timestamp }, undefined, 2)}\n`,
             )
           } catch (error) {
+            clearTimeout(timeout) // Clean up timeout on error
             try {
               // Attempt to read from cache if fetch fails.
               abi = JSON.parse(await readFile(cacheFilePath, 'utf8')).abi

--- a/packages/cli/src/plugins/fetch.ts
+++ b/packages/cli/src/plugins/fetch.ts
@@ -85,13 +85,9 @@ export function fetch(config: FetchConfig): FetchResult {
         let abi: Abi | undefined
         if (cachedFile?.timestamp > Date.now()) abi = cachedFile.abi
         else {
+          const controller = new globalThis.AbortController()
+          const timeout = setTimeout(() => controller.abort(), timeoutDuration)
           try {
-            const controller = new globalThis.AbortController()
-            const timeout = setTimeout(
-              () => controller.abort(),
-              timeoutDuration,
-            )
-
             const { url, init } = await request(contract)
             const response = await globalThis.fetch(url, {
               ...init,
@@ -105,7 +101,7 @@ export function fetch(config: FetchConfig): FetchResult {
               `${JSON.stringify({ abi, timestamp }, undefined, 2)}\n`,
             )
           } catch (error) {
-            clearTimeout(timeout) // Clean up timeout on error
+            clearTimeout(timeout)
             try {
               // Attempt to read from cache if fetch fails.
               abi = JSON.parse(await readFile(cacheFilePath, 'utf8')).abi


### PR DESCRIPTION
Add clearTimeout in catch block to ensure the timeout is properly cleaned up when a fetch request fails, preventing potential memory leaks during error handling