### PR TITLE
fix(core): adds `account` to internal `call` in `waitForTransactionReceipt` for reverted transaction

### DIFF
--- a/.changeset/wise-foxes-smash.md
+++ b/.changeset/wise-foxes-smash.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-fix nonce and account when eth_call in waitForTransactionReceipt
+Fixed passing `account` in `waitForTransactionReceipt` for reverted transaction.

--- a/packages/core/src/actions/waitForTransactionReceipt.test.ts
+++ b/packages/core/src/actions/waitForTransactionReceipt.test.ts
@@ -44,6 +44,7 @@ test('behavior: transaction reverted', async () => {
     [CallExecutionError: Execution reverted with reason: PartyBid::claim: contribution already claimed.
 
     Raw Call Arguments:
+      from:                  0xa0cf798816d4b9b9866b5330eea46a18382f251e
       to:                    0xf1332f21487e74612ed3a0fb36da729b73f1ae19
       value:                 0 ETH
       data:                  0x1e83409a000000000000000000000000a0cf798816d4b9b9866b5330eea46a18382f251e

--- a/packages/core/src/actions/waitForTransactionReceipt.ts
+++ b/packages/core/src/actions/waitForTransactionReceipt.ts
@@ -63,12 +63,13 @@ export async function waitForTransactionReceipt<
       getTransaction,
       'getTransaction',
     )
-    const txn = await action_getTransaction({ hash: receipt.transactionHash })
+    const { from: account, ...txn } = await action_getTransaction({
+      hash: receipt.transactionHash,
+    })
     const action_call = getAction(client, call, 'call')
     const code = await action_call({
       ...(txn as any),
-      nonce: undefined,
-      account: txn.from,
+      account,
       data: txn.input,
       gasPrice: txn.type !== 'eip1559' ? txn.gasPrice : undefined,
       maxFeePerGas: txn.type === 'eip1559' ? txn.maxFeePerGas : undefined,


### PR DESCRIPTION
Related https://github.com/wevm/wagmi/pull/4829
Closes https://github.com/wevm/wagmi/issues/4828

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
