### PR TITLE
feat(solid): add related transaction primitives for solid

### DIFF
--- a/.changeset/lucky-bottles-lay.md
+++ b/.changeset/lucky-bottles-lay.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/solid": minor
+"site": minor
+---
+
+Add `useTransaction`, `useTransactionReceipt`, and `useWaitForTransactionReceipt` primitives.

--- a/packages/solid/src/exports/index.ts
+++ b/packages/solid/src/exports/index.ts
@@ -56,6 +56,12 @@ export { useSwitchChain } from '../primitives/useSwitchChain.js'
 
 export { useSwitchConnection } from '../primitives/useSwitchConnection.js'
 
+export { useTransaction } from '../primitives/useTransaction.js'
+
+export { useTransactionReceipt } from '../primitives/useTransactionReceipt.js'
+
+export { useWaitForTransactionReceipt } from '../primitives/useWaitForTransactionReceipt.js'
+
 export { useWatchBlockNumber } from '../primitives/useWatchBlockNumber.js'
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/solid/src/primitives/useTransaction.test-d.ts
+++ b/packages/solid/src/primitives/useTransaction.test-d.ts
@@ -1,0 +1,14 @@
+import { expectTypeOf, test } from 'vitest'
+
+import { useTransaction } from './useTransaction.js'
+
+test('select data', () => {
+  const result = useTransaction(() => ({
+    query: {
+      select(data) {
+        return data?.nonce
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<number | undefined>()
+})

--- a/packages/solid/src/primitives/useTransaction.test.ts
+++ b/packages/solid/src/primitives/useTransaction.test.ts
@@ -1,0 +1,155 @@
+import { chain, wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { createSignal } from 'solid-js'
+import type { Hash } from 'viem'
+import { expect, test, vi } from 'vitest'
+import { useTransaction } from './useTransaction.js'
+
+test('default', async () => {
+  const { result } = renderPrimitive(() =>
+    useTransaction(() => ({
+      hash: '0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30',
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "accessList": [],
+        "blockHash": "0xd725a38b51e5ceec8c5f6c9ccfdb2cc423af993bb650af5eedca5e4be7156ba7",
+        "blockNumber": 15189204n,
+        "chainId": 1,
+        "from": "0xa0cf798816d4b9b9866b5330eea46a18382f251e",
+        "gas": 21000n,
+        "gasPrice": 9371645552n,
+        "hash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+        "input": "0x",
+        "maxFeePerGas": 13644824566n,
+        "maxPriorityFeePerGas": 1500000000n,
+        "nonce": 86,
+        "r": "0x40174f9a38df876c1a7ce2587848819d4082ccd6d67a88aa5cabe59bf594e14f",
+        "s": "0x7c0c82f62a8a5a9b0e9cf30a54a72fdae8fc54b5b79ddafef0acd30e94e83872",
+        "to": "0xd2135cfb216b74109775236e36d4b433f1df507b",
+        "transactionIndex": 144,
+        "type": "eip1559",
+        "typeHex": "0x2",
+        "v": 0n,
+        "value": 100000000000000000n,
+        "yParity": 0,
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "transaction",
+        {
+          "chainId": 1,
+          "hash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('parameters: chainId', async () => {
+  const { result } = renderPrimitive(() =>
+    useTransaction(() => ({
+      chainId: chain.mainnet2.id,
+      hash: '0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30',
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result.queryKey).toMatchInlineSnapshot(`
+    [
+      "transaction",
+      {
+        "chainId": 456,
+        "hash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+      },
+    ]
+  `)
+})
+
+test('behavior: hash: undefined -> defined', async () => {
+  const [hash, setHash] = createSignal<Hash | undefined>(undefined)
+
+  const { result } = renderPrimitive(() =>
+    useTransaction(() => ({
+      hash: hash(),
+    })),
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": undefined,
+      "dataUpdatedAt": 0,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": false,
+      "isFetchedAfterMount": false,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": true,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": false,
+      "isSuccess": false,
+      "queryKey": [
+        "transaction",
+        {
+          "chainId": 1,
+          "hash": undefined,
+        },
+      ],
+      "refetch": [Function],
+      "status": "pending",
+    }
+  `)
+
+  setHash('0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30')
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result.data).toBeDefined()
+  expect(result.isSuccess).toBe(true)
+})
+
+test('behavior: disabled when properties missing', async () => {
+  const { result } = renderPrimitive(() => useTransaction())
+
+  await wait(100)
+  await vi.waitFor(() => expect(result.isPending).toBeTruthy())
+})

--- a/packages/solid/src/primitives/useTransaction.ts
+++ b/packages/solid/src/primitives/useTransaction.ts
@@ -1,0 +1,68 @@
+import type {
+  Config,
+  GetTransactionErrorType,
+  ResolvedRegister,
+} from '@wagmi/core'
+import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import {
+  type GetTransactionData,
+  type GetTransactionOptions,
+  getTransactionQueryOptions,
+} from '@wagmi/core/query'
+import { type Accessor, createMemo } from 'solid-js'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useTransaction */
+export function useTransaction<
+  config extends Config = ResolvedRegister['config'],
+  chainId extends
+    config['chains'][number]['id'] = config['chains'][number]['id'],
+  selectData = GetTransactionData<config, chainId>,
+>(
+  parameters: useTransaction.Parameters<
+    config,
+    chainId,
+    selectData
+  > = () => ({}),
+): useTransaction.ReturnType<config, chainId, selectData> {
+  const config = useConfig(parameters)
+  const chainId = useChainId(() => ({ config: config() }))
+  const options = createMemo(() =>
+    getTransactionQueryOptions(config(), {
+      ...parameters(),
+      chainId: parameters().chainId ?? chainId(),
+    }),
+  )
+  return useQuery(options) as useTransaction.ReturnType<
+    config,
+    chainId,
+    selectData
+  >
+}
+
+export namespace useTransaction {
+  export type Parameters<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = GetTransactionData<config, chainId>,
+  > = Accessor<SolidParameters<config, chainId, selectData>>
+
+  export type ReturnType<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = GetTransactionData<config, chainId>,
+  > = UseQueryReturnType<selectData, GetTransactionErrorType>
+
+  export type SolidParameters<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = GetTransactionData<config, chainId>,
+  > = Compute<
+    GetTransactionOptions<config, chainId, selectData> & ConfigParameter<config>
+  >
+}

--- a/packages/solid/src/primitives/useTransactionReceipt.test-d.ts
+++ b/packages/solid/src/primitives/useTransactionReceipt.test-d.ts
@@ -1,0 +1,14 @@
+import { expectTypeOf, test } from 'vitest'
+
+import { useTransactionReceipt } from './useTransactionReceipt.js'
+
+test('select data', () => {
+  const result = useTransactionReceipt(() => ({
+    query: {
+      select(data) {
+        return data?.blockNumber
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<bigint | undefined>()
+})

--- a/packages/solid/src/primitives/useTransactionReceipt.test.ts
+++ b/packages/solid/src/primitives/useTransactionReceipt.test.ts
@@ -1,0 +1,189 @@
+import { chain, wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { createSignal } from 'solid-js'
+import type { Hash } from 'viem'
+import { expect, test, vi } from 'vitest'
+import { useTransactionReceipt } from './useTransactionReceipt.js'
+
+test('default', async () => {
+  const { result } = renderPrimitive(() =>
+    useTransactionReceipt(() => ({
+      hash: '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871',
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+        "blockNumber": 16280769n,
+        "contractAddress": null,
+        "cumulativeGasUsed": 21000n,
+        "effectiveGasPrice": 33427926161n,
+        "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+        "gasUsed": 21000n,
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "success",
+        "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+        "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        "transactionIndex": 0,
+        "type": "legacy",
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('parameters: chainId', async () => {
+  const { result } = renderPrimitive(() =>
+    useTransactionReceipt(() => ({
+      chainId: chain.mainnet2.id,
+      hash: '0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871',
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+        "blockNumber": 16280769n,
+        "contractAddress": null,
+        "cumulativeGasUsed": 21000n,
+        "effectiveGasPrice": 33427926161n,
+        "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+        "gasUsed": 21000n,
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "success",
+        "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+        "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        "transactionIndex": 0,
+        "type": "legacy",
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 456,
+          "hash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('behavior: hash: undefined -> defined', async () => {
+  const [hash, setHash] = createSignal<Hash | undefined>(undefined)
+
+  const { result } = renderPrimitive(() =>
+    useTransactionReceipt(() => ({
+      hash: hash(),
+    })),
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": undefined,
+      "dataUpdatedAt": 0,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": false,
+      "isFetchedAfterMount": false,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": true,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": false,
+      "isSuccess": false,
+      "queryKey": [
+        "getTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": undefined,
+        },
+      ],
+      "refetch": [Function],
+      "status": "pending",
+    }
+  `)
+
+  setHash('0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871')
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result.data).toBeDefined()
+  expect(result.isSuccess).toBe(true)
+})
+
+test('behavior: disabled when properties missing', async () => {
+  const { result } = renderPrimitive(() => useTransactionReceipt())
+
+  await wait(100)
+  await vi.waitFor(() => expect(result.isPending).toBeTruthy())
+})

--- a/packages/solid/src/primitives/useTransactionReceipt.ts
+++ b/packages/solid/src/primitives/useTransactionReceipt.ts
@@ -1,0 +1,69 @@
+import type {
+  Config,
+  GetTransactionReceiptErrorType,
+  ResolvedRegister,
+} from '@wagmi/core'
+import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import {
+  type GetTransactionReceiptData,
+  type GetTransactionReceiptOptions,
+  getTransactionReceiptQueryOptions,
+} from '@wagmi/core/query'
+import { type Accessor, createMemo } from 'solid-js'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useTransactionReceipt */
+export function useTransactionReceipt<
+  config extends Config = ResolvedRegister['config'],
+  chainId extends
+    config['chains'][number]['id'] = config['chains'][number]['id'],
+  selectData = GetTransactionReceiptData<config, chainId>,
+>(
+  parameters: useTransactionReceipt.Parameters<
+    config,
+    chainId,
+    selectData
+  > = () => ({}),
+): useTransactionReceipt.ReturnType<config, chainId, selectData> {
+  const config = useConfig(parameters)
+  const chainId = useChainId(() => ({ config: config() }))
+  const options = createMemo(() =>
+    getTransactionReceiptQueryOptions(config(), {
+      ...parameters(),
+      chainId: parameters().chainId ?? chainId(),
+    }),
+  )
+  return useQuery(options) as useTransactionReceipt.ReturnType<
+    config,
+    chainId,
+    selectData
+  >
+}
+
+export namespace useTransactionReceipt {
+  export type Parameters<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = GetTransactionReceiptData<config, chainId>,
+  > = Accessor<SolidParameters<config, chainId, selectData>>
+
+  export type ReturnType<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = GetTransactionReceiptData<config, chainId>,
+  > = UseQueryReturnType<selectData, GetTransactionReceiptErrorType>
+
+  export type SolidParameters<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = GetTransactionReceiptData<config, chainId>,
+  > = Compute<
+    GetTransactionReceiptOptions<config, chainId, selectData> &
+      ConfigParameter<config>
+  >
+}

--- a/packages/solid/src/primitives/useWaitForTransactionReceipt.test-d.ts
+++ b/packages/solid/src/primitives/useWaitForTransactionReceipt.test-d.ts
@@ -1,0 +1,14 @@
+import { expectTypeOf, test } from 'vitest'
+
+import { useWaitForTransactionReceipt } from './useWaitForTransactionReceipt.js'
+
+test('select data', () => {
+  const result = useWaitForTransactionReceipt(() => ({
+    query: {
+      select(data) {
+        return data?.blockNumber
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<bigint | undefined>()
+})

--- a/packages/solid/src/primitives/useWaitForTransactionReceipt.test.ts
+++ b/packages/solid/src/primitives/useWaitForTransactionReceipt.test.ts
@@ -1,0 +1,130 @@
+import { wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { createSignal } from 'solid-js'
+import type { Hash } from 'viem'
+import { expect, test, vi } from 'vitest'
+import { useWaitForTransactionReceipt } from './useWaitForTransactionReceipt.js'
+
+test('default', async () => {
+  const { result } = renderPrimitive(() =>
+    useWaitForTransactionReceipt(() => ({
+      hash: '0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30',
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "blockHash": "0xd725a38b51e5ceec8c5f6c9ccfdb2cc423af993bb650af5eedca5e4be7156ba7",
+        "blockNumber": 15189204n,
+        "chainId": 1,
+        "contractAddress": null,
+        "cumulativeGasUsed": 12949744n,
+        "effectiveGasPrice": 9371645552n,
+        "from": "0xa0cf798816d4b9b9866b5330eea46a18382f251e",
+        "gasUsed": 21000n,
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "success",
+        "to": "0xd2135cfb216b74109775236e36d4b433f1df507b",
+        "transactionHash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+        "transactionIndex": 144,
+        "type": "eip1559",
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "waitForTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": "0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('behavior: hash: undefined -> defined', async () => {
+  const [hash, setHash] = createSignal<Hash | undefined>(undefined)
+
+  const { result } = renderPrimitive(() =>
+    useWaitForTransactionReceipt(() => ({
+      hash: hash(),
+    })),
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": undefined,
+      "dataUpdatedAt": 0,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": false,
+      "isFetchedAfterMount": false,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": true,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": false,
+      "isSuccess": false,
+      "queryKey": [
+        "waitForTransactionReceipt",
+        {
+          "chainId": 1,
+          "hash": undefined,
+        },
+      ],
+      "refetch": [Function],
+      "status": "pending",
+    }
+  `)
+
+  setHash('0x60668ed8c2dc110d61d945a936fcd45b8f13654e5c78481c8c825d1148c7ef30')
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result.data).toBeDefined()
+  expect(result.isSuccess).toBe(true)
+})
+
+test('behavior: disabled when hash is undefined', async () => {
+  const { result } = renderPrimitive(() =>
+    useWaitForTransactionReceipt(() => ({ hash: undefined })),
+  )
+
+  await wait(100)
+  await vi.waitFor(() => expect(result.isPending).toBeTruthy())
+})

--- a/packages/solid/src/primitives/useWaitForTransactionReceipt.ts
+++ b/packages/solid/src/primitives/useWaitForTransactionReceipt.ts
@@ -1,0 +1,69 @@
+import type {
+  Config,
+  ResolvedRegister,
+  WaitForTransactionReceiptErrorType,
+} from '@wagmi/core'
+import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import {
+  type WaitForTransactionReceiptData,
+  type WaitForTransactionReceiptOptions,
+  waitForTransactionReceiptQueryOptions,
+} from '@wagmi/core/query'
+import { type Accessor, createMemo } from 'solid-js'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useWaitForTransactionReceipt */
+export function useWaitForTransactionReceipt<
+  config extends Config = ResolvedRegister['config'],
+  chainId extends
+    config['chains'][number]['id'] = config['chains'][number]['id'],
+  selectData = WaitForTransactionReceiptData<config, chainId>,
+>(
+  parameters: useWaitForTransactionReceipt.Parameters<
+    config,
+    chainId,
+    selectData
+  > = () => ({}),
+): useWaitForTransactionReceipt.ReturnType<config, chainId, selectData> {
+  const config = useConfig(parameters)
+  const chainId = useChainId(() => ({ config: config() }))
+  const options = createMemo(() =>
+    waitForTransactionReceiptQueryOptions(config(), {
+      ...parameters(),
+      chainId: parameters().chainId ?? chainId(),
+    }),
+  )
+  return useQuery(options) as useWaitForTransactionReceipt.ReturnType<
+    config,
+    chainId,
+    selectData
+  >
+}
+
+export namespace useWaitForTransactionReceipt {
+  export type Parameters<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = WaitForTransactionReceiptData<config, chainId>,
+  > = Accessor<SolidParameters<config, chainId, selectData>>
+
+  export type ReturnType<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = WaitForTransactionReceiptData<config, chainId>,
+  > = UseQueryReturnType<selectData, WaitForTransactionReceiptErrorType>
+
+  export type SolidParameters<
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+    selectData = WaitForTransactionReceiptData<config, chainId>,
+  > = Compute<
+    WaitForTransactionReceiptOptions<config, chainId, selectData> &
+      ConfigParameter<config>
+  >
+}

--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -1235,6 +1235,18 @@ export function getSidebar() {
             link: '/solid/api/primitives/useSwitchConnection',
           },
           {
+            text: 'useTransaction',
+            link: '/solid/api/primitives/useTransaction',
+          },
+          {
+            text: 'useTransactionReceipt',
+            link: '/solid/api/primitives/useTransactionReceipt',
+          },
+          {
+            text: 'useWaitForTransactionReceipt',
+            link: '/solid/api/primitives/useWaitForTransactionReceipt',
+          },
+          {
             text: 'useWatchBlockNumber',
             link: '/solid/api/primitives/useWatchBlockNumber',
           },

--- a/site/solid/api/primitives/useTransaction.md
+++ b/site/solid/api/primitives/useTransaction.md
@@ -1,0 +1,196 @@
+---
+title: useTransaction
+description: Primitive for fetching transactions given hashes or block identifiers.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'getTransaction'
+const typeName = 'GetTransaction'
+const TData = 'GetTransactionData'
+const TError = 'GetTransactionErrorType'
+</script>
+
+# useTransaction
+
+Primitive for fetching transactions given hashes or block identifiers.
+
+## Import
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useTransaction } from '@wagmi/solid'
+
+function App() {
+  const result = useTransaction(() => ({
+    hash: '0x0fa64daeae54e207aa98613e308c2ba8abfe274f75507e741508cc4db82c8cb5',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+useTransaction.Parameters
+useTransaction.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useTransaction(() => ({
+  hash: '0x...',
+  // other parameters...
+}))
+```
+
+### blockHash
+
+`bigint | undefined`
+
+Block hash to get transaction at (with [`index`](#index)).
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+function App() {
+  const result = useTransaction(() => ({
+    blockHash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d', // [!code focus]
+    index: 0,
+  }))
+}
+```
+
+### blockNumber
+
+`bigint | undefined`
+
+Block number to get transaction at (with [`index`](#index)).
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+function App() {
+  const result = useTransaction(() => ({
+    blockNumber: 17829139n, // [!code focus]
+    index: 0,
+  }))
+}
+```
+
+### blockTag
+
+`'latest' | 'earliest' | 'pending' | 'safe' | 'finalized' | undefined`
+
+Block tag to get transaction at (with [`index`](#index)).
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+function App() {
+  const result = useTransaction(() => ({
+    blockTag: 'safe', // [!code focus]
+    index: 0,
+  }))
+}
+```
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+import { mainnet } from '@wagmi/solid/chains'
+
+function App() {
+  const result = useTransaction(() => ({
+    chainId: mainnet.id, // [!code focus]
+    hash: '0x0fa64daeae54e207aa98613e308c2ba8abfe274f75507e741508cc4db82c8cb5',
+  }))
+}
+```
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+::: code-group
+```tsx [index.tsx]
+import { useTransaction } from '@wagmi/solid'
+import { config } from './config' // [!code focus]
+
+function App() {
+  const result = useTransaction(() => ({
+    hash: '0x0fa64daeae54e207aa98613e308c2ba8abfe274f75507e741508cc4db82c8cb5',
+    config, // [!code focus]
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+### hash
+
+`` `0x${string}` | undefined ``
+
+Hash to get transaction. [`enabled`](#enabled) set to `false` if `hash` and [`index`](#index) are `undefined`.
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+function App() {
+  const result = useTransaction(() => ({
+    hash: '0x0fa64daeae54e207aa98613e308c2ba8abfe274f75507e741508cc4db82c8cb5', // [!code focus]
+  }))
+}
+```
+
+### index
+
+`number | undefined`
+
+An index to be used with a block identifier ([hash](#blockhash), [number](#blocknumber), or [tag](#blocktag)). [`enabled`](#enabled) set to `false` if `index` and [`hash`](#hash) are `undefined`.
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+function App() {
+  const result = useTransaction(() => ({
+    blockTag: 'safe',
+    index: 0  // [!code focus]
+  }))
+}
+```
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useTransaction } from '@wagmi/solid'
+
+useTransaction.ReturnType
+```
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`getTransaction`](/core/api/actions/getTransaction)

--- a/site/solid/api/primitives/useTransactionReceipt.md
+++ b/site/solid/api/primitives/useTransactionReceipt.md
@@ -1,0 +1,155 @@
+---
+title: useTransactionReceipt
+description: Primitive for returning the Transaction Receipt given a Transaction hash.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'getTransactionReceipt'
+const typeName = 'GetTransactionReceipt'
+const TData = 'GetTransactionReceiptData'
+const TError = 'GetTransactionReceiptErrorType'
+</script>
+
+# useTransactionReceipt
+
+Primitive for returning the [Transaction Receipt](https://viem.sh/docs/glossary/terms#transaction-receipt) given a [Transaction](https://viem.sh/docs/glossary/terms#transaction) hash.
+
+## Import
+
+```ts
+import { useTransactionReceipt } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useTransactionReceipt } from '@wagmi/solid'
+
+useTransactionReceipt.Parameters
+useTransactionReceipt.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useTransactionReceipt(() => ({
+  hash: '0x...',
+  // other parameters...
+}))
+```
+
+### hash
+
+`` `0x${string}` | undefined ``
+
+A transaction hash.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d', // [!code focus]
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+The ID of chain to return the transaction receipt from.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from '@wagmi/solid'
+import { mainnet } from '@wagmi/solid/chains'
+
+function App() {
+  const result = useTransactionReceipt(() => ({
+    chainId: mainnet.id, // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from '@wagmi/solid'
+import { config } from './config' // [!code focus]
+
+function App() {
+  const result = useTransactionReceipt(() => ({
+    config, // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+### scopeKey
+
+`string | undefined`
+
+Scopes the cache to a given context. Primitives that have identical context will share the same cache.
+
+::: code-group
+```tsx [index.tsx]
+import { useTransactionReceipt } from '@wagmi/solid'
+import { config } from './config'
+
+function App() {
+  const result = useTransactionReceipt(() => ({
+    scopeKey: 'foo', // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useTransactionReceipt } from '@wagmi/solid'
+
+useTransactionReceipt.ReturnType
+```
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`getTransactionReceipt`](/core/api/actions/getTransactionReceipt)

--- a/site/solid/api/primitives/useWaitForTransactionReceipt.md
+++ b/site/solid/api/primitives/useWaitForTransactionReceipt.md
@@ -1,0 +1,182 @@
+---
+title: useWaitForTransactionReceipt
+description: Primitive that waits for the transaction to be included on a block, and then returns the transaction receipt.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'waitForTransactionReceipt'
+const typeName = 'WaitForTransactionReceipt'
+const TData = 'WaitForTransactionReceiptData'
+const TError = 'WaitForTransactionReceiptErrorType'
+</script>
+
+# useWaitForTransactionReceipt
+
+Primitive that waits for the transaction to be included on a block, and then returns the transaction receipt. If the transaction reverts, then the action will throw an error. Replacement detection (e.g. sped up transactions) is also supported.
+
+## Import
+
+```ts
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+useWaitForTransactionReceipt.Parameters
+useWaitForTransactionReceipt.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useWaitForTransactionReceipt(() => ({
+  hash: '0x...',
+  // other parameters...
+}))
+```
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+```ts [index.ts]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+import { mainnet } from '@wagmi/solid/chains'
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    chainId: mainnet.id, // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+::: code-group
+```tsx [index.tsx]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+import { config } from './config' // [!code focus]
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+    config, // [!code focus]
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+### confirmations
+
+`number | undefined`
+
+The number of confirmations (blocks that have passed) to wait before resolving.
+
+```ts [index.ts]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    confirmations: 2, // [!code focus]
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  }))
+}
+```
+
+### onReplaced
+
+`
+(({ reason: 'replaced' | 'repriced' | 'cancelled'; replacedTransaction: Transaction; transaction: Transaction; transactionReceipt: TransactionReceipt }) => void) | undefined
+`
+
+Optional callback to emit if the transaction has been replaced.
+
+```ts [index.ts]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+    onReplaced: replacement => console.log(replacement), // [!code focus]
+  }))
+}
+```
+
+### pollingInterval
+
+`number | undefined`
+
+- Polling frequency (in milliseconds).
+- Defaults to the [Config's `pollingInterval` config](/solid/api/createConfig#pollinginterval).
+
+```ts [index.ts]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+    pollingInterval: 1_000, // [!code focus]
+  }))
+}
+```
+
+### hash
+
+`` `0x${string}` | undefined ``
+
+The transaction hash to wait for. [`enabled`](#enabled) set to `false` if `hash` is `undefined`.
+
+```ts [index.ts]
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+function App() {
+  const result = useWaitForTransactionReceipt(() => ({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d', // [!code focus]
+  }))
+}
+```
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useWaitForTransactionReceipt } from '@wagmi/solid'
+
+useWaitForTransactionReceipt.ReturnType
+```
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`waitForTransactionReceipt`](/core/api/actions/waitForTransactionReceipt)


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
## Summary
- Add `useTransaction` primitive for fetching transactions by hash or block identifiers
- Add `useTransactionReceipt` primitive for fetching transaction receipts
- Add `useWaitForTransactionReceipt` primitive for waiting on transaction confirmation

## Changes

### New Primitives
| Primitive | Description |
|-----------|-------------|
| `useTransaction` | Fetches transaction data given a hash or block identifier |
| `useTransactionReceipt` | Returns the transaction receipt for a given hash |
| `useWaitForTransactionReceipt` | Waits for transaction inclusion and returns the receipt with replacement detection |

### Files Added
- `packages/solid/src/primitives/useTransaction.ts`
- `packages/solid/src/primitives/useTransactionReceipt.ts`
- `packages/solid/src/primitives/useWaitForTransactionReceipt.ts`
- Test files (`.test.ts`) and type tests (`.test-d.ts`) for each primitive
- Documentation pages under `site/solid/api/primitives/`

### Files Modified
- `packages/solid/src/exports/index.ts` - Export new primitives
- `site/.vitepress/sidebar.ts` - Add navigation links for docs

## Test Plan
- [x] Unit tests pass for all three primitives
- [x] Type tests verify correct type inference with `select`
- [x] Documentation renders correctly in VitePress
- [x] Primitives work with reactive parameters (Solid signals)

---