### PR TITLE
fix: ReferenceError indexedDB is not defined during SSR

### DIFF
--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -244,7 +244,7 @@ export function walletConnect(parameters: WalletConnectParameters) {
     async getProvider({ chainId } = {}) {
       async function initProvider() {
         const optionalChains = config.chains.map((x) => x.id) as [number]
-        if (!optionalChains.length) return
+        if (!optionalChains.length || typeof indexedDB === 'undefined') return
         const { EthereumProvider } = await import(
           '@walletconnect/ethereum-provider'
         )


### PR DESCRIPTION
Fix issue with indexedDB being undefined during SSR. This issue can be experienced when using `rainbowkit`.

https://github.com/rainbow-me/rainbowkit/issues/2476