### PR TITLE
Adding baseAccount Connector for Base Account

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -45,6 +45,7 @@
     }
   },
   "dependencies": {
+    "@base-org/account": "1.0.2",
     "@coinbase/wallet-sdk": "4.3.6",
     "@metamask/sdk": "0.32.0",
     "@safe-global/safe-apps-provider": "0.18.6",

--- a/packages/connectors/src/baseAccont.test.ts
+++ b/packages/connectors/src/baseAccont.test.ts
@@ -1,0 +1,10 @@
+import { config } from '@wagmi/test'
+import { expect, test } from 'vitest'
+
+import { baseAccount } from './baseAccount.js'
+
+test('setup', () => {
+  const connectorFn = baseAccount({ appName: 'wagmi' })
+  const connector = config._internal.connectors.setup(connectorFn)
+  expect(connector.name).toEqual('Base Account')
+})

--- a/packages/connectors/src/baseAccount.ts
+++ b/packages/connectors/src/baseAccount.ts
@@ -1,0 +1,240 @@
+import type { ProviderInterface, createBaseAccountSDK } from '@base-org/account'
+import {
+  ChainNotConfiguredError,
+  type Connector,
+  createConnector,
+} from '@wagmi/core'
+import type { Mutable, Omit } from '@wagmi/core/internal'
+import {
+  type AddEthereumChainParameter,
+  type Address,
+  type Hex,
+  type ProviderRpcError,
+  SwitchChainError,
+  UserRejectedRequestError,
+  getAddress,
+  numberToHex,
+} from 'viem'
+
+export type BaseAccountParameters = Mutable<
+  Omit<
+    Parameters<typeof createBaseAccountSDK>[0],
+    'appChainIds' // set via wagmi config
+  >
+>
+
+export function baseAccount(parameters: BaseAccountParameters) {
+  type Provider = ProviderInterface
+  type Properties = {
+    connect(parameters?: {
+      chainId?: number | undefined
+      isReconnecting?: boolean | undefined
+    }): Promise<{
+      accounts: readonly Address[]
+      chainId: number
+    }>
+  }
+
+  let walletProvider: Provider | undefined
+
+  let accountsChanged: Connector['onAccountsChanged'] | undefined
+  let chainChanged: Connector['onChainChanged'] | undefined
+  let disconnect: Connector['onDisconnect'] | undefined
+
+  return createConnector<Provider, Properties>((config) => ({
+    id: 'baseAccountSDK',
+    name: 'Base Account',
+    rdns: 'app.base.account',
+    type: 'baseAccount',
+    async connect({ chainId } = {}) {
+      try {
+        const provider = await this.getProvider()
+        const accounts = (
+          (await provider.request({
+            method: 'eth_requestAccounts',
+            params: [],
+          })) as string[]
+        ).map((x) => getAddress(x))
+
+        if (!accountsChanged) {
+          accountsChanged = this.onAccountsChanged.bind(this)
+          provider.on('accountsChanged', accountsChanged)
+        }
+        if (!chainChanged) {
+          chainChanged = this.onChainChanged.bind(this)
+          provider.on('chainChanged', chainChanged)
+        }
+        if (!disconnect) {
+          disconnect = this.onDisconnect.bind(this)
+          provider.on('disconnect', disconnect)
+        }
+
+        // Switch to chain if provided
+        let currentChainId = await this.getChainId()
+        if (chainId && currentChainId !== chainId) {
+          const chain = await this.switchChain!({ chainId }).catch((error) => {
+            if (error.code === UserRejectedRequestError.code) throw error
+            return { id: currentChainId }
+          })
+          currentChainId = chain?.id ?? currentChainId
+        }
+
+        return { accounts, chainId: currentChainId }
+      } catch (error) {
+        if (
+          /(user closed modal|accounts received is empty|user denied account|request rejected)/i.test(
+            (error as Error).message,
+          )
+        )
+          throw new UserRejectedRequestError(error as Error)
+        throw error
+      }
+    },
+    async disconnect() {
+      const provider = await this.getProvider()
+
+      if (accountsChanged) {
+        provider.removeListener('accountsChanged', accountsChanged)
+        accountsChanged = undefined
+      }
+      if (chainChanged) {
+        provider.removeListener('chainChanged', chainChanged)
+        chainChanged = undefined
+      }
+      if (disconnect) {
+        provider.removeListener('disconnect', disconnect)
+        disconnect = undefined
+      }
+
+      await provider.disconnect()
+    },
+    async getAccounts() {
+      const provider = await this.getProvider()
+      return (
+        (await provider.request({
+          method: 'eth_accounts',
+        })) as string[]
+      ).map((x) => getAddress(x))
+    },
+    async getChainId() {
+      const provider = await this.getProvider()
+      const chainId = (await provider.request({
+        method: 'eth_chainId',
+      })) as Hex
+      return Number(chainId)
+    },
+    async getProvider() {
+      if (!walletProvider) {
+        const preference = (() => {
+          if (typeof parameters.preference === 'string')
+            return { options: parameters.preference }
+          return {
+            ...parameters.preference,
+            options: parameters.preference?.options ?? 'all',
+          }
+        })()
+
+        const { createBaseAccountSDK } = await import('@base-org/account')
+        const sdk = createBaseAccountSDK({
+          ...parameters,
+          appChainIds: config.chains.map((x) => x.id),
+          preference,
+        })
+
+        walletProvider = sdk.getProvider()
+      }
+
+      return walletProvider
+    },
+    async isAuthorized() {
+      try {
+        const accounts = await this.getAccounts()
+        return !!accounts.length
+      } catch {
+        return false
+      }
+    },
+    async switchChain({ addEthereumChainParameter, chainId }) {
+      const chain = config.chains.find((chain) => chain.id === chainId)
+      if (!chain) throw new SwitchChainError(new ChainNotConfiguredError())
+
+      const provider = await this.getProvider()
+
+      try {
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: numberToHex(chain.id) }],
+        })
+        return chain
+      } catch (error) {
+        // Indicates chain is not added to provider
+        if ((error as ProviderRpcError).code === 4902) {
+          try {
+            let blockExplorerUrls: string[] | undefined
+            if (addEthereumChainParameter?.blockExplorerUrls)
+              blockExplorerUrls = addEthereumChainParameter.blockExplorerUrls
+            else
+              blockExplorerUrls = chain.blockExplorers?.default.url
+                ? [chain.blockExplorers?.default.url]
+                : []
+
+            let rpcUrls: readonly string[]
+            if (addEthereumChainParameter?.rpcUrls?.length)
+              rpcUrls = addEthereumChainParameter.rpcUrls
+            else rpcUrls = [chain.rpcUrls.default?.http[0] ?? '']
+
+            const addEthereumChain = {
+              blockExplorerUrls,
+              chainId: numberToHex(chainId),
+              chainName: addEthereumChainParameter?.chainName ?? chain.name,
+              iconUrls: addEthereumChainParameter?.iconUrls,
+              nativeCurrency:
+                addEthereumChainParameter?.nativeCurrency ??
+                chain.nativeCurrency,
+              rpcUrls,
+            } satisfies AddEthereumChainParameter
+
+            await provider.request({
+              method: 'wallet_addEthereumChain',
+              params: [addEthereumChain],
+            })
+
+            return chain
+          } catch (error) {
+            throw new UserRejectedRequestError(error as Error)
+          }
+        }
+
+        throw new SwitchChainError(error as Error)
+      }
+    },
+    onAccountsChanged(accounts) {
+      if (accounts.length === 0) this.onDisconnect()
+      else
+        config.emitter.emit('change', {
+          accounts: accounts.map((x) => getAddress(x)),
+        })
+    },
+    onChainChanged(chain) {
+      const chainId = Number(chain)
+      config.emitter.emit('change', { chainId })
+    },
+    async onDisconnect(_error) {
+      config.emitter.emit('disconnect')
+
+      const provider = await this.getProvider()
+      if (accountsChanged) {
+        provider.removeListener('accountsChanged', accountsChanged)
+        accountsChanged = undefined
+      }
+      if (chainChanged) {
+        provider.removeListener('chainChanged', chainChanged)
+        chainChanged = undefined
+      }
+      if (disconnect) {
+        provider.removeListener('disconnect', disconnect)
+        disconnect = undefined
+      }
+    },
+  }))
+}

