### PR TITLE
fix: getConnectors previous result comparison

### DIFF
--- a/.changeset/crazy-cloths-bet.md
+++ b/.changeset/crazy-cloths-bet.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `getConnectors` comparison

--- a/packages/core/src/actions/getConnectors.ts
+++ b/packages/core/src/actions/getConnectors.ts
@@ -12,7 +12,9 @@ export function getConnectors<config extends Config>(
   const connectors = config.connectors
   if (
     previousConnectors.length === connectors.length &&
-    previousConnectors.every((connector, index) => connector === connectors[index])
+    previousConnectors.every(
+      (connector, index) => connector === connectors[index],
+    )
   )
     return previousConnectors
   previousConnectors = connectors


### PR DESCRIPTION
updates the `getConnectors` util to properly compare `previousConnectors` and `connectors`, as the previous check would always be false due to comparing two separate array instances