### PR TITLE
docs: fix function name typo

### DIFF
--- a/site/vue/typescript.md
+++ b/site/vue/typescript.md
@@ -293,7 +293,7 @@ import { useReadContract } from '@wagmi/vue'
 
 useReadContract({
   abi: erc721Abi,
-  functionName: 'balanecOf',
+  functionName: 'balanceOf',
 })
 ```
 


### PR DESCRIPTION
renamed `balanecOf` to `balanceOf` to fix the typo.
