### PR TITLE
fix(deepEqual): support objects with null prototypes

### DIFF
--- a/.changeset/rich-teams-care.md
+++ b/.changeset/rich-teams-care.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-Fix deepEqual crashing for objects with no prototype
+Fixed `deepEqual` crashing for objects with no prototype

--- a/packages/core/src/actions/getConnectors.test.ts
+++ b/packages/core/src/actions/getConnectors.test.ts
@@ -5,4 +5,5 @@ import { getConnectors } from './getConnectors.js'
 
 test('default', () => {
   expect(getConnectors(config)).toEqual(config.connectors)
+  expect(getConnectors(config)).toEqual(config.connectors)
 })

--- a/packages/core/src/actions/getConnectors.ts
+++ b/packages/core/src/actions/getConnectors.ts
@@ -1,5 +1,4 @@
 import type { Config, Connector } from '../createConfig.js'
-import { deepEqual } from '../utils/deepEqual.js'
 
 export type GetConnectorsReturnType<config extends Config = Config> =
   config['connectors']
@@ -11,7 +10,8 @@ export function getConnectors<config extends Config>(
   config: config,
 ): GetConnectorsReturnType<config> {
   const connectors = config.connectors
-  if (deepEqual(previousConnectors, connectors)) return previousConnectors
+  if (previousConnectors.map((c) => c.uid) === connectors.map((c) => c.uid))
+    return previousConnectors
   previousConnectors = connectors
   return connectors
 }

--- a/packages/core/src/utils/deepEqual.ts
+++ b/packages/core/src/utils/deepEqual.ts
@@ -16,9 +16,15 @@ export function deepEqual(a: any, b: any) {
       return true
     }
 
-    if (typeof a.valueOf === "function" && a.valueOf !== Object.prototype.valueOf)
+    if (
+      typeof a.valueOf === 'function' &&
+      a.valueOf !== Object.prototype.valueOf
+    )
       return a.valueOf() === b.valueOf()
-    if (typeof a.toString === "function" && a.toString !== Object.prototype.toString)
+    if (
+      typeof a.toString === 'function' &&
+      a.toString !== Object.prototype.toString
+    )
       return a.toString() === b.toString()
 
     const keys = Object.keys(a)


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

While reviewing a project crash for a client, I discovered that the `deepEqual` function ([invoked by getConnectors](https://github.com/wevm/wagmi/blob/e97836b255b4d5a3d7d9b32a9b99c6340045c6c5/packages/core/src/actions/getConnectors.ts#L14)) crashes if some field inside a connector is an object without a prototype:

```js
const a = Object.create(null)

if (a.valueOf !== Object.prototype.valueOf)
    return a.valueOf() === b.valueOf();
          // ↑ fails with “TypeError: a.valueOf is not a function” since an object
          // with no prototype will have `a.valueOf === undefined`
```

This PR fixes that.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
