### PR TITLE
feat: SIWE via wallet_connect RPC with personal_sign fallback

### DIFF
--- a/packages/core/src/actions/connect.test.ts
+++ b/packages/core/src/actions/connect.test.ts
@@ -141,3 +141,58 @@ test('parameters: siwe with custom domain and uri', async () => {
 
   await disconnect(config, { connector })
 })
+
+test('behavior: wallet_connect user rejection with SIWE capabilities', async () => {
+  const connector_ = config._internal.connectors.setup(
+    mock({
+      accounts,
+      features: { walletConnectError: true },
+    }),
+  )
+
+  await expect(
+    connect(config, {
+      connector: connector_,
+      capabilities: {
+        signInWithEthereum: {
+          nonce: 'test-nonce-rejection',
+          chainId: 1,
+        },
+      },
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [UserRejectedRequestError: User rejected the request.
+
+    Details: User rejected wallet_connect request.
+    Version: viem@2.31.7]
+  `)
+})
+
+test('behavior: wallet_connect error with code 4001', async () => {
+  const customError = new Error('User rejected') as any
+  customError.code = 4001
+
+  const connector_ = config._internal.connectors.setup(
+    mock({
+      accounts,
+      features: { walletConnectError: customError },
+    }),
+  )
+
+  await expect(
+    connect(config, {
+      connector: connector_,
+      capabilities: {
+        signInWithEthereum: {
+          nonce: 'test-nonce-rejection-4001',
+          chainId: 1,
+        },
+      },
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [UserRejectedRequestError: User rejected the request.
+
+    Details: User rejected
+    Version: viem@2.31.7]
+  `)
+})

--- a/packages/core/src/actions/connect.ts
+++ b/packages/core/src/actions/connect.ts
@@ -3,7 +3,10 @@ import type {
   ResourceUnavailableRpcErrorType,
   UserRejectedRequestErrorType,
 } from 'viem'
+import { createSiweMessage } from 'viem/siwe'
+import { numberToHex } from 'viem/utils'
 
+import { getAddress } from 'viem'
 import type { CreateConnectorFn } from '../connectors/createConnector.js'
 import type { Config, Connector } from '../createConfig.js'
 import type { BaseErrorType, ErrorType } from '../errors/base.js'
@@ -13,6 +16,36 @@ import {
 } from '../errors/config.js'
 import type { ChainIdParameter } from '../types/properties.js'
 import type { Compute } from '../types/utils.js'
+import { signMessage } from './signMessage.js'
+
+export type ConnectCapabilities = {
+  signInWithEthereum?: {
+    /** SIWE nonce for authentication */
+    nonce: string
+    /** Chain ID */
+    chainId: number
+    /** SIWE version */
+    version?: string
+    /** URI scheme */
+    scheme?: string
+    /** Domain requesting authentication */
+    domain?: string
+    /** URI for the SIWE message */
+    uri?: string
+    /** Human-readable statement */
+    statement?: string
+    /** ISO 8601 datetime when the message was issued */
+    issuedAt?: string
+    /** ISO 8601 datetime when the message expires */
+    expirationTime?: string
+    /** ISO 8601 datetime when the message becomes valid */
+    notBefore?: string
+    /** Request identifier */
+    requestId?: string
+    /** List of resources */
+    resources?: string[]
+  }
+}
 
 export type ConnectParameters<
   config extends Config = Config,
@@ -36,6 +69,7 @@ export type ConnectParameters<
 > = Compute<
   ChainIdParameter<config> & {
     connector: connector | CreateConnectorFn
+    capabilities?: ConnectCapabilities | undefined
   }
 > &
   parameters
@@ -45,6 +79,12 @@ export type ConnectReturnType<config extends Config = Config> = {
   chainId:
     | config['chains'][number]['id']
     | (number extends config['chains'][number]['id'] ? number : number & {})
+  capabilities?: {
+    signInWithEthereum?: {
+      signature: string
+      message: string
+    }
+  }
 }
 
 export type ConnectErrorType =
@@ -78,9 +118,136 @@ export async function connect<
     config.setState((x) => ({ ...x, status: 'connecting' }))
     connector.emitter.emit('message', { type: 'connecting' })
 
-    const { connector: _, ...rest } = parameters
+    const { connector: _, capabilities, ...rest } = parameters
+
+    let resultCapabilities: ConnectReturnType<config>['capabilities']
+
+    // First try wallet_connect with SIWE capabilities if nonce is provided
+    const siweConfig = capabilities?.signInWithEthereum
+    if (siweConfig?.nonce) {
+      try {
+        const provider = await connector.getProvider()
+
+        const connectResult = await (provider as any).request({
+          method: 'wallet_connect',
+          params: [
+            {
+              version: '1.0',
+              capabilities: {
+                signInWithEthereum: {
+                  ...siweConfig,
+                  chainId: numberToHex(siweConfig.chainId),
+                },
+              },
+            },
+          ],
+        })
+
+        // If wallet_connect succeeded with SIWE
+        if (connectResult?.accounts?.[0]?.capabilities?.signInWithEthereum) {
+          const siweData =
+            connectResult.accounts[0].capabilities.signInWithEthereum
+          resultCapabilities = {
+            signInWithEthereum: {
+              signature: siweData.signature,
+              message: siweData.message,
+            },
+          }
+
+          // Return early with the wallet_connect result
+          const accounts = connectResult.accounts.map((acc: any) =>
+            getAddress(acc.address || acc),
+          ) as readonly [Address, ...Address[]]
+
+          // Get the chain ID from the SIWE config or provider
+          const currentChainId =
+            siweConfig.chainId ||
+            parameters.chainId ||
+            (await connector.getChainId()) ||
+            config.chains[0].id
+
+          connector.emitter.off('connect', config._internal.events.connect)
+          connector.emitter.on('change', config._internal.events.change)
+          connector.emitter.on('disconnect', config._internal.events.disconnect)
+
+          await config.storage?.setItem('recentConnectorId', connector.id)
+          config.setState((x) => ({
+            ...x,
+            connections: new Map(x.connections).set(connector.uid, {
+              accounts,
+              chainId: currentChainId,
+              connector: connector,
+            }),
+            current: connector.uid,
+            status: 'connected',
+          }))
+
+          return {
+            accounts,
+            chainId: currentChainId,
+            capabilities: resultCapabilities,
+          }
+        }
+      } catch (walletConnectError) {
+        // wallet_connect failed, continue with fallback
+        void walletConnectError // Acknowledge error for linter
+      }
+    }
+
+    // Connect normally
     const data = await connector.connect(rest)
     const accounts = data.accounts as readonly [Address, ...Address[]]
+
+    // If no capabilities yet and nonce is provided, create and sign SIWE message
+    if (!resultCapabilities && siweConfig?.nonce) {
+      try {
+        const address = accounts[0]
+        const chainId = siweConfig.chainId || parameters.chainId || data.chainId
+
+        // Create SIWE message
+        const message = createSiweMessage({
+          address,
+          chainId,
+          domain:
+            siweConfig.domain ||
+            (typeof window !== 'undefined' ? window.location.host : 'app'),
+          nonce: siweConfig.nonce,
+          uri:
+            siweConfig.uri ||
+            (typeof window !== 'undefined' ? window.location.href : ''),
+          version: (siweConfig.version || '1') as '1',
+          statement: siweConfig.statement,
+          issuedAt: siweConfig.issuedAt
+            ? new Date(siweConfig.issuedAt)
+            : undefined,
+          expirationTime: siweConfig.expirationTime
+            ? new Date(siweConfig.expirationTime)
+            : undefined,
+          notBefore: siweConfig.notBefore
+            ? new Date(siweConfig.notBefore)
+            : undefined,
+          requestId: siweConfig.requestId,
+          resources: siweConfig.resources,
+          scheme: siweConfig.scheme,
+        })
+
+        // Sign the message
+        const signature = await signMessage(config, {
+          connector,
+          message,
+        })
+
+        resultCapabilities = {
+          signInWithEthereum: {
+            signature,
+            message,
+          },
+        }
+      } catch (signError) {
+        // Signing failed, continue without capabilities
+        void signError // Acknowledge error for linter
+      }
+    }
 
     connector.emitter.off('connect', config._internal.events.connect)
     connector.emitter.on('change', config._internal.events.change)
@@ -98,7 +265,11 @@ export async function connect<
       status: 'connected',
     }))
 
