### PR TITLE
fix(solid): restrict @tanstack/solid-query peer dep to avoid type reg…

### DIFF
--- a/.changeset/red-ways-sniff.md
+++ b/.changeset/red-ways-sniff.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/solid": patch
+---
+
+fix(solid): restrict @tanstack/solid-query peer dep to avoid type regression

--- a/.changeset/red-ways-sniff.md
+++ b/.changeset/red-ways-sniff.md
@@ -2,4 +2,4 @@
 "@wagmi/solid": patch
 ---
 
-fix(solid): restrict @tanstack/solid-query peer dep to avoid type regression
+Restrict `@tanstack/solid-query` peer dep version to avoid type regression

--- a/.changeset/red-ways-sniff.md
+++ b/.changeset/red-ways-sniff.md
@@ -2,4 +2,4 @@
 "@wagmi/solid": patch
 ---
 
-Restricted `@tanstack/solid-query` peer dep version to avoid type regression
+Bumped TanStack Query minimum version

--- a/.changeset/red-ways-sniff.md
+++ b/.changeset/red-ways-sniff.md
@@ -2,4 +2,4 @@
 "@wagmi/solid": patch
 ---
 
-Restrict `@tanstack/solid-query` peer dep version to avoid type regression
+Restricted `@tanstack/solid-query` peer dep version to avoid type regression

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -71,7 +71,7 @@
     }
   },
   "peerDependencies": {
-    "@tanstack/solid-query": ">=5.0.0",
+    "@tanstack/solid-query": ">=5.0.0 <5.71.9",
     "solid-js": "1.x",
     "typescript": ">=5.7.3",
     "viem": "2.x"

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -71,7 +71,7 @@
     }
   },
   "peerDependencies": {
-    "@tanstack/solid-query": ">=5.0.0 <5.71.9 || >=5.90.24",
+    "@tanstack/solid-query": ">=5.90.24",
     "solid-js": "1.x",
     "typescript": ">=5.7.3",
     "viem": "2.x"

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -71,7 +71,7 @@
     }
   },
   "peerDependencies": {
-    "@tanstack/solid-query": ">=5.0.0 <5.71.9",
+    "@tanstack/solid-query": ">=5.0.0 <5.71.9 || >=5.90.24",
     "solid-js": "1.x",
     "typescript": ">=5.7.3",
     "viem": "2.x"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": ">=5.0.0",
-    "@tanstack/solid-query": ">=5.0.0",
+    "@tanstack/solid-query": ">=5.90.24",
     "@tanstack/vue-query": ">=5.0.0",
     "@types/react": ">=18",
     "@types/react-dom": ">=18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 5.49.2
       version: 5.49.2
     '@tanstack/solid-query':
-      specifier: 5.49.1
-      version: 5.49.1
+      specifier: 5.96.2
+      version: 5.96.2
     '@tanstack/vue-query':
       specifier: 5.49.1
       version: 5.49.1
@@ -407,7 +407,7 @@ importers:
     dependencies:
       '@tanstack/solid-query':
         specifier: 'catalog:'
-        version: 5.49.1(solid-js@1.9.10)
+        version: 5.96.2(solid-js@1.9.10)
       '@wagmi/solid':
         specifier: workspace:*
         version: link:../../solid
@@ -438,7 +438,7 @@ importers:
     devDependencies:
       '@tanstack/solid-query':
         specifier: 'catalog:'
-        version: 5.49.1(solid-js@1.9.10)
+        version: 5.96.2(solid-js@1.9.10)
       solid-js:
         specifier: 'catalog:'
         version: 1.9.10
@@ -453,7 +453,7 @@ importers:
         version: 5.49.2(react@19.2.0)
       '@tanstack/solid-query':
         specifier: 'catalog:'
-        version: 5.49.1(solid-js@1.9.10)
+        version: 5.96.2(solid-js@1.9.10)
       '@tanstack/vue-query':
         specifier: 'catalog:'
         version: 5.49.1(vue@3.4.27(typescript@5.9.3))
@@ -578,7 +578,7 @@ importers:
         version: 1.2.1(solid-js@1.9.10)(vinxi@0.5.10(@types/node@24.6.2)(db0@0.3.4)(idb-keyval@6.2.1)(ioredis@5.8.2)(jiti@2.6.1)(terser@5.31.0)(tsx@4.20.6)(yaml@2.8.1))(vite@7.2.2(@types/node@24.6.2)(jiti@2.6.1)(terser@5.31.0)(tsx@4.20.6)(yaml@2.8.1))
       '@tanstack/solid-query':
         specifier: 'catalog:'
-        version: 5.49.1(solid-js@1.9.10)
+        version: 5.96.2(solid-js@1.9.10)
       '@wagmi/solid':
         specifier: workspace:*
         version: link:../../packages/solid
@@ -608,7 +608,7 @@ importers:
         version: 1.147.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tanstack/react-router-ssr-query':
         specifier: ^1.145.7
-        version: 1.147.3(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.49.2(react@19.2.0))(@tanstack/react-router@1.147.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@tanstack/router-core@1.147.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.147.3(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.49.2(react@19.2.0))(@tanstack/react-router@1.147.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@tanstack/router-core@1.147.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tanstack/react-start':
         specifier: ^1.145.7
         version: 1.149.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.2.2(@types/node@24.6.2)(jiti@2.6.1)(terser@5.31.0)(tsx@4.20.6)(yaml@2.8.1)))(vite@7.2.2(@types/node@24.6.2)(jiti@2.6.1)(terser@5.31.0)(tsx@4.20.6)(yaml@2.8.1))
@@ -746,7 +746,7 @@ importers:
     dependencies:
       '@tanstack/solid-query':
         specifier: 'catalog:'
-        version: 5.49.1(solid-js@1.9.10)
+        version: 5.96.2(solid-js@1.9.10)
       '@wagmi/solid':
         specifier: workspace:*
         version: link:../../packages/solid
@@ -4794,6 +4794,9 @@ packages:
   '@tanstack/query-core@5.90.10':
     resolution: {integrity: sha512-EhZVFu9rl7GfRNuJLJ3Y7wtbTnENsvzp+YpcAV7kCYiXni1v8qZh++lpw4ch4rrwC0u/EZRnBHIehzCGzwXDSQ==}
 
+  '@tanstack/query-core@5.96.2':
+    resolution: {integrity: sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==}
+
   '@tanstack/query-devtools@5.92.0':
     resolution: {integrity: sha512-N8D27KH1vEpVacvZgJL27xC6yPFUy0Zkezn5gnB3L3gRCxlDeSuiya7fKge8Y91uMTnC8aSxBQhcK6ocY7alpQ==}
 
@@ -4940,8 +4943,8 @@ packages:
     resolution: {integrity: sha512-a05fzK+jBGacsSAc1vE8an7lpBh4H0PyIEcivtEyHLomgSeElAJxm9E2It/0nYRZ5Lh23m0okbhzJNaYWZpAOg==}
     engines: {node: '>=12'}
 
-  '@tanstack/solid-query@5.49.1':
-    resolution: {integrity: sha512-bEOphgQ2ohBBauxQmBUnmYFJe4rqOFX/AmtHgypeF7cbYH9F05TVn8zbXmpZnvyV2ASU0BDbxCrztRdg2JpKaA==}
+  '@tanstack/solid-query@5.96.2':
+    resolution: {integrity: sha512-gAJhm/aHtubM4gKrtBJy9lMIQggtG4pN3P47dIbYi7pESm8ud0EY/jWkj18TUIC65e1nbSOerKBtjRvzydz5+Q==}
     peerDependencies:
       solid-js: ^1.6.0
 
@@ -15341,6 +15344,8 @@ snapshots:
 
   '@tanstack/query-core@5.90.10': {}
 
+  '@tanstack/query-core@5.96.2': {}
+
   '@tanstack/query-devtools@5.92.0': {}
 
   '@tanstack/query-persist-client-core@5.91.9':
@@ -15392,12 +15397,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/react-router-ssr-query@1.147.3(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.49.2(react@19.2.0))(@tanstack/react-router@1.147.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@tanstack/router-core@1.147.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-router-ssr-query@1.147.3(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.49.2(react@19.2.0))(@tanstack/react-router@1.147.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@tanstack/router-core@1.147.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@tanstack/query-core': 5.90.10
+      '@tanstack/query-core': 5.96.2
       '@tanstack/react-query': 5.49.2(react@19.2.0)
       '@tanstack/react-router': 1.147.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@tanstack/router-ssr-query-core': 1.147.1(@tanstack/query-core@5.90.10)(@tanstack/router-core@1.147.1)
+      '@tanstack/router-ssr-query-core': 1.147.1(@tanstack/query-core@5.96.2)(@tanstack/router-core@1.147.1)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
@@ -15518,9 +15523,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-ssr-query-core@1.147.1(@tanstack/query-core@5.90.10)(@tanstack/router-core@1.147.1)':
+  '@tanstack/router-ssr-query-core@1.147.1(@tanstack/query-core@5.96.2)(@tanstack/router-core@1.147.1)':
     dependencies:
-      '@tanstack/query-core': 5.90.10
+      '@tanstack/query-core': 5.96.2
       '@tanstack/router-core': 1.147.1
 
   '@tanstack/router-utils@1.143.11':
@@ -15551,9 +15556,9 @@ snapshots:
       - supports-color
       - vite
 
-  '@tanstack/solid-query@5.49.1(solid-js@1.9.10)':
+  '@tanstack/solid-query@5.96.2(solid-js@1.9.10)':
     dependencies:
-      '@tanstack/query-core': 5.49.1
+      '@tanstack/query-core': 5.96.2
       solid-js: 1.9.10
 
   '@tanstack/start-client-core@1.148.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalog:
   '@safe-global/safe-apps-sdk': 9.1.0
   '@tanstack/query-core': 5.49.1
   '@tanstack/react-query': 5.49.2
-  '@tanstack/solid-query': 5.49.1
+  '@tanstack/solid-query': 5.96.2
   '@tanstack/vue-query': 5.49.1
   '@types/react': ^19.2.0
   '@types/react-dom': ^19.2.0


### PR DESCRIPTION
…ression

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

## Summary

- Restrict `@tanstack/solid-query` peer dependency to `>=5.0.0 <5.71.9` to avoid type inference regression

## Context

Starting from `@tanstack/solid-query@5.71.9`(https://github.com/TanStack/query/pull/8950), there's a type inference regression where generics are lost on deprecated `create*` APIs (e.g., `createQuery`, `createMutation`). 

This affects `@wagmi/solid` which still uses these APIs.

Once the upstream fix is released, we'll update the peer dependency constraint accordingly.

Related https://github.com/TanStack/query/pull/10093

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
