### PR TITLE
fix: add `chainId` param back onto `getProvider`

### DIFF
--- a/.changeset/hot-dogs-draw.md
+++ b/.changeset/hot-dogs-draw.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Added `chainId` parameter on `walletConnect#getProvider`

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -266,7 +266,7 @@ export function walletConnect(parameters: WalletConnectParameters) {
       const provider = await this.getProvider()
       return provider.accounts.map((x) => getAddress(x))
     },
-    async getProvider() {
+    async getProvider({ chainId } = {}) {
       async function initProvider() {
         const optionalChains = config.chains.map((x) => x.id) as [number]
         if (!optionalChains.length) return
@@ -296,6 +296,7 @@ export function walletConnect(parameters: WalletConnectParameters) {
         provider_ = await providerPromise
         provider_?.events.setMaxListeners(Number.POSITIVE_INFINITY)
       }
+      if (chainId) await this.switchChain?.({ chainId })
       return provider_!
     },
     async getChainId() {


### PR DESCRIPTION
https://github.com/wevm/wagmi/pull/4691 introduced a regression & breaking change from the removal of `getProvider#chainId` on the `walletConnect` connector. This means that apps can no longer reliably target a chain to execute a request, and will run into chain assertion issues as the chain will not be "switched" behind the scenes.

Seems that the original issue in https://github.com/wevm/wagmi/pull/4691 was to fix connection logic, which didn't touch the `switchChain` logic in `getProvider` anyway.

This PR partially reverts that change, and adds back in the [switch chain logic](https://github.com/wevm/wagmi/pull/4691/files#diff-a2cb64b937e0e0ce597ba8d09a2c9cc263248ee266e415c9fd97322739502d14L244-L274), but does not revert the logic to resolve the original issue.