### PR TITLE
Chore(test): remove redundant await from restart helper

### DIFF
--- a/packages/test/src/clients.ts
+++ b/packages/test/src/clients.ts
@@ -49,7 +49,7 @@ function wagmiTestMethods(
   return {
     /** Resets instance attached to chain. */
     async restart() {
-      return await fetch(`${client.chain.rpcUrls.default.http[0]}/restart`)
+      return fetch(`${client.chain.rpcUrls.default.http[0]}/restart`)
     },
     /** Resets fork attached to chain at starting block number. */
     resetFork() {


### PR DESCRIPTION
Remove the redundant await in `packages/test/src/clients.ts` so `restart()` just returns the fetch promise keep the helper lightweight while preserving the exact response surface
