### PR TITLE
fix(cli): escape dots in version regex pattern

### DIFF
--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -82,7 +82,7 @@ function hasGlobalInstallation(pm: PackageManager): boolean {
       encoding: 'utf-8',
       stdio: 'pipe',
     })
-    const isGlobal = /^\d+.\d+.\d+$/.test(result)
+    const isGlobal = /^\d+\.\d+\.\d+$/.test(result)
     cache.set(key, isGlobal)
     return isGlobal
   } catch {


### PR DESCRIPTION
Fix regex pattern for semver validation in package manager version check.

The previous pattern `/^\d+.\d+.\d+$/` used unescaped dots, which match any character instead of literal dots. This could cause false positives, accepting invalid version strings like `1a2b3c` as valid semver.

Changed to `/^\d+\.\d+\.\d+$/` to properly match literal dots in version strings.