### PR TITLE
fix(vue): replace TODO placeholder with correct docs path in error messages

### DIFF
--- a/packages/vue/src/errors/plugin.test.ts
+++ b/packages/vue/src/errors/plugin.test.ts
@@ -9,7 +9,7 @@ test('WagmiPluginNotFoundError', () => {
   expect(new WagmiPluginNotFoundError()).toMatchInlineSnapshot(`
     [WagmiPluginNotFoundError: No \`config\` found in Vue context, use \`WagmiPlugin\` to properly initialize the library.
 
-    Docs: https://wagmi.sh/vue/api/TODO.html
+    Docs: https://wagmi.sh/vue/api/errors.html
     Version: @wagmi/vue@x.y.z]
   `)
 })
@@ -18,7 +18,7 @@ test('WagmiInjectionContextError', () => {
   expect(new WagmiInjectionContextError()).toMatchInlineSnapshot(`
     [WagmiInjectionContextError: Wagmi composables can only be used inside \`setup()\` function or functions that support injection context.
 
-    Docs: https://wagmi.sh/vue/api/TODO.html
+    Docs: https://wagmi.sh/vue/api/errors.html
     Version: @wagmi/vue@x.y.z]
   `)
 })

--- a/packages/vue/src/errors/plugin.ts
+++ b/packages/vue/src/errors/plugin.ts
@@ -9,7 +9,7 @@ export class WagmiPluginNotFoundError extends BaseError {
     super(
       'No `config` found in Vue context, use `WagmiPlugin` to properly initialize the library.',
       {
-        docsPath: '/api/TODO',
+        docsPath: '/api/errors',
       },
     )
   }
@@ -24,7 +24,7 @@ export class WagmiInjectionContextError extends BaseError {
     super(
       'Wagmi composables can only be used inside `setup()` function or functions that support injection context.',
       {
-        docsPath: '/api/TODO',
+        docsPath: '/api/errors',
       },
     )
   }


### PR DESCRIPTION
Fixed broken documentation links in Vue error plugin by replacing placeholder `/api/TODO` paths with the correct `/api/errors` path

**Changes:**
- Updated `docsPath` in `WagmiPluginNotFoundError` and `WagmiInjectionContextError` 
- Updated corresponding snapshot tests to reflect the corrected URLs

**Before:** Users got broken links like `https://wagmi.sh/vue/api/TODO.html`
**After:** Users get working links like `https://wagmi.sh/vue/api/errors.html`