### PR TITLE
refactor: update `chainId` computation for `useReadContracts` to reduce unnecessary query invalidations

### DIFF
--- a/.changeset/sixty-mugs-serve.md
+++ b/.changeset/sixty-mugs-serve.md
@@ -1,5 +1,5 @@
 ---
-"wagmi": minor
+"wagmi": patch
 ---
 
-fix: compute proper chainId value on useReadConstracts to avoid unnecessary queryKey mutations
+Optimized internal `chainId` computation for `useReadContracts` to reduce unnecessary query invalidations.

--- a/packages/react/src/hooks/useReadContracts.test.ts
+++ b/packages/react/src/hooks/useReadContracts.test.ts
@@ -1,7 +1,7 @@
-import { abi, address, chain } from '@wagmi/test'
+import { switchChain } from '@wagmi/core'
+import { abi, address, chain, config } from '@wagmi/test'
 import { renderHook } from '@wagmi/test/react'
 import { expect, test, vi } from 'vitest'
-
 import { useReadContracts } from './useReadContracts.js'
 
 test('default', async () => {
@@ -85,7 +85,7 @@ test('default', async () => {
   `)
 })
 
-test.skip('multichain', async () => {
+test('multichain', async () => {
   const { mainnet, mainnet2, optimism } = chain
   const { result } = await renderHook(() =>
     useReadContracts({
@@ -141,7 +141,7 @@ test.skip('multichain', async () => {
     }),
   )
 
-  await vi.waitUntil(() => result.current.isSuccess, { timeout: 5_000 })
+  await vi.waitUntil(() => result.current.isSuccess, { timeout: 10_000 })
 
   expect(result.current).toMatchInlineSnapshot(`
     {
@@ -251,6 +251,114 @@ test.skip('multichain', async () => {
               ],
               "chainId": 10,
               "functionName": "balanceOf",
+            },
+          ],
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('behavior: all same chainId', async () => {
+  const { mainnet, mainnet2 } = chain
+  await switchChain(config, { chainId: mainnet2.id })
+  const { result } = await renderHook(() =>
+    useReadContracts({
+      contracts: [
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0xd2135CfB216b74109775236E36d4b433F1DF507B'],
+        },
+      ],
+    }),
+  )
+
+  await vi.waitUntil(() => result.current.isSuccess, { timeout: 10_000 })
+
+  expect(result.current).toMatchInlineSnapshot(`
+    {
+      "data": [
+        {
+          "result": 2n,
+          "status": "success",
+        },
+        {
+          "result": 1n,
+          "status": "success",
+        },
+        {
+          "result": 0n,
+          "status": "success",
+        },
+      ],
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "readContracts",
+        {
+          "chainId": 1,
+          "contracts": [
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0xd2135CfB216b74109775236E36d4b433F1DF507B",
+              ],
+              "chainId": 1,
+              "functionName": "love",
             },
           ],
         },

--- a/packages/react/src/hooks/useReadContracts.ts
+++ b/packages/react/src/hooks/useReadContracts.ts
@@ -5,7 +5,7 @@ import type {
   ReadContractsErrorType,
   ResolvedRegister,
 } from '@wagmi/core'
-import type { ChainIdParameter, Compute } from '@wagmi/core/internal'
+import type { Compute } from '@wagmi/core/internal'
 import {
   type ReadContractsData,
   type ReadContractsOptions,
@@ -62,19 +62,16 @@ export function useReadContracts<
 
   const config = useConfig(parameters)
   const chainId = useChainId({ config })
-  const contractsChainId: number | undefined = useMemo(() => {
+  const contractsChainId = useMemo(() => {
     if (contracts.length === 0) return undefined
-
-    // Get the chainId of the first contract (if any)
-    const firstChainId = (contracts[0] as ChainIdParameter<config>).chainId
-
-    // If all contracts have the same chainId as the first, return it
-    const allSameChainId = contracts.every(
-      (contract: ChainIdParameter<config>) =>
-        (contract as ChainIdParameter<config>).chainId === firstChainId,
+    const firstChainId = (contracts[0] as { chainId?: number }).chainId
+    if (
+      (contracts as { chainId?: number }[]).every(
+        (contract) => contract.chainId === firstChainId,
+      )
     )
-
-    return allSameChainId ? firstChainId : undefined
+      return firstChainId
+    return undefined
   }, [contracts])
 
   const options = readContractsQueryOptions<config, contracts, allowFailure>(


### PR DESCRIPTION
Optimizes internal `chainId` computation for `useReadContracts` to reduce unnecessary query invalidations.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
