### PR TITLE
fix: bigint serialization error in query keys

### DIFF
--- a/.changeset/fifty-brooms-obey.md
+++ b/.changeset/fifty-brooms-obey.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": minor
+---
+
+fix bigint serialization error in query keys

--- a/packages/core/src/query/infiniteReadContracts.ts
+++ b/packages/core/src/query/infiniteReadContracts.ts
@@ -11,6 +11,7 @@ import type {
   ScopeKeyParameter,
 } from '../types/properties.js'
 import type { StrictOmit } from '../types/utils.js'
+import { serialize } from '../utils/serialize.js'
 import type { InfiniteQueryOptions } from './types.js'
 import { filterQueryOptions } from './utils.js'
 
@@ -109,7 +110,8 @@ export function infiniteReadContractsQueryKey<
     RequiredPageParamsParameters<contracts, allowFailure, pageParam>,
 ) {
   const { contracts: _, query: _q, ...parameters } = options
-  return ['infiniteReadContracts', filterQueryOptions(parameters)] as const
+  const serialized = JSON.parse(serialize(parameters))
+  return ['infiniteReadContracts', filterQueryOptions(serialized)] as const
 }
 
 export type InfiniteReadContractsQueryKey<

--- a/packages/core/src/query/readContract.ts
+++ b/packages/core/src/query/readContract.ts
@@ -10,6 +10,7 @@ import {
 import type { Config } from '../createConfig.js'
 import type { ScopeKeyParameter } from '../types/properties.js'
 import type { UnionExactPartial } from '../types/utils.js'
+import { serialize } from '../utils/serialize.js'
 import { filterQueryOptions } from './utils.js'
 
 export type ReadContractOptions<
@@ -82,7 +83,8 @@ export function readContractQueryKey<
   args extends ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
 >(options: ReadContractOptions<abi, functionName, args, config> = {} as any) {
   const { abi: _, ...rest } = options
-  return ['readContract', filterQueryOptions(rest)] as const
+  const serialized = JSON.parse(serialize(rest))
+  return ['readContract', filterQueryOptions(serialized)] as const
 }
 
 export type ReadContractQueryKey<

--- a/packages/core/src/query/readContracts.ts
+++ b/packages/core/src/query/readContracts.ts
@@ -15,6 +15,7 @@ import type {
   ScopeKeyParameter,
 } from '../types/properties.js'
 import type { ExactPartial } from '../types/utils.js'
+import { serialize } from '../utils/serialize.js'
 import { filterQueryOptions } from './utils.js'
 
 export type ReadContractsOptions<
@@ -85,7 +86,10 @@ export function readContractsQueryKey<
   for (const contract of (options.contracts ??
     []) as (ContractFunctionParameters & { chainId: number })[]) {
     const { abi: _, ...rest } = contract
-    contracts.push({ ...rest, chainId: rest.chainId ?? options.chainId })
+    const serialized = JSON.parse(
+      serialize({ ...rest, chainId: rest.chainId ?? options.chainId }),
+    )
+    contracts.push(serialized)
   }
   return [
     'readContracts',


### PR DESCRIPTION
## Problem
Query keys containing bigint values were causing serialization errors when used with TanStack Query's caching mechanism. This happened because `JSON.stringify()` cannot serialize bigint values directly, leading to runtime errors like:

```
TypeError: Do not know how to serialize a BigInt
```

## Solution

Updated query key generation functions to use the existing `serialize` utility function, which properly handles bigint values by converting them to a serializable format before creating query keys.