### PR TITLE
docs: add beginner-friendly wallet connect example to README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -273,3 +273,19 @@ If you find Wagmi useful or use it for work, please consider [sponsoring Wagmi](
   <img src="https://raw.githubusercontent.com/wevm/.github/refs/heads/main/content/quicknode-badge.svg" alt="Powered by QuickNode" height="35">
 </a>
 
+## Simple Wallet Connect Example
+
+```tsx
+import { useAccount, useConnect } from 'wagmi'
+import { injected } from 'wagmi/connectors'
+
+export function Wallet() {
+  const { address, isConnected } = useAccount()
+  const { connect } = useConnect()
+
+  if (!isConnected) {
+    return <button onClick={() => connect({ connector: injected() })}>Connect Wallet</button>
+  }
+
+  return <div>Connected: {address}</div>
+}


### PR DESCRIPTION
This pull request adds a simple and beginner-friendly wallet connection example using wagmi hooks and injected connectors.

The goal is to help new developers quickly understand how to:
- Connect a wallet
- Detect connection state
- Display the connected address

This improves the onboarding experience for developers building Ethereum dApps with wagmi.
