### PR TITLE
docs(vue): fix incorrect composable name references in guides

### DIFF
--- a/site/vue/guides/send-transaction.md
+++ b/site/vue/guides/send-transaction.md
@@ -1,6 +1,6 @@
 # Send Transaction
 
-The following guide teaches you how to send transactions in Wagmi. The example below builds on the [Connect Wallet guide](/vue/guides/connect-wallet) and uses the [useSendTransaction](/vue/api/composables/useSendTransaction) & [useWaitForTransaction](/vue/api/composables/useWaitForTransactionReceipt) composables. 
+The following guide teaches you how to send transactions in Wagmi. The example below builds on the [Connect Wallet guide](/vue/guides/connect-wallet) and uses the [useSendTransaction](/vue/api/composables/useSendTransaction) & [useWaitForTransactionReceipt](/vue/api/composables/useWaitForTransactionReceipt) composables. 
 
 ## Example
 

--- a/site/vue/guides/write-to-contract.md
+++ b/site/vue/guides/write-to-contract.md
@@ -2,7 +2,7 @@
 
 The [`useWriteContract` Composable](/vue/api/composables/useWriteContract) allows you to mutate data on a smart contract, from a `payable` or `nonpayable` (write) function. These types of functions require gas to be executed, hence a transaction is broadcasted in order to change the state.
 
-In the guide below, we will teach you how to implement a "Mint NFT" form that takes in a dynamic argument (token ID) using Wagmi. The example below builds on the [Connect Wallet guide](/vue/guides/connect-wallet) and uses the [useWriteContract](/vue/api/composables/useWriteContract) & [useWaitForTransaction](/vue/api/composables/useWaitForTransactionReceipt) composables. 
+In the guide below, we will teach you how to implement a "Mint NFT" form that takes in a dynamic argument (token ID) using Wagmi. The example below builds on the [Connect Wallet guide](/vue/guides/connect-wallet) and uses the [useWriteContract](/vue/api/composables/useWriteContract) & [useWaitForTransactionReceipt](/vue/api/composables/useWaitForTransactionReceipt) composables. 
 
 If you have already completed the [Sending Transactions guide](/vue/guides/send-transaction), this guide will look very similar! That's because writing to a contract internally broadcasts & sends a transaction.
 


### PR DESCRIPTION
## Summary
- Fix incorrect composable name references in Vue guides
- `useWaitForTransaction` should be `useWaitForTransactionReceipt` in send-transaction.md and write-to-contract.md

This is a follow-up to #4989 which fixed the same issue in the React guides.

## Test plan
- [x] Verified the correct composable name matches the actual exported composable