-    return { accounts, chainId: data.chainId }
+    return {
+      accounts,
+      chainId: data.chainId,
+      ...(resultCapabilities ? { capabilities: resultCapabilities } : {}),
+    }
   } catch (error) {
     config.setState((x) => ({
       ...x,

--- a/packages/core/src/actions/connect.ts
+++ b/packages/core/src/actions/connect.ts
@@ -189,7 +189,14 @@ export async function connect<
           }
         }
       } catch (walletConnectError) {
-        // wallet_connect failed, continue with fallback
+        // If user rejected the request, throw the error instead of continuing
+        if (
+          (walletConnectError as any)?.code === 4001 || // Standard user rejection code
+          (walletConnectError as any)?.name === 'UserRejectedRequestError'
+        ) {
+          throw walletConnectError
+        }
+        // For other errors, continue with fallback
         void walletConnectError // Acknowledge error for linter
       }
     }

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -14,6 +14,7 @@ export {
   type ConnectErrorType,
   type ConnectParameters,
   type ConnectReturnType,
+  type ConnectCapabilities,
   connect,
 } from '../actions/connect.js'
 
@@ -115,10 +116,7 @@ export {
   getChainId,
 } from '../actions/getChainId.js'
 
-export {
-  type GetChainsReturnType,
-  getChains,
-} from '../actions/getChains.js'
+export { type GetChainsReturnType, getChains } from '../actions/getChains.js'
 
 export {
   type GetClientParameters,

--- a/playgrounds/vite-react/src/App.tsx
+++ b/playgrounds/vite-react/src/App.tsx
@@ -113,7 +113,7 @@ function Connect() {
                 ? {
                     capabilities: {
                       signInWithEthereum: {
-                        nonce: crypto.randomUUID(),
+                        nonce: crypto.randomUUID().replace(/-/g, ''),
                         chainId,
                         domain: window.location.host,
                         uri: window.location.href,


### PR DESCRIPTION
## Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

- Adds SIWE authentication to wagmi's connect action with a new `capabilities` parameter that accepts a nested structure (e.g., `connect({ capabilities: { signInWithEthereum: { nonce, chainId } } })`)
- Attempts `wallet_connect` RPC method with SIWE capabilities when provided
- Falls back to standard connection flow + message signing if `wallet_connect` is unsupported by the wallet
- Returns SIWE signature and message in the connect result's `capabilities` field for authentication verification
- Supports full SIWE spec including optional fields like `statement`, `domain`, `uri`, `expirationTime`, `resources`, etc.
- Maintains full backward compatibility - existing connect calls work unchanged
- Includes comprehensive tests and updated playground example with SIWE toggle

Example usage

```tsx
import { useChainId, useConnect } from 'wagmi'

function Example() {
  const chainId = useChainId()
  const { connectors, connect, data } = useConnect()

  useEffect(() => {
    if (data?.capabilities?.signInWithEthereum) {
      console.log('message', data.capabilities.signInWithEthereum.message)
      console.log('signature', data.capabilities.signInWithEthereum.signature)
    }
  }, [data])

  return (
    <div>
      <h2>Connect</h2>
      {connectors.map((connector) => (
        <button
          key={connector.uid}
          onClick={() =>
            connect({
              connector,
              chainId,
              capabilities: {
                signInWithEthereum: {
                  nonce: crypto.randomUUID().replace(/-/g, ''),
                }
              }
            })
          }
          type="button"
        >
          {connector.name}
        </button>
      ))}
    </div>
  )
}
```

## Open questions
1. Should this be more generalized via generic types?

```tsx
// Example: Define custom capability schemas
type CustomAuthSchema = {
  // This type will be available in connect's capabilities param
  Parameters: {
    customAuth?: {
      provider: string
      scope: string[]
    }
  }
  // This type will be available in the `data?.capabilities` object
  ReturnType: {
    customAuth?: {
      token: string
      expiresIn: number
    }
  }
}

const { connectors, connect, status, error, data } = useConnect<
    typeof config,
    unknown,
    [SignInWithEthereumSchema, CustomAuthSchema, BiometricAuthSchema]
  >()
```

2. Should this be scoped under an `unstable_` namespace?

```tsx
connect({
  connector,
  chainId,
  unstable_capabilities: {
    signInWithEthereum: {
      nonce: crypto.randomUUID().replace(/-/g, ''),
    }
  }
})
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
