### PR TITLE
fix: vite-react template

### DIFF
--- a/.changeset/fancy-dingos-appear.md
+++ b/.changeset/fancy-dingos-appear.md
@@ -1,0 +1,5 @@
+---
+"create-wagmi": patch
+---
+
+Fixed Vite React template build by removing global Buffer patch

--- a/packages/create-wagmi/templates/vite-react/src/main.tsx
+++ b/packages/create-wagmi/templates/vite-react/src/main.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { Buffer } from 'buffer'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { WagmiProvider } from 'wagmi'
@@ -8,8 +7,6 @@ import App from './App.tsx'
 import { config } from './wagmi.ts'
 
 import './index.css'
-
-globalThis.Buffer = Buffer
 
 const queryClient = new QueryClient()
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

When creating a new project with `pnpm create wagmi`, the new project is missing the `buffer` polyfill dependency and has a type error in `main.tsx` where it patches the global buffer.

This PR removes the `buffer` re-assignment since it is no longer required.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
