### PR TITLE
Add new testnet Celo Sepolia and remove deprecated testnets 

### DIFF
--- a/packages/cli/src/plugins/etherscan.ts
+++ b/packages/cli/src/plugins/etherscan.ts
@@ -221,7 +221,7 @@ type ChainId =
   | 199 // BitTorrent Chain Mainnet
   | 1029 // BitTorrent Chain Testnet
   | 42220 // Celo Mainnet
-  | 44787 // Celo Alfajores Testnet
+  | 11142220 // Celo Sepolia Testnet
   | 25 // Cronos Mainnet
   | 252 // Fraxtal Mainnet
   | 2522 // Fraxtal Testnet

--- a/packages/cli/src/plugins/sourcify.ts
+++ b/packages/cli/src/plugins/sourcify.ts
@@ -123,8 +123,7 @@ type ChainId =
   | 534 // Candle
   | 7700 // Canto
   | 7701 // Canto Tesnet
-  | 44787 // Celo Alfajores Testnet
-  | 62320 // Celo Baklava Testnet
+  | 11142220 // Celo Sepolia Testnet
   | 42220 // Celo Mainnet
   | 5115 // Citrea Testnet
   | 78432 // Conduit Subnet


### PR DESCRIPTION
Add new testnet Celo Sepolia and remove deprecated testnets Alfajores and Baklava

Celo Sepolia, our new Ethereum L2 testnet, is now live. This new environment replaces Alfajores when Holesky was sunset on September 30, 2025. 

**Key details:**

Chain ID: 11142220
State: Fresh start (no inherited contracts or history)
Docs & Migration Guide: https://docs.celo.org/cel2/notices/celo-sepolia-launch

**Dependencies:**

- Celo Sepolia is live on Sourcify and Etherscan


