### PR TITLE
docs: fix incorrect import and hook name references

### DIFF
--- a/site/cli/api/plugins/etherscan.md
+++ b/site/cli/api/plugins/etherscan.md
@@ -100,7 +100,7 @@ View supported chains on the [Etherscan docs](https://docs.etherscan.io/ethersca
 
 ```ts
 import { defineConfig } from '@wagmi/cli'
-import { blockExplorer } from '@wagmi/cli/plugins'
+import { etherscan } from '@wagmi/cli/plugins'
 
 export default defineConfig({
   plugins: [
@@ -160,13 +160,13 @@ export default defineConfig({
 
 ```ts
 import { defineConfig } from '@wagmi/cli'
-import { blockExplorer } from '@wagmi/cli/plugins'
+import { etherscan } from '@wagmi/cli/plugins'
 
 export default defineConfig({
   plugins: [
     etherscan({
       apiKey: process.env.ETHERSCAN_API_KEY,
-      chainId: 1, 
+      chainId: 1,
       contracts: [
         {
           name: 'FiatToken',

--- a/site/react/guides/send-transaction.md
+++ b/site/react/guides/send-transaction.md
@@ -1,6 +1,6 @@
 # Send Transaction
 
-The following guide teaches you how to send transactions in Wagmi. The example below builds on the [Connect Wallet guide](/react/guides/connect-wallet) and uses the [useSendTransaction](/react/api/hooks/useSendTransaction) & [useWaitForTransaction](/react/api/hooks/useWaitForTransactionReceipt) hooks. 
+The following guide teaches you how to send transactions in Wagmi. The example below builds on the [Connect Wallet guide](/react/guides/connect-wallet) and uses the [useSendTransaction](/react/api/hooks/useSendTransaction) & [useWaitForTransactionReceipt](/react/api/hooks/useWaitForTransactionReceipt) hooks. 
 
 ## Example
 

--- a/site/react/guides/write-to-contract.md
+++ b/site/react/guides/write-to-contract.md
@@ -2,7 +2,7 @@
 
 The [`useWriteContract` Hook](/react/api/hooks/useWriteContract) allows you to mutate data on a smart contract, from a `payable` or `nonpayable` (write) function. These types of functions require gas to be executed, hence a transaction is broadcasted in order to change the state.
 
-In the guide below, we will teach you how to implement a "Mint NFT" form that takes in a dynamic argument (token ID) using Wagmi. The example below builds on the [Connect Wallet guide](/react/guides/connect-wallet) and uses the [useWriteContract](/react/api/hooks/useWriteContract) & [useWaitForTransaction](/react/api/hooks/useWaitForTransactionReceipt) hooks. 
+In the guide below, we will teach you how to implement a "Mint NFT" form that takes in a dynamic argument (token ID) using Wagmi. The example below builds on the [Connect Wallet guide](/react/guides/connect-wallet) and uses the [useWriteContract](/react/api/hooks/useWriteContract) & [useWaitForTransactionReceipt](/react/api/hooks/useWaitForTransactionReceipt) hooks. 
 
 If you have already completed the [Sending Transactions guide](/react/guides/send-transaction), this guide will look very similar! That's because writing to a contract internally broadcasts & sends a transaction.
 


### PR DESCRIPTION
## Summary
- Fix incorrect `blockExplorer` import in etherscan.md plugin docs - should be `etherscan`
- Fix incorrect hook name references in send-transaction.md and write-to-contract.md guides - `useWaitForTransaction` should be `useWaitForTransactionReceipt`

## Test plan
- [x] Verified the correct import name matches the actual module export
- [x] Verified the correct hook name matches the actual exported hook