### PR TITLE
fix(core): tighten writeContract mutation types

### DIFF
--- a/packages/core/src/query/writeContract.ts
+++ b/packages/core/src/query/writeContract.ts
@@ -23,8 +23,12 @@ export function writeContractMutationOptions<config extends Config>(
     WriteContractErrorType,
     WriteContractVariables<
       Abi,
-      string,
-      readonly unknown[],
+      ContractFunctionName<Abi, 'nonpayable' | 'payable'>,
+      ContractFunctionArgs<
+        Abi,
+        'nonpayable' | 'payable',
+        ContractFunctionName<Abi, 'nonpayable' | 'payable'>
+      >,
       config,
       config['chains'][number]['id']
     >


### PR DESCRIPTION
Tighten `writeContract` mutation typing so callers can only use function names and arguments defined in the provided ABI