--- a/packages/connectors/src/exports/index.ts
+++ b/packages/connectors/src/exports/index.ts
@@ -6,6 +6,8 @@ export {
   mock,
 } from '@wagmi/core'
 
+export { type BaseAccountParameters, baseAccount } from '../baseAccount.js'
+
 export {
   type CoinbaseWalletParameters,
   coinbaseWallet,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
 
   packages/connectors:
     dependencies:
+      '@base-org/account':
+        specifier: 1.0.2
+        version: 1.0.2(@types/react@18.3.1)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(wagmi@packages+react)(zod@3.22.4)
       '@coinbase/wallet-sdk':
         specifier: 4.3.6
         version: 4.3.6(@types/react@18.3.1)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -929,6 +932,14 @@ packages:
   '@babel/types@7.26.0':
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-org/account@1.0.2':
+    resolution: {integrity: sha512-jVRmMgGWQSqL4EiKoj5koXPNnTbdf4a5h+ljRU0hL8wzbGJ0hM/ZyFm/j5VNrFAX5dLLmBoa9Tf+RRwyfTvdvQ==}
+    peerDependencies:
+      wagmi: '*'
+    peerDependenciesMeta:
+      wagmi:
+        optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -8788,6 +8799,28 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@base-org/account@1.0.2(@types/react@18.3.1)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(wagmi@packages+react)(zod@3.22.4)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.8.3)(zod@3.22.4)
+      preact: 10.24.2
+      viem: 2.31.7(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      zustand: 5.0.3(@types/react@18.3.1)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
+    optionalDependencies:
+      wagmi: link:packages/react
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
 
   '@bcoe/v8-coverage@0.2.3': {}
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

We’ve recently rebranded Coinbase Smart Wallet to Base Account, and launched a dedicated SDK for it [here](https://github.com/base/account-sdk).

Our recommended migration path for this migration/transition is to introduce a separate Base Account connector specifically for the Base Account (Smart Wallet), while the existing Coinbase Wallet connector will continue to support both EOA users and Smart Wallets to ensure a smooth migration. More [details](https://docs.base.org/base-account/guides/migration-guide) 

This PR adds the new connector for Base Account.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
