### PR TITLE
fix: config.connectors type inference

### DIFF
--- a/.changeset/witty-icons-hear.md
+++ b/.changeset/witty-icons-hear.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `config.connectors` type inference

--- a/packages/core/src/actions/connect.test-d.ts
+++ b/packages/core/src/actions/connect.test-d.ts
@@ -1,4 +1,4 @@
-import { accounts } from '@wagmi/test'
+import { accounts, config as testConfig } from '@wagmi/test'
 import { type Address, type Hex, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { expectTypeOf, test } from 'vitest'
@@ -79,4 +79,13 @@ test('parameters: withCapabilities', async () => {
       }[],
     ]
   >()
+})
+
+test('behavior: with config', () => {
+  connect(testConfig, {
+    connector: testConfig.connectors[0]!,
+    foo: 'bar',
+  })
+  // @ts-expect-error
+  testConfig.connectors[4]
 })

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -414,7 +414,9 @@ export function createConfig<
       return chains.getState() as chains
     },
     get connectors() {
-      return connectors.getState() as Connector<connectorFns[number]>[]
+      return connectors.getState() as Readonly<{
+        [key in keyof connectorFns]: Connector<connectorFns[key]>
+      }>
     },
     storage,
 
@@ -552,7 +554,9 @@ export type Config<
     readonly CreateConnectorFn[] = readonly CreateConnectorFn[],
 > = {
   readonly chains: chains
-  readonly connectors: readonly Connector<connectorFns[number]>[]
+  readonly connectors: Readonly<{
+    [key in keyof connectorFns]: Connector<connectorFns[key]>
+  }>
   readonly storage: Storage | null
 
   readonly state: State<chains>

--- a/packages/register-tests/react/src/useConnect.test-d.ts
+++ b/packages/register-tests/react/src/useConnect.test-d.ts
@@ -5,14 +5,28 @@ import { useConnect, useConnectors } from 'wagmi'
 test('infers connect parameters', () => {
   const connect = useConnect()
   const connectors = useConnectors()
-  const connector = connectors[0]!
+  const connector = connectors[0]! as (typeof connectors)[number]
 
   connect.mutate({
     connector,
     foo: 'bar',
   })
   connect.mutate({
+    connector: connectors[1],
+    // @ts-expect-error
+    foo: 'bar',
+  })
+  connect.mutate({
     connector,
+    capabilities: {
+      signInWithEthereum: {
+        nonce: 'foobarbaz',
+      },
+    },
+  })
+  connect.mutate({
+    connector: connectors[0],
+    // @ts-expect-error
     capabilities: {
       signInWithEthereum: {
         nonce: 'foobarbaz',


### PR DESCRIPTION
Fixes `config.connectors` type inference

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
