### PR TITLE
feat(solid): missing contracts related primitives

### DIFF
--- a/.changeset/lucky-bottles-lay.md
+++ b/.changeset/lucky-bottles-lay.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/solid': minor
+---
+
+Added contract interaction primitives for SolidJS: `useReadContract`, `useReadContracts`, `useInfiniteReadContracts`, `useSimulateContract`, `useWriteContract`, `useWriteContractSync`, and `useWatchContractEvent`.

--- a/.changeset/lucky-bottles-lay.md
+++ b/.changeset/lucky-bottles-lay.md
@@ -2,4 +2,4 @@
 '@wagmi/solid': minor
 ---
 
-Added contract interaction primitives for SolidJS: `useReadContract`, `useReadContracts`, `useInfiniteReadContracts`, `useSimulateContract`, `useWriteContract`, `useWriteContractSync`, and `useWatchContractEvent`.
+Added contract interaction primitives: `useReadContract`, `useReadContracts`, `useInfiniteReadContracts`, `useSimulateContract`, `useWriteContract`, `useWriteContractSync`, and `useWatchContractEvent`.

--- a/.changeset/lucky-bottles-lay.md
+++ b/.changeset/lucky-bottles-lay.md
@@ -1,5 +1,5 @@
 ---
-'@wagmi/solid': minor
+'@wagmi/solid': patch
 ---
 
 Added contract interaction primitives: `useReadContract`, `useReadContracts`, `useInfiniteReadContracts`, `useSimulateContract`, `useWriteContract`, `useWriteContractSync`, and `useWatchContractEvent`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.vitest-temp.json
 .DS_Store
 .attest
+.amp
 .next
 .nuxt
 .pnpm-debug.log*
+.vercel
 .tanstack
 .wrangler
 _

--- a/packages/solid/src/exports/index.ts
+++ b/packages/solid/src/exports/index.ts
@@ -28,6 +28,8 @@ export { useBalance } from '../primitives/useBalance.js'
 
 export { useBlockNumber } from '../primitives/useBlockNumber.js'
 
+export { useInfiniteReadContracts } from '../primitives/useInfiniteReadContracts.js'
+
 export { useChainId } from '../primitives/useChainId.js'
 
 export { useChains } from '../primitives/useChains.js'
@@ -50,13 +52,25 @@ export { useConnectors } from '../primitives/useConnectors.js'
 
 export { useDisconnect } from '../primitives/useDisconnect.js'
 
+export { useReadContract } from '../primitives/useReadContract.js'
+
+export { useReadContracts } from '../primitives/useReadContracts.js'
+
 export { useReconnect } from '../primitives/useReconnect.js'
 
 export { useSwitchChain } from '../primitives/useSwitchChain.js'
 
+export { useSimulateContract } from '../primitives/useSimulateContract.js'
+
 export { useSwitchConnection } from '../primitives/useSwitchConnection.js'
 
 export { useWatchBlockNumber } from '../primitives/useWatchBlockNumber.js'
+
+export { useWatchContractEvent } from '../primitives/useWatchContractEvent.js'
+
+export { useWriteContract } from '../primitives/useWriteContract.js'
+
+export { useWriteContractSync } from '../primitives/useWriteContractSync.js'
 
 ////////////////////////////////////////////////////////////////////////////////
 // Hydrate

--- a/packages/solid/src/exports/index.ts
+++ b/packages/solid/src/exports/index.ts
@@ -27,40 +27,26 @@ export {
 export { useBalance } from '../primitives/useBalance.js'
 
 export { useBlockNumber } from '../primitives/useBlockNumber.js'
-
-export { useInfiniteReadContracts } from '../primitives/useInfiniteReadContracts.js'
-
 export { useChainId } from '../primitives/useChainId.js'
-
 export { useChains } from '../primitives/useChains.js'
-
 export { useClient } from '../primitives/useClient.js'
-
 export { useConfig } from '../primitives/useConfig.js'
-
 export { useConnect } from '../primitives/useConnect.js'
-
 export { useConnection } from '../primitives/useConnection.js'
-
 export { useConnectionEffect } from '../primitives/useConnectionEffect.js'
-
 export { useConnections } from '../primitives/useConnections.js'
-
 export { useConnectorClient } from '../primitives/useConnectorClient.js'
-
 export { useConnectors } from '../primitives/useConnectors.js'
-
 export { useDisconnect } from '../primitives/useDisconnect.js'
+export { useInfiniteReadContracts } from '../primitives/useInfiniteReadContracts.js'
 
 export { useReadContract } from '../primitives/useReadContract.js'
 
 export { useReadContracts } from '../primitives/useReadContracts.js'
 
 export { useReconnect } from '../primitives/useReconnect.js'
-
-export { useSwitchChain } from '../primitives/useSwitchChain.js'
-
 export { useSimulateContract } from '../primitives/useSimulateContract.js'
+export { useSwitchChain } from '../primitives/useSwitchChain.js'
 
 export { useSwitchConnection } from '../primitives/useSwitchConnection.js'
 

--- a/packages/solid/src/exports/index.ts
+++ b/packages/solid/src/exports/index.ts
@@ -27,17 +27,29 @@ export {
 export { useBalance } from '../primitives/useBalance.js'
 
 export { useBlockNumber } from '../primitives/useBlockNumber.js'
+
 export { useChainId } from '../primitives/useChainId.js'
+
 export { useChains } from '../primitives/useChains.js'
+
 export { useClient } from '../primitives/useClient.js'
+
 export { useConfig } from '../primitives/useConfig.js'
+
 export { useConnect } from '../primitives/useConnect.js'
+
 export { useConnection } from '../primitives/useConnection.js'
+
 export { useConnectionEffect } from '../primitives/useConnectionEffect.js'
+
 export { useConnections } from '../primitives/useConnections.js'
+
 export { useConnectorClient } from '../primitives/useConnectorClient.js'
+
 export { useConnectors } from '../primitives/useConnectors.js'
+
 export { useDisconnect } from '../primitives/useDisconnect.js'
+
 export { useInfiniteReadContracts } from '../primitives/useInfiniteReadContracts.js'
 
 export { useReadContract } from '../primitives/useReadContract.js'
@@ -45,7 +57,9 @@ export { useReadContract } from '../primitives/useReadContract.js'
 export { useReadContracts } from '../primitives/useReadContracts.js'
 
 export { useReconnect } from '../primitives/useReconnect.js'
+
 export { useSimulateContract } from '../primitives/useSimulateContract.js'
+
 export { useSwitchChain } from '../primitives/useSwitchChain.js'
 
 export { useSwitchConnection } from '../primitives/useSwitchConnection.js'

--- a/packages/solid/src/primitives/useInfiniteReadContracts.test-d.ts
+++ b/packages/solid/src/primitives/useInfiniteReadContracts.test-d.ts
@@ -1,0 +1,44 @@
+import { abi } from '@wagmi/test'
+import { expectTypeOf, test } from 'vitest'
+
+import { useInfiniteReadContracts } from './useInfiniteReadContracts.js'
+
+test('select data', () => {
+  const result = useInfiniteReadContracts(() => ({
+    allowFailure: false,
+    cacheKey: 'foo',
+    contracts(pageParam) {
+      expectTypeOf(pageParam).toEqualTypeOf<string>()
+      return [
+        {
+          address: '0x',
+          abi: abi.erc20,
+          functionName: 'balanceOf',
+          args: ['0x'],
+        },
+        {
+          address: '0x',
+          abi: abi.wagmiMintExample,
+          functionName: 'tokenURI',
+          args: [123n],
+        },
+      ]
+    },
+    query: {
+      initialPageParam: '0',
+      getNextPageParam(lastPage, allPages, lastPageParam, allPageParams) {
+        expectTypeOf(lastPage).toEqualTypeOf<[bigint, string]>()
+        expectTypeOf(allPages).toEqualTypeOf<[bigint, string][]>()
+        expectTypeOf(lastPageParam).toEqualTypeOf<string>()
+        expectTypeOf(allPageParams).toEqualTypeOf<string[]>()
+        return lastPageParam + 1
+      },
+      select(data) {
+        expectTypeOf(data.pageParams[0]!).toEqualTypeOf<string>()
+        expectTypeOf(data.pages[0]!).toEqualTypeOf<[bigint, string]>()
+        return data.pages[0]?.[0]!
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<bigint | undefined>()
+})

--- a/packages/solid/src/primitives/useInfiniteReadContracts.test.ts
+++ b/packages/solid/src/primitives/useInfiniteReadContracts.test.ts
@@ -1,0 +1,57 @@
+import { abi, address, wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { expect, test, vi } from 'vitest'
+
+import { useInfiniteReadContracts } from './useInfiniteReadContracts.js'
+
+test('default', async () => {
+  const limit = 3
+
+  const { result } = renderPrimitive(() =>
+    useInfiniteReadContracts(() => ({
+      cacheKey: 'foo',
+      contracts(pageParam) {
+        return [...new Array(limit)].map(
+          (_, i) =>
+            ({
+              address: address.shields,
+              abi: abi.shields,
+              functionName: 'tokenURI',
+              args: [BigInt(pageParam + i + 1)],
+            }) as const,
+        )
+      },
+      query: {
+        initialPageParam: 0,
+        getNextPageParam(_lastPage, _allPages, lastPageParam) {
+          return lastPageParam + limit
+        },
+        select(data) {
+          const results = []
+          for (const page of data.pages) {
+            for (const response of page) {
+              if (response.status === 'success') {
+                const decoded = atob(
+                  response.result.replace(/(^.*base64,)/, ''),
+                )
+                const json = JSON.parse(decoded) as { name: string }
+                results.push(json.name)
+              } else results.push('Error fetching shield')
+            }
+          }
+          return results
+        },
+      },
+    })),
+  )
+  await wait(0)
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 10_000 })
+  expect(result.data).toMatchInlineSnapshot(`
+    [
+      "Three Shields on Pink Perfect",
+      "Three Shields on Sky Perfect",
+      "Three Shields on Evergreen Perfect",
+    ]
+  `)
+}, 20_000)

--- a/packages/solid/src/primitives/useInfiniteReadContracts.ts
+++ b/packages/solid/src/primitives/useInfiniteReadContracts.ts
@@ -1,3 +1,4 @@
+import type { DefaultError, QueryKey } from '@tanstack/solid-query'
 import type {
   Config,
   ReadContractsErrorType,
@@ -12,7 +13,6 @@ import {
   infiniteReadContractsQueryOptions,
   structuralSharing,
 } from '@wagmi/core/query'
-import type { DefaultError, QueryKey } from '@tanstack/solid-query'
 import type { Accessor } from 'solid-js'
 import { createMemo } from 'solid-js'
 import type { ContractFunctionParameters } from 'viem'
@@ -72,12 +72,10 @@ export function useInfiniteReadContracts<
         chainId: chainId(),
         contracts:
           contracts as useInfiniteReadContracts.SolidParameters['contracts'],
-        query:
-          query as unknown as SolidInfiniteQueryParameters,
+        query: query as unknown as SolidInfiniteQueryParameters,
       }),
       ...(query as any),
-      structuralSharing:
-        (query as any).structuralSharing ?? structuralSharing,
+      structuralSharing: (query as any).structuralSharing ?? structuralSharing,
     }
   })
 
@@ -86,7 +84,8 @@ export function useInfiniteReadContracts<
 
 export namespace useInfiniteReadContracts {
   export type Parameters<
-    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    contracts extends
+      readonly unknown[] = readonly ContractFunctionParameters[],
     allowFailure extends boolean = true,
     config extends Config = Config,
     pageParam = unknown,
@@ -96,35 +95,27 @@ export namespace useInfiniteReadContracts {
   >
 
   export type ReturnType<
-    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    contracts extends
+      readonly unknown[] = readonly ContractFunctionParameters[],
     allowFailure extends boolean = true,
     selectData = InfiniteReadContractsData<contracts, allowFailure>,
   > = UseInfiniteQueryReturnType<selectData, ReadContractsErrorType>
 
   export type SolidParameters<
-    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    contracts extends
+      readonly unknown[] = readonly ContractFunctionParameters[],
     allowFailure extends boolean = true,
     config extends Config = Config,
     pageParam = unknown,
     selectData = InfiniteReadContractsData<contracts, allowFailure>,
-  > = InfiniteReadContractsOptions<
-    contracts,
-    allowFailure,
-    pageParam,
-    config
-  > &
+  > = InfiniteReadContractsOptions<contracts, allowFailure, pageParam, config> &
     ConfigParameter<config> &
     InfiniteQueryParameter<
       InfiniteReadContractsQueryFnData<contracts, allowFailure>,
       ReadContractsErrorType,
       selectData,
       InfiniteReadContractsData<contracts, allowFailure>,
-      InfiniteReadContractsQueryKey<
-        contracts,
-        allowFailure,
-        pageParam,
-        config
-      >,
+      InfiniteReadContractsQueryKey<contracts, allowFailure, pageParam, config>,
       pageParam
     >
 }

--- a/packages/solid/src/primitives/useInfiniteReadContracts.ts
+++ b/packages/solid/src/primitives/useInfiniteReadContracts.ts
@@ -1,0 +1,130 @@
+import type {
+  Config,
+  ReadContractsErrorType,
+  ResolvedRegister,
+} from '@wagmi/core'
+import type { ConfigParameter, Omit } from '@wagmi/core/internal'
+import {
+  type InfiniteReadContractsData,
+  type InfiniteReadContractsOptions,
+  type InfiniteReadContractsQueryFnData,
+  type InfiniteReadContractsQueryKey,
+  infiniteReadContractsQueryOptions,
+  structuralSharing,
+} from '@wagmi/core/query'
+import type { DefaultError, QueryKey } from '@tanstack/solid-query'
+import type { Accessor } from 'solid-js'
+import { createMemo } from 'solid-js'
+import type { ContractFunctionParameters } from 'viem'
+import {
+  type SolidInfiniteQueryParameters,
+  type UseInfiniteQueryReturnType,
+  useInfiniteQuery,
+} from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+type InfiniteQueryParameter<
+  queryFnData = unknown,
+  error = DefaultError,
+  data = queryFnData,
+  queryData = queryFnData,
+  queryKey extends QueryKey = QueryKey,
+  pageParam = unknown,
+> = {
+  query: Omit<
+    SolidInfiniteQueryParameters<
+      queryFnData,
+      error,
+      data,
+      queryData,
+      queryKey,
+      pageParam
+    >,
+    'queryFn' | 'queryHash' | 'queryKey' | 'queryKeyHashFn' | 'throwOnError'
+  >
+}
+
+/** https://wagmi.sh/solid/api/primitives/useInfiniteReadContracts */
+export function useInfiniteReadContracts<
+  const contracts extends readonly unknown[],
+  allowFailure extends boolean = true,
+  config extends Config = ResolvedRegister['config'],
+  pageParam = unknown,
+  selectData = InfiniteReadContractsData<contracts, allowFailure>,
+>(
+  parameters: useInfiniteReadContracts.Parameters<
+    contracts,
+    allowFailure,
+    config,
+    pageParam,
+    selectData
+  >,
+): useInfiniteReadContracts.ReturnType<contracts, allowFailure, selectData> {
+  const config = useConfig(parameters)
+  const chainId = useChainId(() => ({ config: config() }))
+
+  const options = createMemo(() => {
+    const { contracts = [], query } = parameters()
+    return {
+      ...infiniteReadContractsQueryOptions(config(), {
+        ...parameters(),
+        chainId: chainId(),
+        contracts:
+          contracts as useInfiniteReadContracts.SolidParameters['contracts'],
+        query:
+          query as unknown as SolidInfiniteQueryParameters,
+      }),
+      ...(query as any),
+      structuralSharing:
+        (query as any).structuralSharing ?? structuralSharing,
+    }
+  })
+
+  return useInfiniteQuery(options as any) as any
+}
+
+export namespace useInfiniteReadContracts {
+  export type Parameters<
+    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    allowFailure extends boolean = true,
+    config extends Config = Config,
+    pageParam = unknown,
+    selectData = InfiniteReadContractsData<contracts, allowFailure>,
+  > = Accessor<
+    SolidParameters<contracts, allowFailure, config, pageParam, selectData>
+  >
+
+  export type ReturnType<
+    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    allowFailure extends boolean = true,
+    selectData = InfiniteReadContractsData<contracts, allowFailure>,
+  > = UseInfiniteQueryReturnType<selectData, ReadContractsErrorType>
+
+  export type SolidParameters<
+    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    allowFailure extends boolean = true,
+    config extends Config = Config,
+    pageParam = unknown,
+    selectData = InfiniteReadContractsData<contracts, allowFailure>,
+  > = InfiniteReadContractsOptions<
+    contracts,
+    allowFailure,
+    pageParam,
+    config
+  > &
+    ConfigParameter<config> &
+    InfiniteQueryParameter<
+      InfiniteReadContractsQueryFnData<contracts, allowFailure>,
+      ReadContractsErrorType,
+      selectData,
+      InfiniteReadContractsData<contracts, allowFailure>,
+      InfiniteReadContractsQueryKey<
+        contracts,
+        allowFailure,
+        pageParam,
+        config
+      >,
+      pageParam
+    >
+}

--- a/packages/solid/src/primitives/useInfiniteReadContracts.ts
+++ b/packages/solid/src/primitives/useInfiniteReadContracts.ts
@@ -66,15 +66,17 @@ export function useInfiniteReadContracts<
 
   const options = createMemo(() => {
     const { contracts = [], query } = parameters()
+    const options = infiniteReadContractsQueryOptions(config(), {
+      ...parameters(),
+      chainId: chainId(),
+      contracts:
+        contracts as useInfiniteReadContracts.SolidParameters['contracts'],
+      query: query as unknown as SolidInfiniteQueryParameters,
+    })
     return {
-      ...infiniteReadContractsQueryOptions(config(), {
-        ...parameters(),
-        chainId: chainId(),
-        contracts:
-          contracts as useInfiniteReadContracts.SolidParameters['contracts'],
-        query: query as unknown as SolidInfiniteQueryParameters,
-      }),
       ...(query as any),
+      ...options,
+      initialPageParam: options.initialPageParam,
       structuralSharing: (query as any).structuralSharing ?? structuralSharing,
     }
   })

--- a/packages/solid/src/primitives/useReadContract.test-d.ts
+++ b/packages/solid/src/primitives/useReadContract.test-d.ts
@@ -1,0 +1,70 @@
+import { abi } from '@wagmi/test'
+import type { Address } from 'viem'
+import { assertType, expectTypeOf, test } from 'vitest'
+
+import { useReadContract } from './useReadContract.js'
+
+test('select data', () => {
+  const result = useReadContract(() => ({
+    address: '0x',
+    abi: abi.erc20,
+    functionName: 'balanceOf',
+    args: ['0x'],
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<bigint>()
+        return data?.toString()
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<string | undefined>()
+})
+
+test('overloads', () => {
+  const result1 = useReadContract(() => ({
+    address: '0x',
+    abi: abi.viewOverloads,
+    functionName: 'foo',
+  }))
+  assertType<number | undefined>(result1.data)
+
+  const result2 = useReadContract(() => ({
+    address: '0x',
+    abi: abi.viewOverloads,
+    functionName: 'foo',
+    args: [],
+  }))
+  assertType<number | undefined>(result2.data)
+
+  const result3 = useReadContract(() => ({
+    address: '0x',
+    abi: abi.viewOverloads,
+    functionName: 'foo',
+    args: ['0x'],
+  }))
+  assertType<string | undefined>(result3.data)
+
+  const result4 = useReadContract(() => ({
+    address: '0x',
+    abi: abi.viewOverloads,
+    functionName: 'foo',
+    args: ['0x', '0x'],
+  }))
+  assertType<
+    | {
+        foo: `0x${string}`
+        bar: `0x${string}`
+      }
+    | undefined
+  >(result4.data)
+})
+
+test('deployless read (bytecode)', () => {
+  const result = useReadContract(() => ({
+    code: '0x',
+    abi: abi.erc20,
+    functionName: 'balanceOf',
+    args: ['0x'],
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<bigint | undefined>()
+})

--- a/packages/solid/src/primitives/useReadContract.test-d.ts
+++ b/packages/solid/src/primitives/useReadContract.test-d.ts
@@ -1,5 +1,4 @@
 import { abi } from '@wagmi/test'
-import type { Address } from 'viem'
 import { assertType, expectTypeOf, test } from 'vitest'
 
 import { useReadContract } from './useReadContract.js'

--- a/packages/solid/src/primitives/useReadContract.test.ts
+++ b/packages/solid/src/primitives/useReadContract.test.ts
@@ -1,0 +1,133 @@
+import { abi, address, bytecode, chain, wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { expect, test, vi } from 'vitest'
+
+import { useReadContract } from './useReadContract.js'
+
+test('default', async () => {
+  const { result } = renderPrimitive(() =>
+    useReadContract(() => ({
+      address: address.wagmiMintExample,
+      abi: abi.wagmiMintExample,
+      functionName: 'balanceOf',
+      args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": 10n,
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "readContract",
+        {
+          "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+          "args": [
+            "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+          ],
+          "chainId": 1,
+          "functionName": "balanceOf",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('parameters: chainId', async () => {
+  const { result } = renderPrimitive(() =>
+    useReadContract(() => ({
+      address: address.wagmiMintExample,
+      abi: abi.wagmiMintExample,
+      functionName: 'balanceOf',
+      args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+      chainId: chain.mainnet2.id,
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": 10n,
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "readContract",
+        {
+          "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+          "args": [
+            "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+          ],
+          "chainId": 456,
+          "functionName": "balanceOf",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('parameters: deployless read (bytecode)', async () => {
+  const { result } = renderPrimitive(() =>
+    useReadContract(() => ({
+      abi: abi.wagmiMintExample,
+      functionName: 'name',
+      code: bytecode.wagmiMintExample,
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result.data).toMatchInlineSnapshot(`"wagmi"`)
+})
+
+test('behavior: disabled when properties missing', async () => {
+  const { result } = renderPrimitive(() => useReadContract())
+
+  await wait(100)
+  await vi.waitFor(() => expect(result.isPending).toBeTruthy())
+})

--- a/packages/solid/src/primitives/useReadContract.ts
+++ b/packages/solid/src/primitives/useReadContract.ts
@@ -1,0 +1,93 @@
+import type {
+  Config,
+  ReadContractErrorType,
+  ResolvedRegister,
+} from '@wagmi/core'
+import type { ConfigParameter, UnionCompute } from '@wagmi/core/internal'
+import {
+  type ReadContractData,
+  type ReadContractOptions,
+  readContractQueryOptions,
+} from '@wagmi/core/query'
+import type { Accessor } from 'solid-js'
+import { createMemo } from 'solid-js'
+import type { Abi, ContractFunctionArgs, ContractFunctionName } from 'viem'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useReadContract */
+export function useReadContract<
+  const abi extends Abi | readonly unknown[],
+  functionName extends ContractFunctionName<abi, 'pure' | 'view'>,
+  const args extends ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+  config extends Config = ResolvedRegister['config'],
+  selectData = ReadContractData<abi, functionName, args>,
+>(
+  parameters: useReadContract.Parameters<
+    abi,
+    functionName,
+    args,
+    config,
+    selectData
+  > = () => ({}) as any,
+): useReadContract.ReturnType<abi, functionName, args, selectData> {
+  const config = useConfig(parameters)
+  const chainId = useChainId(() => ({ config: config() }))
+  const options = createMemo(() =>
+    readContractQueryOptions(config(), {
+      ...(parameters() as any),
+      chainId: parameters().chainId ?? chainId(),
+    }),
+  )
+  return useQuery(options) as any
+}
+
+export namespace useReadContract {
+  export type Parameters<
+    abi extends Abi | readonly unknown[] = Abi,
+    functionName extends ContractFunctionName<
+      abi,
+      'pure' | 'view'
+    > = ContractFunctionName<abi, 'pure' | 'view'>,
+    args extends ContractFunctionArgs<
+      abi,
+      'pure' | 'view',
+      functionName
+    > = ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+    config extends Config = Config,
+    selectData = ReadContractData<abi, functionName, args>,
+  > = Accessor<SolidParameters<abi, functionName, args, config, selectData>>
+
+  export type ReturnType<
+    abi extends Abi | readonly unknown[] = Abi,
+    functionName extends ContractFunctionName<
+      abi,
+      'pure' | 'view'
+    > = ContractFunctionName<abi, 'pure' | 'view'>,
+    args extends ContractFunctionArgs<
+      abi,
+      'pure' | 'view',
+      functionName
+    > = ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+    selectData = ReadContractData<abi, functionName, args>,
+  > = UseQueryReturnType<selectData, ReadContractErrorType>
+
+  export type SolidParameters<
+    abi extends Abi | readonly unknown[] = Abi,
+    functionName extends ContractFunctionName<
+      abi,
+      'pure' | 'view'
+    > = ContractFunctionName<abi, 'pure' | 'view'>,
+    args extends ContractFunctionArgs<
+      abi,
+      'pure' | 'view',
+      functionName
+    > = ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+    config extends Config = Config,
+    selectData = ReadContractData<abi, functionName, args>,
+  > = UnionCompute<
+    ReadContractOptions<abi, functionName, args, config, selectData> &
+      ConfigParameter<config>
+  >
+}

--- a/packages/solid/src/primitives/useReadContracts.test-d.ts
+++ b/packages/solid/src/primitives/useReadContracts.test-d.ts
@@ -1,0 +1,93 @@
+import { abi } from '@wagmi/test'
+import { assertType, expectTypeOf, test } from 'vitest'
+
+import { useReadContracts } from './useReadContracts.js'
+
+test('select data', () => {
+  const result = useReadContracts(() => ({
+    allowFailure: false,
+    contracts: [
+      {
+        address: '0x',
+        abi: abi.erc20,
+        functionName: 'balanceOf',
+        chainId: 1,
+        args: ['0x'],
+      },
+      {
+        address: '0x',
+        abi: abi.wagmiMintExample,
+        functionName: 'tokenURI',
+        args: [123n],
+      },
+    ],
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<[bigint, string]>()
+        return data[0]
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<bigint | undefined>()
+})
+
+test('overloads', async () => {
+  const result1 = useReadContracts(() => ({
+    allowFailure: false,
+    contracts: [
+      {
+        address: '0x',
+        abi: abi.viewOverloads,
+        functionName: 'foo',
+      },
+    ],
+  }))
+  assertType<[number] | undefined>(result1.data)
+
+  const result2 = useReadContracts(() => ({
+    allowFailure: false,
+    contracts: [
+      {
+        address: '0x',
+        abi: abi.viewOverloads,
+        functionName: 'foo',
+        args: [],
+      },
+    ],
+  }))
+  assertType<[number] | undefined>(result2.data)
+
+  const result3 = useReadContracts(() => ({
+    allowFailure: false,
+    contracts: [
+      {
+        address: '0x',
+        abi: abi.viewOverloads,
+        functionName: 'foo',
+        args: ['0x'],
+      },
+    ],
+  }))
+  assertType<[string] | undefined>(result3.data)
+
+  const result4 = useReadContracts(() => ({
+    allowFailure: false,
+    contracts: [
+      {
+        address: '0x',
+        abi: abi.viewOverloads,
+        functionName: 'foo',
+        args: ['0x', '0x'],
+      },
+    ],
+  }))
+  assertType<
+    | [
+        {
+          foo: `0x${string}`
+          bar: `0x${string}`
+        },
+      ]
+    | undefined
+  >(result4.data)
+})

--- a/packages/solid/src/primitives/useReadContracts.test.ts
+++ b/packages/solid/src/primitives/useReadContracts.test.ts
@@ -1,0 +1,335 @@
+import { switchChain } from '@wagmi/core'
+import { abi, address, chain, config } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { expect, test, vi } from 'vitest'
+
+import { useReadContracts } from './useReadContracts.js'
+
+test('default', async () => {
+  const { result } = renderPrimitive(() =>
+    useReadContracts(() => ({
+      contracts: [
+        {
+          address: address.wagmiMintExample,
+          abi: abi.wagmiMintExample,
+          functionName: 'balanceOf',
+          args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+        },
+        {
+          address: address.wagmiMintExample,
+          abi: abi.wagmiMintExample,
+          functionName: 'symbol',
+        },
+      ],
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": [
+        {
+          "result": 10n,
+          "status": "success",
+        },
+        {
+          "result": "WAGMI",
+          "status": "success",
+        },
+      ],
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "readContracts",
+        {
+          "chainId": 1,
+          "contracts": [
+            {
+              "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+              "args": [
+                "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+              ],
+              "chainId": 1,
+              "functionName": "balanceOf",
+            },
+            {
+              "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+              "chainId": 1,
+              "functionName": "symbol",
+            },
+          ],
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})
+
+test('multichain', async () => {
+  const { mainnet, mainnet2 } = chain
+  const { result } = renderPrimitive(() =>
+    useReadContracts(() => ({
+      contracts: [
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0xd2135CfB216b74109775236E36d4b433F1DF507B'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet2.id,
+          functionName: 'getAlive',
+        },
+        {
+          abi: abi.mloot,
+          address: address.mloot,
+          chainId: mainnet2.id,
+          functionName: 'tokenOfOwnerByIndex',
+          args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 0n],
+        },
+      ],
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 60_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": [
+        {
+          "result": 2n,
+          "status": "success",
+        },
+        {
+          "result": 1n,
+          "status": "success",
+        },
+        {
+          "result": 0n,
+          "status": "success",
+        },
+        {
+          "result": false,
+          "status": "success",
+        },
+        {
+          "result": 370395n,
+          "status": "success",
+        },
+      ],
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "readContracts",
+        {
+          "contracts": [
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0xd2135CfB216b74109775236E36d4b433F1DF507B",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "chainId": 456,
+              "functionName": "getAlive",
+            },
+            {
+              "address": "0x1dfe7ca09e99d10835bf73044a23b73fc20623df",
+              "args": [
+                "0xA0Cf798816D4b9b9866b5330EEa46a18382f251e",
+                0n,
+              ],
+              "chainId": 456,
+              "functionName": "tokenOfOwnerByIndex",
+            },
+          ],
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+}, 60_000)
+
+test('behavior: all same chainId', async () => {
+  const { mainnet, mainnet2 } = chain
+  await switchChain(config, { chainId: mainnet2.id })
+  const { result } = renderPrimitive(() =>
+    useReadContracts(() => ({
+      contracts: [
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+        },
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          chainId: mainnet.id,
+          functionName: 'love',
+          args: ['0xd2135CfB216b74109775236E36d4b433F1DF507B'],
+        },
+      ],
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 10_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": [
+        {
+          "result": 2n,
+          "status": "success",
+        },
+        {
+          "result": 1n,
+          "status": "success",
+        },
+        {
+          "result": 0n,
+          "status": "success",
+        },
+      ],
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "readContracts",
+        {
+          "contracts": [
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+            {
+              "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+              "args": [
+                "0xd2135CfB216b74109775236E36d4b433F1DF507B",
+              ],
+              "chainId": 1,
+              "functionName": "love",
+            },
+          ],
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+})

--- a/packages/solid/src/primitives/useReadContracts.ts
+++ b/packages/solid/src/primitives/useReadContracts.ts
@@ -55,20 +55,23 @@ export function useReadContracts<
 
 export namespace useReadContracts {
   export type Parameters<
-    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    contracts extends
+      readonly unknown[] = readonly ContractFunctionParameters[],
     allowFailure extends boolean = true,
     config extends Config = Config,
     selectData = ReadContractsData<contracts, allowFailure>,
   > = Accessor<SolidParameters<contracts, allowFailure, config, selectData>>
 
   export type ReturnType<
-    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    contracts extends
+      readonly unknown[] = readonly ContractFunctionParameters[],
     allowFailure extends boolean = true,
     selectData = ReadContractsData<contracts, allowFailure>,
   > = UseQueryReturnType<selectData, ReadContractsErrorType>
 
   export type SolidParameters<
-    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    contracts extends
+      readonly unknown[] = readonly ContractFunctionParameters[],
     allowFailure extends boolean = true,
     config extends Config = Config,
     selectData = ReadContractsData<contracts, allowFailure>,

--- a/packages/solid/src/primitives/useReadContracts.ts
+++ b/packages/solid/src/primitives/useReadContracts.ts
@@ -1,0 +1,79 @@
+import type {
+  Config,
+  ReadContractsErrorType,
+  ResolvedRegister,
+} from '@wagmi/core'
+import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import {
+  type ReadContractsData,
+  type ReadContractsOptions,
+  readContractsQueryOptions,
+} from '@wagmi/core/query'
+import type { Accessor } from 'solid-js'
+import { createMemo } from 'solid-js'
+import type { ContractFunctionParameters } from 'viem'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useReadContracts */
+export function useReadContracts<
+  const contracts extends readonly unknown[],
+  allowFailure extends boolean = true,
+  config extends Config = ResolvedRegister['config'],
+  selectData = ReadContractsData<contracts, allowFailure>,
+>(
+  parameters: useReadContracts.Parameters<
+    contracts,
+    allowFailure,
+    config,
+    selectData
+  > = () => ({}),
+): useReadContracts.ReturnType<contracts, allowFailure, selectData> {
+  const config = useConfig(parameters)
+  const chainId = useChainId(() => ({ config: config() }))
+  const contractsChainId = createMemo(() => {
+    const firstChainId = (
+      parameters().contracts?.[0] as { chainId?: number } | undefined
+    )?.chainId
+    if (
+      ((parameters().contracts ?? []) as { chainId?: number }[]).every(
+        (contract) => contract.chainId === firstChainId,
+      )
+    )
+      return firstChainId
+    return undefined
+  })
+  const options = createMemo(() =>
+    readContractsQueryOptions(config(), {
+      ...parameters(),
+      chainId: contractsChainId() ?? chainId(),
+    }),
+  )
+  return useQuery(options) as any
+}
+
+export namespace useReadContracts {
+  export type Parameters<
+    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    allowFailure extends boolean = true,
+    config extends Config = Config,
+    selectData = ReadContractsData<contracts, allowFailure>,
+  > = Accessor<SolidParameters<contracts, allowFailure, config, selectData>>
+
+  export type ReturnType<
+    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    allowFailure extends boolean = true,
+    selectData = ReadContractsData<contracts, allowFailure>,
+  > = UseQueryReturnType<selectData, ReadContractsErrorType>
+
+  export type SolidParameters<
+    contracts extends readonly unknown[] = readonly ContractFunctionParameters[],
+    allowFailure extends boolean = true,
+    config extends Config = Config,
+    selectData = ReadContractsData<contracts, allowFailure>,
+  > = Compute<
+    ReadContractsOptions<contracts, allowFailure, config, selectData> &
+      ConfigParameter<config>
+  >
+}

--- a/packages/solid/src/primitives/useSimulateContract.test-d.ts
+++ b/packages/solid/src/primitives/useSimulateContract.test-d.ts
@@ -1,0 +1,58 @@
+import { abi } from '@wagmi/test'
+import type { Address } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+
+import { useSimulateContract } from './useSimulateContract.js'
+
+test('default', () => {
+  const result = useSimulateContract(() => ({
+    address: '0x',
+    abi: abi.erc20,
+    functionName: 'transferFrom',
+    args: ['0x', '0x', 123n],
+  }))
+
+  expectTypeOf(result.data).toMatchTypeOf<
+    | {
+        result: boolean
+        request: {
+          chainId?: undefined
+          abi: readonly [
+            {
+              readonly name: 'transferFrom'
+              readonly type: 'function'
+              readonly stateMutability: 'nonpayable'
+              readonly inputs: readonly [
+                { readonly type: 'address'; readonly name: 'sender' },
+                { readonly type: 'address'; readonly name: 'recipient' },
+                { readonly type: 'uint256'; readonly name: 'amount' },
+              ]
+              readonly outputs: readonly [{ type: 'bool' }]
+            },
+          ]
+          functionName: 'transferFrom'
+          args: readonly [Address, Address, bigint]
+        }
+      }
+    | undefined
+  >()
+})
+
+test('select data', () => {
+  const result = useSimulateContract(() => ({
+    address: '0x',
+    abi: abi.erc20,
+    functionName: 'transferFrom',
+    args: ['0x', '0x', 123n],
+    chainId: 1,
+    query: {
+      select(data) {
+        expectTypeOf(data.result).toEqualTypeOf<boolean>()
+        return data.request.args
+      },
+    },
+  }))
+  expectTypeOf(result.data).toEqualTypeOf<
+    readonly [Address, Address, bigint] | undefined
+  >()
+})

--- a/packages/solid/src/primitives/useSimulateContract.test.ts
+++ b/packages/solid/src/primitives/useSimulateContract.test.ts
@@ -1,0 +1,92 @@
+import { connect, disconnect } from '@wagmi/core'
+import { abi, address, config, wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { expect, test, vi } from 'vitest'
+
+import { useSimulateContract } from './useSimulateContract.js'
+
+const connector = config.connectors[0]!
+
+test('default', async () => {
+  await connect(config, { connector })
+
+  const { result } = renderPrimitive(() =>
+    useSimulateContract(() => ({
+      address: address.wagmiMintExample,
+      abi: abi.wagmiMintExample,
+      functionName: 'mint',
+    })),
+  )
+
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "chainId": 1,
+        "request": {
+          "abi": [
+            {
+              "inputs": [],
+              "name": "mint",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function",
+            },
+          ],
+          "account": {
+            "address": "0x95132632579b073D12a6673e18Ab05777a6B86f8",
+            "type": "json-rpc",
+          },
+          "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+          "args": undefined,
+          "chainId": 1,
+          "dataSuffix": undefined,
+          "functionName": "mint",
+        },
+        "result": undefined,
+      },
+      "dataUpdatedAt": 1675209600000,
+      "error": null,
+      "errorUpdateCount": 0,
+      "errorUpdatedAt": 0,
+      "failureCount": 0,
+      "failureReason": null,
+      "fetchStatus": "idle",
+      "isError": false,
+      "isFetched": true,
+      "isFetchedAfterMount": true,
+      "isFetching": false,
+      "isInitialLoading": false,
+      "isLoading": false,
+      "isLoadingError": false,
+      "isPaused": false,
+      "isPending": false,
+      "isPlaceholderData": false,
+      "isRefetchError": false,
+      "isRefetching": false,
+      "isStale": true,
+      "isSuccess": true,
+      "queryKey": [
+        "simulateContract",
+        {
+          "account": "0x95132632579b073D12a6673e18Ab05777a6B86f8",
+          "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+          "chainId": 1,
+          "functionName": "mint",
+        },
+      ],
+      "refetch": [Function],
+      "status": "success",
+    }
+  `)
+
+  await disconnect(config, { connector })
+})
+
+test('behavior: disabled when properties missing', async () => {
+  const { result } = renderPrimitive(() => useSimulateContract())
+
+  await wait(100)
+  await vi.waitFor(() => expect(result.isPending).toBeTruthy())
+})

--- a/packages/solid/src/primitives/useSimulateContract.ts
+++ b/packages/solid/src/primitives/useSimulateContract.ts
@@ -1,0 +1,121 @@
+import type {
+  Config,
+  ResolvedRegister,
+  SimulateContractErrorType,
+} from '@wagmi/core'
+import type { ConfigParameter } from '@wagmi/core/internal'
+import {
+  type SimulateContractData,
+  type SimulateContractOptions,
+  simulateContractQueryOptions,
+} from '@wagmi/core/query'
+import type { Accessor } from 'solid-js'
+import { createMemo } from 'solid-js'
+import type { Abi, ContractFunctionArgs, ContractFunctionName } from 'viem'
+import { type UseQueryReturnType, useQuery } from '../utils/query.js'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+import { useConnection } from './useConnection.js'
+
+/** https://wagmi.sh/solid/api/primitives/useSimulateContract */
+export function useSimulateContract<
+  const abi extends Abi | readonly unknown[],
+  functionName extends ContractFunctionName<abi, 'nonpayable' | 'payable'>,
+  const args extends ContractFunctionArgs<
+    abi,
+    'nonpayable' | 'payable',
+    functionName
+  >,
+  config extends Config = ResolvedRegister['config'],
+  chainId extends config['chains'][number]['id'] | undefined = undefined,
+  selectData = SimulateContractData<abi, functionName, args, config, chainId>,
+>(
+  parameters: useSimulateContract.Parameters<
+    abi,
+    functionName,
+    args,
+    config,
+    chainId,
+    selectData
+  > = () => ({}) as any,
+): useSimulateContract.ReturnType<
+  abi,
+  functionName,
+  args,
+  config,
+  chainId,
+  selectData
+> {
+  const config = useConfig(parameters)
+  const connection = useConnection()
+  const chainId = useChainId(() => ({ config: config() }))
+  const options = createMemo(() =>
+    simulateContractQueryOptions(config(), {
+      ...(parameters() as any),
+      account: parameters().account ?? connection().address,
+      chainId: parameters().chainId ?? chainId(),
+      connector: parameters().connector ?? connection().connector,
+    }),
+  )
+  return useQuery(options) as any
+}
+
+export namespace useSimulateContract {
+  export type Parameters<
+    abi extends Abi | readonly unknown[] = Abi,
+    functionName extends ContractFunctionName<
+      abi,
+      'nonpayable' | 'payable'
+    > = ContractFunctionName<abi, 'nonpayable' | 'payable'>,
+    args extends ContractFunctionArgs<
+      abi,
+      'nonpayable' | 'payable',
+      functionName
+    > = ContractFunctionArgs<abi, 'nonpayable' | 'payable', functionName>,
+    config extends Config = Config,
+    chainId extends config['chains'][number]['id'] | undefined = undefined,
+    selectData = SimulateContractData<abi, functionName, args, config, chainId>,
+  > = Accessor<
+    SolidParameters<abi, functionName, args, config, chainId, selectData>
+  >
+
+  export type ReturnType<
+    abi extends Abi | readonly unknown[] = Abi,
+    functionName extends ContractFunctionName<
+      abi,
+      'nonpayable' | 'payable'
+    > = ContractFunctionName<abi, 'nonpayable' | 'payable'>,
+    args extends ContractFunctionArgs<
+      abi,
+      'nonpayable' | 'payable',
+      functionName
+    > = ContractFunctionArgs<abi, 'nonpayable' | 'payable', functionName>,
+    config extends Config = Config,
+    chainId extends config['chains'][number]['id'] | undefined = undefined,
+    selectData = SimulateContractData<abi, functionName, args, config, chainId>,
+  > = UseQueryReturnType<selectData, SimulateContractErrorType>
+
+  export type SolidParameters<
+    abi extends Abi | readonly unknown[] = Abi,
+    functionName extends ContractFunctionName<
+      abi,
+      'nonpayable' | 'payable'
+    > = ContractFunctionName<abi, 'nonpayable' | 'payable'>,
+    args extends ContractFunctionArgs<
+      abi,
+      'nonpayable' | 'payable',
+      functionName
+    > = ContractFunctionArgs<abi, 'nonpayable' | 'payable', functionName>,
+    config extends Config = Config,
+    chainId extends config['chains'][number]['id'] | undefined = undefined,
+    selectData = SimulateContractData<abi, functionName, args, config, chainId>,
+  > = SimulateContractOptions<
+    abi,
+    functionName,
+    args,
+    config,
+    chainId,
+    selectData
+  > &
+    ConfigParameter<config>
+}

--- a/packages/solid/src/primitives/useWatchContractEvent.test-d.ts
+++ b/packages/solid/src/primitives/useWatchContractEvent.test-d.ts
@@ -1,0 +1,123 @@
+import { createConfig, http, webSocket } from '@wagmi/core'
+import { mainnet, optimism } from '@wagmi/core/chains'
+import { abi } from '@wagmi/test'
+import { expectTypeOf, test } from 'vitest'
+
+import { useWatchContractEvent } from './useWatchContractEvent.js'
+
+test('default', () => {
+  useWatchContractEvent(() => ({
+    address: '0x',
+    abi: abi.erc20,
+    eventName: 'Transfer',
+    poll: false,
+    args: {
+      from: '0x',
+      to: '0x',
+    },
+    onLogs(logs) {
+      expectTypeOf(logs[0]!.eventName).toEqualTypeOf<'Transfer'>()
+      expectTypeOf(logs[0]!.args).toEqualTypeOf<{
+        from?: `0x${string}` | undefined
+        to?: `0x${string}` | undefined
+        value?: bigint | undefined
+      }>()
+    },
+  }))
+})
+
+test('behavior: no eventName', () => {
+  useWatchContractEvent(() => ({
+    address: '0x',
+    abi: abi.erc20,
+    args: {
+      // TODO: Figure out why this is not working
+      // @ts-ignore
+      from: '0x',
+      to: '0x',
+    },
+    onLogs(logs) {
+      expectTypeOf(logs[0]!.eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+      expectTypeOf(logs[0]!.args).toEqualTypeOf<
+        | {
+            from?: `0x${string}` | undefined
+            to?: `0x${string}` | undefined
+            value?: bigint | undefined
+          }
+        | {
+            owner?: `0x${string}` | undefined
+            spender?: `0x${string}` | undefined
+            value?: bigint | undefined
+          }
+      >()
+    },
+  }))
+})
+
+test('differing transports', () => {
+  const config = createConfig({
+    chains: [mainnet, optimism],
+    transports: {
+      [mainnet.id]: http(),
+      [optimism.id]: webSocket(),
+    },
+  })
+
+  type Result = useWatchContractEvent.SolidParameters<
+    typeof abi.erc20,
+    'Transfer' | 'Approval',
+    true,
+    typeof config,
+    typeof mainnet.id | typeof optimism.id
+  >
+  expectTypeOf<Result['poll']>().toEqualTypeOf<boolean | undefined>()
+  useWatchContractEvent(() => ({
+    config,
+    poll: false,
+    address: '0x',
+    abi: abi.erc20,
+    onLogs() {},
+  }))
+
+  type Result2 = useWatchContractEvent.SolidParameters<
+    typeof abi.erc20,
+    'Transfer' | 'Approval',
+    true,
+    typeof config,
+    typeof mainnet.id
+  >
+  expectTypeOf<Result2['poll']>().toEqualTypeOf<true | undefined>()
+  useWatchContractEvent(() => ({
+    config,
+    chainId: mainnet.id,
+    poll: true,
+    address: '0x',
+    abi: abi.erc20,
+    onLogs() {},
+  }))
+
+  type Result3 = useWatchContractEvent.SolidParameters<
+    typeof abi.erc20,
+    'Transfer' | 'Approval',
+    true,
+    typeof config,
+    typeof optimism.id
+  >
+  expectTypeOf<Result3['poll']>().toEqualTypeOf<boolean | undefined>()
+  useWatchContractEvent(() => ({
+    config,
+    chainId: optimism.id,
+    poll: true,
+    address: '0x',
+    abi: abi.erc20,
+    onLogs() {},
+  }))
+  useWatchContractEvent(() => ({
+    config,
+    chainId: optimism.id,
+    poll: false,
+    address: '0x',
+    abi: abi.erc20,
+    onLogs() {},
+  }))
+})

--- a/packages/solid/src/primitives/useWatchContractEvent.test-d.ts
+++ b/packages/solid/src/primitives/useWatchContractEvent.test-d.ts
@@ -5,53 +5,62 @@ import { expectTypeOf, test } from 'vitest'
 
 import { useWatchContractEvent } from './useWatchContractEvent.js'
 
+type LogsOf<parameters> = parameters extends {
+  onLogs?: ((logs: infer logs) => void) | undefined
+}
+  ? logs
+  : never
+
 test('default', () => {
-  useWatchContractEvent(() => ({
-    address: '0x',
-    abi: abi.erc20,
-    eventName: 'Transfer',
-    poll: false,
-    args: {
-      from: '0x',
-      to: '0x',
-    },
-    onLogs(logs) {
-      expectTypeOf(logs[0]!.eventName).toEqualTypeOf<'Transfer'>()
-      expectTypeOf(logs[0]!.args).toEqualTypeOf<{
-        from?: `0x${string}` | undefined
-        to?: `0x${string}` | undefined
-        value?: bigint | undefined
-      }>()
-    },
-  }))
+  type Parameters = useWatchContractEvent.SolidParameters<
+    typeof abi.erc20,
+    'Transfer'
+  >
+  const logs = null as unknown as LogsOf<Parameters>
+  const eventName: 'Transfer' = logs[0]!.eventName
+  const args: {
+    from?: `0x${string}` | undefined
+    to?: `0x${string}` | undefined
+    value?: bigint | undefined
+  } = logs[0]!.args
+
+  expectTypeOf(eventName).toEqualTypeOf<'Transfer'>()
+  expectTypeOf(args).toEqualTypeOf<{
+    from?: `0x${string}` | undefined
+    to?: `0x${string}` | undefined
+    value?: bigint | undefined
+  }>()
 })
 
 test('behavior: no eventName', () => {
-  useWatchContractEvent(() => ({
-    address: '0x',
-    abi: abi.erc20,
-    args: {
-      // TODO: Figure out why this is not working
-      // @ts-ignore
-      from: '0x',
-      to: '0x',
-    },
-    onLogs(logs) {
-      expectTypeOf(logs[0]!.eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
-      expectTypeOf(logs[0]!.args).toEqualTypeOf<
-        | {
-            from?: `0x${string}` | undefined
-            to?: `0x${string}` | undefined
-            value?: bigint | undefined
-          }
-        | {
-            owner?: `0x${string}` | undefined
-            spender?: `0x${string}` | undefined
-            value?: bigint | undefined
-          }
-      >()
-    },
-  }))
+  type Parameters = useWatchContractEvent.SolidParameters<typeof abi.erc20>
+  const logs = null as unknown as LogsOf<Parameters>
+  const eventName: 'Transfer' | 'Approval' = logs[0]!.eventName
+  const args:
+    | {
+        from?: `0x${string}` | undefined
+        to?: `0x${string}` | undefined
+        value?: bigint | undefined
+      }
+    | {
+        owner?: `0x${string}` | undefined
+        spender?: `0x${string}` | undefined
+        value?: bigint | undefined
+      } = logs[0]!.args
+
+  expectTypeOf(eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+  expectTypeOf(args).toEqualTypeOf<
+    | {
+        from?: `0x${string}` | undefined
+        to?: `0x${string}` | undefined
+        value?: bigint | undefined
+      }
+    | {
+        owner?: `0x${string}` | undefined
+        spender?: `0x${string}` | undefined
+        value?: bigint | undefined
+      }
+  >()
 })
 
 test('differing transports', () => {

--- a/packages/solid/src/primitives/useWatchContractEvent.test.ts
+++ b/packages/solid/src/primitives/useWatchContractEvent.test.ts
@@ -1,0 +1,89 @@
+import { connect, disconnect, readContract, writeContract } from '@wagmi/core'
+import {
+  abi,
+  accounts,
+  address,
+  config,
+  testClient,
+  transactionHashRegex,
+  wait,
+} from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { createWalletClient, erc20Abi, http, parseEther } from 'viem'
+import type { WatchEventOnLogsParameter } from 'viem/actions'
+import { expect, test, vi } from 'vitest'
+
+import { useWatchContractEvent } from './useWatchContractEvent.js'
+
+const connector = config.connectors[0]!
+
+test('default', async () => {
+  const data = await connect(config, { connector })
+  const connectedAddress = data.accounts[0]
+
+  // impersonate usdc holder account and transfer usdc to connected account
+  await testClient.mainnet.impersonateAccount({ address: address.usdcHolder })
+  await testClient.mainnet.setBalance({
+    address: address.usdcHolder,
+    value: 10000000000000000000000n,
+  })
+  await createWalletClient({
+    account: address.usdcHolder,
+    chain: testClient.mainnet.chain,
+    transport: http(),
+  }).writeContract({
+    address: address.usdc,
+    abi: abi.erc20,
+    functionName: 'transfer',
+    args: [connectedAddress, parseEther('10', 'gwei')],
+  })
+  await testClient.mainnet.mine({ blocks: 1 })
+  await testClient.mainnet.stopImpersonatingAccount({
+    address: address.usdcHolder,
+  })
+
+  const balance = await readContract(config, {
+    address: address.usdc,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [connectedAddress],
+  })
+  expect(balance).toBeGreaterThan(0n)
+
+  // start watching transfer events
+  let logs: WatchEventOnLogsParameter = []
+  renderPrimitive(() =>
+    useWatchContractEvent(() => ({
+      address: address.usdc,
+      abi: abi.erc20,
+      eventName: 'Transfer',
+      onLogs(next) {
+        logs = logs.concat(next)
+      },
+    })),
+  )
+
+  await writeContract(config, {
+    address: address.usdc,
+    abi: abi.erc20,
+    functionName: 'transfer',
+    args: [accounts[1], parseEther('1', 'gwei')],
+  })
+
+  await writeContract(config, {
+    address: address.usdc,
+    abi: abi.erc20,
+    functionName: 'transfer',
+    args: [accounts[3], parseEther('1', 'gwei')],
+  })
+
+  await testClient.mainnet.mine({ blocks: 1 })
+  await testClient.mainnet.mine({ blocks: 1 })
+  await wait(1000) // wait for events to be emitted
+
+  expect(logs.length).toBe(2)
+  expect(logs[0]?.transactionHash).toMatch(transactionHashRegex)
+
+  await disconnect(config, { connector })
+  await wait(500)
+})

--- a/packages/solid/src/primitives/useWatchContractEvent.test.ts
+++ b/packages/solid/src/primitives/useWatchContractEvent.test.ts
@@ -11,7 +11,7 @@ import {
 import { renderPrimitive } from '@wagmi/test/solid'
 import { createWalletClient, erc20Abi, http, parseEther } from 'viem'
 import type { WatchEventOnLogsParameter } from 'viem/actions'
-import { expect, test, vi } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { useWatchContractEvent } from './useWatchContractEvent.js'
 

--- a/packages/solid/src/primitives/useWatchContractEvent.ts
+++ b/packages/solid/src/primitives/useWatchContractEvent.ts
@@ -61,9 +61,7 @@ export namespace useWatchContractEvent {
     config extends Config = Config,
     chainId extends
       config['chains'][number]['id'] = config['chains'][number]['id'],
-  > = Accessor<
-    SolidParameters<abi, eventName, strict, config, chainId>
-  >
+  > = Accessor<SolidParameters<abi, eventName, strict, config, chainId>>
 
   export type ReturnType = void
 

--- a/packages/solid/src/primitives/useWatchContractEvent.ts
+++ b/packages/solid/src/primitives/useWatchContractEvent.ts
@@ -1,0 +1,84 @@
+import {
+  type Config,
+  type ResolvedRegister,
+  type WatchContractEventParameters,
+  watchContractEvent,
+} from '@wagmi/core'
+import type {
+  ConfigParameter,
+  EnabledParameter,
+  UnionCompute,
+  UnionExactPartial,
+} from '@wagmi/core/internal'
+import { type Accessor, createEffect, onCleanup } from 'solid-js'
+import type { Abi, ContractEventName } from 'viem'
+import { useChainId } from './useChainId.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useWatchContractEvent */
+export function useWatchContractEvent<
+  const abi extends Abi | readonly unknown[],
+  eventName extends ContractEventName<abi>,
+  strict extends boolean | undefined = undefined,
+  config extends Config = ResolvedRegister['config'],
+  chainId extends
+    config['chains'][number]['id'] = config['chains'][number]['id'],
+>(
+  parameters: useWatchContractEvent.Parameters<
+    abi,
+    eventName,
+    strict,
+    config,
+    chainId
+  > = () => ({}) as any,
+): useWatchContractEvent.ReturnType {
+  const config = useConfig(parameters)
+  const configChainId = useChainId(() => ({ config: config() }))
+  createEffect(() => {
+    const {
+      config: _,
+      chainId = configChainId(),
+      enabled = true,
+      onLogs,
+      ...rest
+    } = parameters()
+    if (!enabled) return
+    if (!onLogs) return
+    const unwatch = watchContractEvent(config(), {
+      ...(rest as any),
+      chainId,
+      onLogs,
+    })
+    onCleanup(() => unwatch())
+  })
+}
+
+export namespace useWatchContractEvent {
+  export type Parameters<
+    abi extends Abi | readonly unknown[] = Abi,
+    eventName extends ContractEventName<abi> = ContractEventName<abi>,
+    strict extends boolean | undefined = undefined,
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+  > = Accessor<
+    SolidParameters<abi, eventName, strict, config, chainId>
+  >
+
+  export type ReturnType = void
+
+  export type SolidParameters<
+    abi extends Abi | readonly unknown[] = Abi,
+    eventName extends ContractEventName<abi> = ContractEventName<abi>,
+    strict extends boolean | undefined = undefined,
+    config extends Config = Config,
+    chainId extends
+      config['chains'][number]['id'] = config['chains'][number]['id'],
+  > = UnionCompute<
+    UnionExactPartial<
+      WatchContractEventParameters<abi, eventName, strict, config, chainId>
+    > &
+      ConfigParameter<config> &
+      EnabledParameter
+  >
+}

--- a/packages/solid/src/primitives/useWriteContract.test-d.ts
+++ b/packages/solid/src/primitives/useWriteContract.test-d.ts
@@ -1,0 +1,66 @@
+import type { WriteContractErrorType } from '@wagmi/core'
+import { abi } from '@wagmi/test'
+import type { Abi, Address, Hash } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+
+import { useWriteContract } from './useWriteContract.js'
+
+const contextValue = { foo: 'bar' } as const
+
+test('context', () => {
+  const writeContract = useWriteContract(() => ({
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+          abi: Abi
+          functionName: string
+          args?: readonly unknown[] | undefined
+        }>()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<WriteContractErrorType>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+          abi: Abi
+          functionName: string
+          args?: readonly unknown[] | undefined
+        }>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Hash>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue>()
+
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+          abi: Abi
+          functionName: string
+          args?: readonly unknown[] | undefined
+        }>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Hash | undefined>()
+        expectTypeOf(error).toEqualTypeOf<WriteContractErrorType | null>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+          abi: Abi
+          functionName: string
+          args?: readonly unknown[] | undefined
+        }>()
+      },
+    },
+  }))
+
+  expectTypeOf(writeContract.data).toEqualTypeOf<Hash | undefined>()
+  expectTypeOf(
+    writeContract.error,
+  ).toEqualTypeOf<WriteContractErrorType | null>()
+  expectTypeOf(writeContract.context).toEqualTypeOf<
+    typeof contextValue | undefined
+  >()
+})

--- a/packages/solid/src/primitives/useWriteContract.test-d.ts
+++ b/packages/solid/src/primitives/useWriteContract.test-d.ts
@@ -1,6 +1,5 @@
 import type { WriteContractErrorType } from '@wagmi/core'
-import { abi } from '@wagmi/test'
-import type { Abi, Address, Hash } from 'viem'
+import type { Abi, Hash } from 'viem'
 import { expectTypeOf, test } from 'vitest'
 
 import { useWriteContract } from './useWriteContract.js'

--- a/packages/solid/src/primitives/useWriteContract.test.ts
+++ b/packages/solid/src/primitives/useWriteContract.test.ts
@@ -1,0 +1,25 @@
+import { connect, disconnect } from '@wagmi/core'
+import { abi, address, config } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { expect, test, vi } from 'vitest'
+
+import { useWriteContract } from './useWriteContract.js'
+
+const connector = config.connectors[0]!
+
+test('default', async () => {
+  await connect(config, { connector })
+
+  const { result } = renderPrimitive(() => useWriteContract())
+
+  result.mutate({
+    abi: abi.wagmiMintExample,
+    address: address.wagmiMintExample,
+    functionName: 'mint',
+  })
+  await vi.waitUntil(() => result.isSuccess, { timeout: 5_000 })
+
+  expect(result.data).toBeDefined()
+
+  await disconnect(config, { connector })
+})

--- a/packages/solid/src/primitives/useWriteContract.ts
+++ b/packages/solid/src/primitives/useWriteContract.ts
@@ -1,0 +1,78 @@
+import type {
+  Config,
+  ResolvedRegister,
+  WriteContractErrorType,
+} from '@wagmi/core'
+import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import {
+  type WriteContractData,
+  type WriteContractMutate,
+  type WriteContractMutateAsync,
+  type WriteContractOptions,
+  type WriteContractVariables,
+  writeContractMutationOptions,
+} from '@wagmi/core/query'
+import type { Accessor } from 'solid-js'
+import { mergeProps } from 'solid-js'
+import type { Abi } from 'viem'
+import { type UseMutationReturnType, useMutation } from '../utils/query.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useWriteContract */
+export function useWriteContract<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: useWriteContract.Parameters<config, context> = () => ({}),
+): useWriteContract.ReturnType<config, context> {
+  const config = useConfig(parameters)
+  const mutation = useMutation(() =>
+    writeContractMutationOptions(config(), parameters()),
+  )
+  type Return = useWriteContract.ReturnType<config, context>
+  return mergeProps(mutation, {
+    get writeContract() {
+      return mutation.mutate as Return['mutate']
+    },
+    get writeContractAsync() {
+      return mutation.mutateAsync as Return['mutateAsync']
+    },
+  }) as unknown as Return
+}
+
+export namespace useWriteContract {
+  export type Parameters<
+    config extends Config = Config,
+    context = unknown,
+  > = Accessor<SolidParameters<config, context>>
+
+  export type ReturnType<
+    config extends Config = Config,
+    context = unknown,
+  > = Compute<
+    UseMutationReturnType<
+      WriteContractData,
+      WriteContractErrorType,
+      WriteContractVariables<
+        Abi,
+        string,
+        readonly unknown[],
+        config,
+        config['chains'][number]['id']
+      >,
+      context,
+      WriteContractMutate<config, context>,
+      WriteContractMutateAsync<config, context>
+    > & {
+      /** @deprecated use `mutate` instead */
+      writeContract: WriteContractMutate<config, context>
+      /** @deprecated use `mutateAsync` instead */
+      writeContractAsync: WriteContractMutateAsync<config, context>
+    }
+  >
+
+  export type SolidParameters<
+    config extends Config = Config,
+    context = unknown,
+  > = Compute<ConfigParameter<config> & WriteContractOptions<config, context>>
+}

--- a/packages/solid/src/primitives/useWriteContractSync.test-d.ts
+++ b/packages/solid/src/primitives/useWriteContractSync.test-d.ts
@@ -1,0 +1,54 @@
+import type { WriteContractSyncErrorType } from '@wagmi/core'
+import { abi } from '@wagmi/test'
+import type { Abi, TransactionReceipt } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+
+import { useWriteContractSync } from './useWriteContractSync.js'
+
+const contextValue = { foo: 'bar' } as const
+
+test('context', () => {
+  const writeContractSync = useWriteContractSync(() => ({
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toMatchTypeOf<{
+          chainId?: number | undefined
+          abi: Abi
+          functionName: string
+          args?: readonly unknown[] | undefined
+        }>()
+        return contextValue
+      },
+      onError(error, _variables, context) {
+        expectTypeOf(error).toEqualTypeOf<WriteContractSyncErrorType>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+      },
+      onSuccess(data, _variables, context) {
+        expectTypeOf(data).toEqualTypeOf<TransactionReceipt>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue>()
+      },
+      onSettled(data, error, _variables, context) {
+        expectTypeOf(data).toEqualTypeOf<TransactionReceipt | undefined>()
+        expectTypeOf(error).toEqualTypeOf<WriteContractSyncErrorType | null>()
+        expectTypeOf(context).toEqualTypeOf<typeof contextValue | undefined>()
+      },
+    },
+  }))
+
+  expectTypeOf(writeContractSync.data).toEqualTypeOf<
+    TransactionReceipt | undefined
+  >()
+  expectTypeOf(
+    writeContractSync.error,
+  ).toEqualTypeOf<WriteContractSyncErrorType | null>()
+  expectTypeOf(writeContractSync.context).toEqualTypeOf<
+    typeof contextValue | undefined
+  >()
+
+  writeContractSync.mutate({
+    address: '0x',
+    abi: abi.wagmiMintExample,
+    functionName: 'mint',
+    chainId: 1,
+  })
+})

--- a/packages/solid/src/primitives/useWriteContractSync.test.ts
+++ b/packages/solid/src/primitives/useWriteContractSync.test.ts
@@ -1,0 +1,33 @@
+import { connect, disconnect } from '@wagmi/core'
+import { abi, address, config, testClient, wait } from '@wagmi/test'
+import { renderPrimitive } from '@wagmi/test/solid'
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import { useWriteContractSync } from './useWriteContractSync.js'
+
+const connector = config.connectors[0]!
+
+beforeEach(async () => {
+  await disconnect(config).catch(() => {})
+})
+
+test('default', async () => {
+  await connect(config, { connector })
+
+  const { result } = renderPrimitive(() => useWriteContractSync())
+
+  result.mutate({
+    abi: abi.wagmiMintExample,
+    address: address.wagmiMintExample,
+    functionName: 'mint',
+  })
+  await wait(2_000)
+  await testClient.mainnet.mine({ blocks: 1 })
+  await vi.waitUntil(() => result.isSuccess, { timeout: 15_000 })
+
+  expect(result.data).toBeDefined()
+  expect(result.data?.status).toBe('success')
+  expect(result.data?.blockNumber).toBeDefined()
+
+  await disconnect(config, { connector })
+})

--- a/packages/solid/src/primitives/useWriteContractSync.ts
+++ b/packages/solid/src/primitives/useWriteContractSync.ts
@@ -1,0 +1,80 @@
+import type {
+  Config,
+  ResolvedRegister,
+  WriteContractSyncErrorType,
+} from '@wagmi/core'
+import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import {
+  type WriteContractSyncData,
+  type WriteContractSyncMutate,
+  type WriteContractSyncMutateAsync,
+  type WriteContractSyncOptions,
+  type WriteContractSyncVariables,
+  writeContractSyncMutationOptions,
+} from '@wagmi/core/query'
+import type { Accessor } from 'solid-js'
+import { mergeProps } from 'solid-js'
+import type { Abi } from 'viem'
+import { type UseMutationReturnType, useMutation } from '../utils/query.js'
+import { useConfig } from './useConfig.js'
+
+/** https://wagmi.sh/solid/api/primitives/useWriteContractSync */
+export function useWriteContractSync<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: useWriteContractSync.Parameters<config, context> = () => ({}),
+): useWriteContractSync.ReturnType<config, context> {
+  const config = useConfig(parameters)
+  const mutation = useMutation(() =>
+    writeContractSyncMutationOptions(config(), parameters()),
+  )
+  type Return = useWriteContractSync.ReturnType<config, context>
+  return mergeProps(mutation, {
+    get writeContractSync() {
+      return mutation.mutate as Return['mutate']
+    },
+    get writeContractSyncAsync() {
+      return mutation.mutateAsync as Return['mutateAsync']
+    },
+  }) as unknown as Return
+}
+
+export namespace useWriteContractSync {
+  export type Parameters<
+    config extends Config = Config,
+    context = unknown,
+  > = Accessor<SolidParameters<config, context>>
+
+  export type ReturnType<
+    config extends Config = Config,
+    context = unknown,
+  > = Compute<
+    UseMutationReturnType<
+      WriteContractSyncData,
+      WriteContractSyncErrorType,
+      WriteContractSyncVariables<
+        Abi,
+        string,
+        readonly unknown[],
+        config,
+        config['chains'][number]['id']
+      >,
+      context,
+      WriteContractSyncMutate<config, context>,
+      WriteContractSyncMutateAsync<config, context>
+    > & {
+      /** @deprecated use `mutate` instead */
+      writeContractSync: WriteContractSyncMutate<config, context>
+      /** @deprecated use `mutateAsync` instead */
+      writeContractSyncAsync: WriteContractSyncMutateAsync<config, context>
+    }
+  >
+
+  export type SolidParameters<
+    config extends Config = Config,
+    context = unknown,
+  > = Compute<
+    ConfigParameter<config> & WriteContractSyncOptions<config, context>
+  >
+}

--- a/packages/vue/src/nuxt/module.ts
+++ b/packages/vue/src/nuxt/module.ts
@@ -17,9 +17,12 @@ export const wagmiModule: NuxtModule<WagmiModuleOptions> =
       const { resolve } = createResolver(import.meta.url)
 
       // Add types
-      nuxt.hook('prepare:types', ({ references }) => {
-        references.push({ types: '@wagmi/vue/nuxt' })
-      })
+      nuxt.hook(
+        'prepare:types',
+        ({ references }: { references: { types: string }[] }) => {
+          references.push({ types: '@wagmi/vue/nuxt' })
+        },
+      )
 
       // Add auto imports
       const composables = resolve('./runtime/composables')

--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -1225,7 +1225,23 @@ export function getSidebar() {
             text: 'useDisconnect',
             link: '/solid/api/primitives/useDisconnect',
           },
+          {
+            text: 'useInfiniteReadContracts',
+            link: '/solid/api/primitives/useInfiniteReadContracts',
+          },
+          {
+            text: 'useReadContract',
+            link: '/solid/api/primitives/useReadContract',
+          },
+          {
+            text: 'useReadContracts',
+            link: '/solid/api/primitives/useReadContracts',
+          },
           { text: 'useReconnect', link: '/solid/api/primitives/useReconnect' },
+          {
+            text: 'useSimulateContract',
+            link: '/solid/api/primitives/useSimulateContract',
+          },
           {
             text: 'useSwitchChain',
             link: '/solid/api/primitives/useSwitchChain',
@@ -1237,6 +1253,14 @@ export function getSidebar() {
           {
             text: 'useWatchBlockNumber',
             link: '/solid/api/primitives/useWatchBlockNumber',
+          },
+          {
+            text: 'useWatchContractEvent',
+            link: '/solid/api/primitives/useWatchContractEvent',
+          },
+          {
+            text: 'useWriteContract',
+            link: '/solid/api/primitives/useWriteContract',
           },
         ],
       },

--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -1262,6 +1262,10 @@ export function getSidebar() {
             text: 'useWriteContract',
             link: '/solid/api/primitives/useWriteContract',
           },
+          {
+            text: 'useWriteContractSync',
+            link: '/solid/api/primitives/useWriteContractSync',
+          },
         ],
       },
       {

--- a/site/solid/api/primitives/useInfiniteReadContracts.md
+++ b/site/solid/api/primitives/useInfiniteReadContracts.md
@@ -1,0 +1,119 @@
+---
+title: useInfiniteReadContracts
+description: Primitive for calling multiple read methods on a contract with "infinite scroll"/"fetch more" support.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const includeInfiniteQueryOptions = true
+const TPageParam = 'number'
+const TData = 'InfiniteReadContractsData'
+const TError = 'ReadContractsErrorType'
+</script>
+
+# useInfiniteReadContracts
+
+Primitive for calling multiple contract read-only methods with "infinite scrolling"/"fetch more" support.
+
+## Import
+
+```ts
+import { useInfiniteReadContracts } from '@wagmi/solid'
+```
+
+## Usage
+
+The example below shows how to fetch a set of [mloot](https://etherscan.io/address/0x1dfe7ca09e99d10835bf73044a23b73fc20623df) attributes (chestwear, footwear, and handwear) with "fetch more" support.
+
+::: code-group
+```tsx [index.tsx]
+import { useInfiniteReadContracts } from '@wagmi/solid'
+import { abi } from './abi'
+
+const mlootContractConfig = {
+  address: '0x1dfe7ca09e99d10835bf73044a23b73fc20623df',
+  abi,
+} as const
+
+function App() {
+  const result = useInfiniteReadContracts(() => ({
+    cacheKey: 'mlootAttributes',
+    contracts(pageParam) {
+      const args = [pageParam] as const
+      return [
+        { ...mlootContractConfig, functionName: 'getChest', args },
+        { ...mlootContractConfig, functionName: 'getFoot', args },
+        { ...mlootContractConfig, functionName: 'getHand', args },
+      ]
+    },
+    query: {
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage, _allPages, lastPageParam) => {
+        return lastPageParam + 1
+      },
+    },
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+In the above example, we are setting a few things:
+
+- [`cacheKey`](#cachekey): A unique key to store the data in the cache.
+- [`query.initialPageParam`](#initialpageparam): An initial page parameter to use when fetching the first set of contracts.
+- [`query.getNextPageParam`](#getnextpageparam): A function that returns the next page parameter to use when fetching the next set of contracts.
+- [`contracts`](#contracts): A function that provides `pageParam` (derived from the above) as an argument and expects to return an array of contracts.
+
+## Parameters
+
+```ts
+import { useInfiniteReadContracts } from '@wagmi/solid'
+
+useInfiniteReadContracts.Parameters
+useInfiniteReadContracts.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useInfiniteReadContracts(() => ({
+  cacheKey: 'mlootAttributes',
+  contracts(pageParam) { ... },
+  query: { ... },
+}))
+```
+
+### cacheKey
+
+`string`
+
+A unique key to store the data in the cache.
+
+### contracts
+
+`(pageParam: TPageParam) => Contract[]`
+
+A function that provides `pageParam` (derived from the above) as an argument and expects to return an array of contracts. Each contract includes `abi`, `address`, `functionName`, `args`, and optional `chainId`.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useInfiniteReadContracts } from '@wagmi/solid'
+
+useInfiniteReadContracts.ReturnType
+```
+
+<!--@include: @shared/query-result.md-->
+
+## Action
+
+- [`readContracts`](/core/api/actions/readContracts)

--- a/site/solid/api/primitives/useInfiniteReadContracts.md
+++ b/site/solid/api/primitives/useInfiniteReadContracts.md
@@ -114,6 +114,10 @@ useInfiniteReadContracts.ReturnType
 
 <!--@include: @shared/query-result.md-->
 
+## Type Inference
+
+With each contract ABI returned from [`contracts`](#contracts) setup correctly, TypeScript will infer the correct types for each contract's `functionName`, `args`, and the paginated return type. See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
 ## Action
 
 - [`readContracts`](/core/api/actions/readContracts)

--- a/site/solid/api/primitives/useReadContract.md
+++ b/site/solid/api/primitives/useReadContract.md
@@ -1,0 +1,138 @@
+---
+title: useReadContract
+description: Primitive for calling a read-only function on a contract, and returning the response.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'readContract'
+const typeName = 'ReadContract'
+const TData = 'ReadContractData'
+const TError = 'ReadContractErrorType'
+</script>
+
+# useReadContract
+
+Primitive for calling a **read-only** function on a contract, and returning the response.
+
+A **read-only** function (constant function) on a Solidity contract is denoted by a pure or view keyword. They can only read the state of the contract, and cannot make any changes to it. Since read-only methods do not change the state of the contract, they do not require any gas to be executed, and can be called by any user without the need to pay for gas.
+
+## Import
+
+```ts
+import { useReadContract } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useReadContract } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  const result = useReadContract(() => ({
+    abi,
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    functionName: 'totalSupply',
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useReadContract } from '@wagmi/solid'
+
+useReadContract.Parameters
+useReadContract.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useReadContract(() => ({
+  abi,
+  address: '0x...',
+  functionName: 'totalSupply',
+  // other parameters...
+}))
+```
+
+### abi
+
+`Abi | undefined`
+
+The contract's ABI. Check out the [TypeScript docs](/solid/typescript#const-assert-abis-typed-data) for how to set up ABIs for maximum type inference and safety.
+
+### address
+
+`Address | undefined`
+
+The contract's address.
+
+### args
+
+`readonly unknown[] | undefined`
+
+- Arguments to pass when calling the contract.
+- Inferred from [`abi`](#abi) and [`functionName`](#functionname).
+
+### blockNumber
+
+`bigint | undefined`
+
+Block number to call contract at.
+
+### blockTag
+
+`'latest' | 'earliest' | 'pending' | 'safe' | 'finalized' | undefined`
+
+Block tag to call contract at.
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+### functionName
+
+`string | undefined`
+
+- Function to call on the contract.
+- Inferred from [`abi`](#abi).
+
+### scopeKey
+
+`string | undefined`
+
+Scopes the cache to a given context. Primitives that have identical context will share the same cache.
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useReadContract } from '@wagmi/solid'
+
+useReadContract.ReturnType
+```
+
+The return type's [`data`](#data) property is inferrable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/solid/typescript#const-assert-abis-typed-data) for more info.
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`readContract`](/core/api/actions/readContract)

--- a/site/solid/api/primitives/useReadContract.md
+++ b/site/solid/api/primitives/useReadContract.md
@@ -131,6 +131,10 @@ The return type's [`data`](#data) property is inferrable via the combination of 
 
 <!--@include: @shared/query-result.md-->
 
+## Type Inference
+
+With [`abi`](#abi) setup correctly, TypeScript will infer the correct types for [`functionName`](#functionname), [`args`](#args), and the return type. See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
 <!--@include: @shared/query-imports.md-->
 
 ## Action

--- a/site/solid/api/primitives/useReadContracts.md
+++ b/site/solid/api/primitives/useReadContracts.md
@@ -1,0 +1,149 @@
+---
+title: useReadContracts
+description: Primitive for calling multiple read methods on a contract.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'readContracts'
+const typeName = 'ReadContracts'
+const TData = 'ReadContractsData'
+const TError = 'ReadContractsErrorType'
+</script>
+
+# useReadContracts
+
+Primitive for calling multiple read methods on a contract.
+
+## Import
+
+```ts
+import { useReadContracts } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useReadContracts } from '@wagmi/solid'
+
+const wagmigotchiContract = {
+  address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  abi: wagmigotchiABI,
+} as const
+const mlootContract = {
+  address: '0x1dfe7ca09e99d10835bf73044a23b73fc20623df',
+  abi: mlootABI,
+} as const
+
+function App() {
+  const result = useReadContracts(() => ({
+    contracts: [
+      {
+        ...wagmigotchiContract,
+        functionName: 'getAlive',
+      },
+      {
+        ...wagmigotchiContract,
+        functionName: 'getBoredom',
+      },
+      {
+        ...mlootContract,
+        functionName: 'getChest',
+        args: [69],
+      },
+      {
+        ...mlootContract,
+        functionName: 'getWaist',
+        args: [69],
+      },
+    ],
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useReadContracts } from '@wagmi/solid'
+
+useReadContracts.Parameters
+useReadContracts.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useReadContracts(() => ({
+  contracts: [...],
+  // other parameters...
+}))
+```
+
+### contracts
+
+`readonly Contract[]`
+
+Set of contracts to call. Each contract includes `abi`, `address`, `functionName`, `args`, and optional `chainId`.
+
+### allowFailure
+
+`boolean`
+
+Whether or not the primitive should throw if a call reverts. If set to `true` (default), and a call reverts, then `useReadContracts` will fail silently and its error will be logged in the results array. Defaults to `true`.
+
+### batchSize
+
+`number`
+
+The maximum size (in bytes) for each calldata chunk. Set to `0` to disable the size limit. Defaults to `1024`.
+
+### blockNumber
+
+`number`
+
+The block number to perform the read against.
+
+### blockTag
+
+`'latest' | 'earliest' | 'pending' | 'safe' | 'finalized' | undefined`
+
+Block tag to read against.
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+### multicallAddress
+
+`Address`
+
+Address of multicall contract.
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useReadContracts } from '@wagmi/solid'
+
+useReadContracts.ReturnType
+```
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`readContracts`](/core/api/actions/readContracts)

--- a/site/solid/api/primitives/useReadContracts.md
+++ b/site/solid/api/primitives/useReadContracts.md
@@ -142,6 +142,10 @@ useReadContracts.ReturnType
 
 <!--@include: @shared/query-result.md-->
 
+## Type Inference
+
+With each contract ABI in [`contracts`](#contracts) setup correctly, TypeScript will infer the correct types for each contract's `functionName`, `args`, and the return type. See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
 <!--@include: @shared/query-imports.md-->
 
 ## Action

--- a/site/solid/api/primitives/useSimulateContract.md
+++ b/site/solid/api/primitives/useSimulateContract.md
@@ -1,0 +1,168 @@
+---
+title: useSimulateContract
+description: Primitive for simulating/validating a contract interaction.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'simulateContract'
+const typeName = 'SimulateContract'
+const TData = 'SimulateContractData'
+const TError = 'SimulateContractErrorType'
+</script>
+
+# useSimulateContract
+
+Primitive for simulating/validating a contract interaction.
+
+## Import
+
+```ts
+import { useSimulateContract } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useSimulateContract } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  const result = useSimulateContract(() => ({
+    abi,
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    functionName: 'transferFrom',
+    args: [
+      '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+      123n,
+    ],
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+::: details Composing with `useWriteContract`
+
+`useSimulateContract` can be combined with [`useWriteContract`](/solid/api/primitives/useWriteContract) to reduce the amount of validation required by wallets.
+
+```tsx [index.tsx]
+import { useSimulateContract, useWriteContract } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  const { data } = useSimulateContract(() => ({
+    abi,
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    functionName: 'transferFrom',
+    args: [
+      '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+      '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+      123n,
+    ],
+  }))
+  const writeContract = useWriteContract()
+  const request = data?.request
+  // Call writeContract.mutate(request) when ready
+}
+```
+:::
+
+## Parameters
+
+```ts
+import { useSimulateContract } from '@wagmi/solid'
+
+useSimulateContract.Parameters
+useSimulateContract.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useSimulateContract(() => ({
+  abi,
+  address: '0x...',
+  functionName: 'transferFrom',
+  args: ['0x...', '0x...', 123n],
+  // other parameters...
+}))
+```
+
+### abi
+
+`Abi | undefined`
+
+The contract's ABI. Check out the [TypeScript docs](/solid/typescript#const-assert-abis-typed-data) for how to set up ABIs for maximum type inference and safety.
+
+### account
+
+`Account | undefined`
+
+Account to use when calling the contract (`msg.sender`). Throws if account is not found on [`connector`](#connector).
+
+### address
+
+`Address | undefined`
+
+The contract's address.
+
+### args
+
+`readonly unknown[] | undefined`
+
+- Arguments to pass when calling the contract.
+- Inferred from [`abi`](#abi) and [`functionName`](#functionname).
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+### connector
+
+`Connector | undefined`
+
+[Connector](/solid/api/connectors) to simulate transaction with.
+
+### functionName
+
+`string | undefined`
+
+- Function to call on the contract.
+- Inferred from [`abi`](#abi).
+
+### scopeKey
+
+`string | undefined`
+
+Scopes the cache to a given context. Primitives that have identical context will share the same cache.
+
+<!--@include: @shared/query-options.md-->
+
+## Return Type
+
+```ts
+import { useSimulateContract } from '@wagmi/solid'
+
+useSimulateContract.ReturnType
+```
+
+The return type's [`data`](#data) property is inferrable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/solid/typescript#const-assert-abis-typed-data) for more info.
+
+<!--@include: @shared/query-result.md-->
+
+<!--@include: @shared/query-imports.md-->
+
+## Action
+
+- [`simulateContract`](/core/api/actions/simulateContract)

--- a/site/solid/api/primitives/useSimulateContract.md
+++ b/site/solid/api/primitives/useSimulateContract.md
@@ -161,6 +161,10 @@ The return type's [`data`](#data) property is inferrable via the combination of 
 
 <!--@include: @shared/query-result.md-->
 
+## Type Inference
+
+With [`abi`](#abi) setup correctly, TypeScript will infer the correct types for [`functionName`](#functionname), [`args`](#args), and [`value`](#value). See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
 <!--@include: @shared/query-imports.md-->
 
 ## Action

--- a/site/solid/api/primitives/useWatchContractEvent.md
+++ b/site/solid/api/primitives/useWatchContractEvent.md
@@ -1,0 +1,160 @@
+---
+title: useWatchContractEvent
+description: Primitive that watches and returns emitted contract event logs.
+---
+
+# useWatchContractEvent
+
+Primitive that watches and returns emitted contract event logs.
+
+## Import
+
+```ts
+import { useWatchContractEvent } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useWatchContractEvent } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  useWatchContractEvent(() => ({
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    abi,
+    eventName: 'Transfer',
+    onLogs(logs) {
+      console.log('New logs!', logs)
+    },
+  }))
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useWatchContractEvent } from '@wagmi/solid'
+
+useWatchContractEvent.Parameters
+useWatchContractEvent.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+```ts
+useWatchContractEvent(() => ({
+  address: '0x...',
+  abi,
+  eventName: 'Transfer',
+  onLogs(logs) { ... },
+}))
+```
+
+### abi
+
+`Abi`
+
+The contract's ABI. Check out the [TypeScript docs](/solid/typescript#const-assert-abis-typed-data) for how to set up ABIs for maximum type inference and safety.
+
+### address
+
+`Address | undefined`
+
+The contract's address.
+
+### args
+
+`object | readonly unknown[] | undefined`
+
+- Arguments to pass when calling the contract.
+- Inferred from [`abi`](#abi) and [`eventName`](#eventname).
+
+### batch
+
+`boolean | undefined`
+
+- Whether or not the events should be batched on each invocation.
+- Defaults to `true`.
+
+### chainId
+
+`config['chains'][number]['id'] | undefined`
+
+ID of chain to use when fetching data.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+### enabled
+
+`boolean | undefined`
+
+- Whether or not to watch for events.
+- Defaults to `true`.
+
+### eventName
+
+`string`
+
+- Event to listen for the contract.
+- Inferred from [`abi`](#abi).
+
+### onError
+
+`((error: Error) => void) | undefined`
+
+Error thrown from getting the block number.
+
+### onLogs
+
+`(logs: Log[], prevLogs: Log[] | undefined) => void`
+
+Callback for when logs changes.
+
+### poll
+
+`boolean | undefined`
+
+- Whether or not to use a polling mechanism to check for new blocks instead of a WebSocket subscription.
+- Defaults to `false` for WebSocket Clients, and `true` for non-WebSocket Clients.
+
+### pollingInterval
+
+`number | undefined`
+
+- Polling frequency (in milliseconds).
+- Defaults to the [Config's `pollingInterval` config](/core/api/createConfig#pollinginterval).
+
+### strict
+
+`boolean | undefined`
+
+- Defaults to `false`.
+
+### syncConnectedChain
+
+`boolean | undefined`
+
+- Set up subscriber for connected chain changes.
+- Defaults to [`Config['syncConnectedChain']`](/core/api/createConfig#syncconnectedchain).
+
+## Return Type
+
+```ts
+import { useWatchContractEvent } from '@wagmi/solid'
+
+useWatchContractEvent.ReturnType
+```
+
+Primitive returns `void`.
+
+## Action
+
+- [`watchContractEvent`](/core/api/actions/watchContractEvent)

--- a/site/solid/api/primitives/useWatchContractEvent.md
+++ b/site/solid/api/primitives/useWatchContractEvent.md
@@ -155,6 +155,10 @@ useWatchContractEvent.ReturnType
 
 Primitive returns `void`.
 
+## Type Inference
+
+With [`abi`](#abi) setup correctly, TypeScript will infer the correct types for [`eventName`](#eventname), [`args`](#args), and [`onLogs`](#onlogs) parameters. See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
 ## Action
 
 - [`watchContractEvent`](/core/api/actions/watchContractEvent)

--- a/site/solid/api/primitives/useWriteContract.md
+++ b/site/solid/api/primitives/useWriteContract.md
@@ -1,0 +1,123 @@
+---
+title: useWriteContract
+description: Primitive for executing a write function on a contract.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'writeContract'
+const typeName = 'WriteContract'
+const mutate = 'writeContract'
+const TData = 'WriteContractData'
+const TError = 'WriteContractErrorType'
+const TVariables = 'WriteContractVariables'
+</script>
+
+# useWriteContract
+
+Primitive for executing a write function on a contract.
+
+A "write" function on a Solidity contract modifies the state of the blockchain. These types of functions require gas to be executed, hence a transaction is broadcasted in order to change the state.
+
+## Import
+
+```ts
+import { useWriteContract } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useWriteContract } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  const writeContract = useWriteContract()
+
+  const handleTransfer = () => {
+    writeContract.mutate({
+      abi,
+      address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      functionName: 'transferFrom',
+      args: [
+        '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+        '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+        123n,
+      ],
+    })
+  }
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+### Synchronous Usage
+
+If you want to wait for the transaction to be included in a block, you can use `useWriteContractSync`:
+
+::: code-group
+```tsx [index.tsx]
+import { useWriteContractSync } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  const writeContractSync = useWriteContractSync()
+
+  const handleTransfer = () => {
+    writeContractSync.mutate({
+      abi,
+      address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      functionName: 'transferFrom',
+      args: [
+        '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+        '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+        123n,
+      ],
+    })
+  }
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useWriteContract } from '@wagmi/solid'
+
+useWriteContract.Parameters
+useWriteContract.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+<!--@include: @shared/mutation-options.md-->
+
+## Return Type
+
+```ts
+import { useWriteContract } from '@wagmi/solid'
+
+useWriteContract.ReturnType
+```
+
+The return type's [`data`](#data) property is inferrable via the combination of [`abi`](#abi), [`functionName`](#functionname), and [`args`](#args). Check out the [TypeScript docs](/solid/typescript#const-assert-abis-typed-data) for more info.
+
+<!--@include: @shared/mutation-result.md-->
+
+## Type Inference
+
+With [`abi`](/core/api/actions/writeContract#abi) setup correctly, TypeScript will infer the correct types for [`functionName`](/core/api/actions/writeContract#functionname), [`args`](/core/api/actions/writeContract#args), and the [`value`](/core/api/actions/writeContract##value). See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
+<!--@include: @shared/mutation-imports.md-->
+
+## Action
+
+- [`writeContract`](/core/api/actions/writeContract)

--- a/site/solid/api/primitives/useWriteContractSync.md
+++ b/site/solid/api/primitives/useWriteContractSync.md
@@ -1,0 +1,87 @@
+---
+title: useWriteContractSync
+description: Primitive for executing a write function on a contract and waiting for the transaction receipt.
+---
+
+<script setup>
+const packageName = '@wagmi/solid'
+const actionName = 'writeContractSync'
+const typeName = 'WriteContractSync'
+const mutate = 'writeContractSync'
+const TData = 'WriteContractSyncData'
+const TError = 'WriteContractSyncErrorType'
+const TVariables = 'WriteContractSyncVariables'
+</script>
+
+# useWriteContractSync
+
+Primitive for executing a write function on a contract and waiting for the transaction receipt.
+
+Unlike [`useWriteContract`](/solid/api/primitives/useWriteContract), this primitive waits for the transaction to be included in a block before resolving, returning a `TransactionReceipt` instead of just a transaction hash.
+
+## Import
+
+```ts
+import { useWriteContractSync } from '@wagmi/solid'
+```
+
+## Usage
+
+::: code-group
+```tsx [index.tsx]
+import { useWriteContractSync } from '@wagmi/solid'
+import { abi } from './abi'
+
+function App() {
+  const writeContractSync = useWriteContractSync()
+
+  const handleMint = () => {
+    writeContractSync.mutate({
+      abi,
+      address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      functionName: 'mint',
+    })
+  }
+
+  // writeContractSync.data contains the TransactionReceipt when successful
+}
+```
+<<< @/snippets/solid/config.ts[config.ts]
+:::
+
+## Parameters
+
+```ts
+import { useWriteContractSync } from '@wagmi/solid'
+
+useWriteContractSync.Parameters
+useWriteContractSync.SolidParameters
+```
+
+Parameters are passed as a getter function to maintain Solid reactivity.
+
+### config
+
+`Config | undefined`
+
+[`Config`](/solid/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](/solid/api/WagmiProvider).
+
+<!--@include: @shared/mutation-options.md-->
+
+## Return Type
+
+```ts
+import { useWriteContractSync } from '@wagmi/solid'
+
+useWriteContractSync.ReturnType
+```
+
+The return type's [`data`](#data) property is a `TransactionReceipt` containing the full receipt of the confirmed transaction.
+
+<!--@include: @shared/mutation-result.md-->
+
+<!--@include: @shared/mutation-imports.md-->
+
+## Action
+
+- [`writeContract`](/core/api/actions/writeContract)

--- a/site/solid/api/primitives/useWriteContractSync.md
+++ b/site/solid/api/primitives/useWriteContractSync.md
@@ -80,8 +80,12 @@ The return type's [`data`](#data) property is a `TransactionReceipt` containing 
 
 <!--@include: @shared/mutation-result.md-->
 
+## Type Inference
+
+With [`abi`](/core/api/actions/writeContract#abi) setup correctly, TypeScript will infer the correct types for [`functionName`](/core/api/actions/writeContract#functionname), [`args`](/core/api/actions/writeContract#args), and [`value`](/core/api/actions/writeContract#value) when calling `mutate` or `mutateAsync`. See the Wagmi [TypeScript docs](/solid/typescript) for more information.
+
 <!--@include: @shared/mutation-imports.md-->
 
 ## Action
 
-- [`writeContract`](/core/api/actions/writeContract)
+- [`writeContractSync`](/core/api/actions/writeContract#synchronous-usage)

--- a/site/solid/typescript.md
+++ b/site/solid/typescript.md
@@ -121,28 +121,182 @@ useBlockNumber(() => ({ chainId: 123, config: configB }))
 
 This approach is more explicit, but works well for advanced use-cases, if you don't want to use Solid Context or declaration merging, etc.
 
-## Reactive Parameters
+## Const-Assert ABIs & Typed Data
 
-In Solid, primitive parameters are passed as getter functions (accessors) to maintain reactivity. This is different from React where parameters are passed directly as objects.
+`@wagmi/solid` can infer types based on [ABIs](https://docs.soliditylang.org/en/latest/abi-spec.html#json) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Typed Data definitions, powered by [Viem](https://viem.sh) and [ABIType](https://github.com/wevm/abitype). This achieves full end-to-end type-safety from your contracts to your frontend and enlightened developer experience by autocompleting ABI item names, catching misspellings, inferring argument and return types (including overloads), and more.
+
+For this to work, you must either [const-assert](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) ABIs and Typed Data (more info below) or define them inline. For example, `useReadContract`'s `abi` configuration parameter:
 
 ```ts
-// React style (NOT used in @wagmi/solid)
-useBlockNumber({ chainId: 1 })
-
-// Solid style (used in @wagmi/solid)
-useBlockNumber(() => ({ chainId: 1 }))
+const { data } = useReadContract(() => ({
+  abi: […], // <--- defined inline // [!code focus]
+}))
 ```
 
-This allows Wagmi to react to changes in your parameters automatically when using Solid's reactive primitives like `createSignal`.
-
 ```ts
-import { createSignal } from 'solid-js'
-import { useBlockNumber } from '@wagmi/solid'
+const abi = […] as const // <--- const assertion // [!code focus]
+const { data } = useReadContract(() => ({ abi }))
+```
 
-const [chainId, setChainId] = createSignal(1)
+If type inference isn't working, it's likely you forgot to add a `const` assertion or define the configuration parameter inline. Also, make sure your ABIs, Typed Data definitions, and [TypeScript configuration](#requirements) are valid and set up correctly.
 
-// Block number will automatically update when chainId changes
-useBlockNumber(() => ({ chainId: chainId() }))
+::: tip
+Unfortunately [TypeScript doesn't support importing JSON `as const` yet](https://github.com/microsoft/TypeScript/issues/32063). Check out the [Wagmi CLI](/cli/getting-started) to help with this! It can automatically fetch ABIs from Etherscan and other block explorers, resolve ABIs from your Foundry/Hardhat projects, and more.
+:::
+
+Anywhere you see the `abi` or `types` configuration property, you can likely use const-asserted or inline ABIs and Typed Data to get type-safety and inference. These properties are also called out in the docs.
+
+Here's what [`useReadContract`](/solid/api/primitives/useReadContract) looks like with and without a const-asserted `abi` property.
+
+::: code-group
+```ts twoslash [Const-Asserted]
+// @twoslash-cache: {"v":1,"hash":"25c05b213e654cde6c0450f8420a688d95bd909200e1d2a0249b6c4fe82629ee","data":"N4Igdg9gJgpgziAXAbVAFwJ4AcZJACwgDcYAnEAGhDRgA808AKAQwBsBLZuASgAIAzAK5gAxmnYQwvQXBgAlGMygBhSWlLMxAHhGS4aXswBG7XnRpgocXgEETvAD69SiqJNYZpYANaQA7mDIALoUAsJiEmAAcswAtjBm9DCW1qpg6ppoAGLh4pIx8VrG7KEAOiBYgi7ljrzlROwwfuUAfKG6YPqGpADm1ubJVrxpGWI5onlgNr1wRSZlFVUwNU71jc2UYRORBTBtvB387D2JFkNpRycAvMOSl6GyrDBiACLMaMy8NwpKIxqv72YcxKWwi+TiMFCzBmLRajCw0IhNFIcAA/IhpLIfio1P80AA6AAKiPiyNmxVCQm24PiUJm7TuxweMCeAI+LW4GJk8lcf0y+IUaCqYAAKtgYMDKbkdhC6X1may0G92aUwCwOFw+GAIXAESIEtzsXyxKr2LEsBBSAZDbzcZlKCA3CIEIgCGg0Fg4IgAPTevzMHqxdj4uD4b1wCAcKDe5hYdjerCkM3scQkODem2/O1iB36aEMRAATioTzAPTQ+CQAEYAKxUD69GAFkCZnHpPEOjhgXCIAAMVBE+ERYjISELAF8KOhxXhCCRyPXzHgOl0oICMSYeux0rVhLAjt2oA6nS6QCL8AlWFwDHBBCJ9XA4EJWB5nPBIyQoLw1x8BJbeBWCQAI6CGQGD4rmDYFjWABsJbJOWlaIAALPW0I9E2eA/swnbbj2ABMA5Dnio6IAAHJO044LOxCjou9BMGwnA8JiPJZu2mRaC4SjuJ4qCqrwglvjxYCvtq8QYuURhsMwogwAA8vw5QANwCUJ3FuKJniYDgkkgFSYJgCpamCRpvG8HmNAALKCB8JgcJgekNE0xlSOprjmdulRoF6wmaa+/FuUJ7kia+OkwHpShQC4j6ucFwVmVpvDiRFdQgBAARkHFQnjkEqlBX55kQLZ3m+YlAXACZ8Xldp4p6YI25oPhsHZYJuX5ZOvCVQVNXJRCensHANhYImtFQFklo2C+rWFUl4V6QZkwzb1lkwDZdnsA5GBOesy0eUlXm2WV+0VVVCUnbVulpVFMVwDN52hZ4KV6Rl3akDNnXdfFIX+ZdqXlDd8B3SA+XfaZF19RJaUQDgGhoJaH15VVvXFR6R0Yr1gVg7NYV1WlRgQJGiMdaEX0/eZz1pRhaDDaNn57Y9AF4+Ui2RAzv0WR81m2cUW07S5IPIxDh0+RjEPIPiktIz1EOo6VYuMxLUsk11VWS/iKtk4J6sdSE+MyXJinlKEmPq3rFxMrwm6NXCCIaKSZBolyWK2hxYhEiSTaO1o6scs7bFtqMBKCsKYo4D7kstKa5qWtaLvsUHx4QM6s7up6Pp+gGQYhmGEZRjGcYJkmQapvAGbx4HHZUHmVpIDBdYgKWiHVg3DbU3grbGgwJZ4UghEgIOw7ItWADslHUDOrpznR1BLq68KkDDZCYHwgOPuivAAAa9rQAAkwD6EmZbjpvu6WDAB4wEe1dQWO/dNxWSAj2hjbNmvCA992SAAMxEUPpH4XHuFGi84HQ0AYvPUasMV6GBMBvTGWscZPX6vrK8hslKCxlozeaaVWaSHZuZVa61eYpm2mlZyGxQbkwOmAeWSDeBYzBr1HBAMoDRSBvdahYkUHlFellTBwV2pC0ZnLdG9DGHfWYczFsjVmowWJqqT6wiOaU3KINWmi9PwTVIFNVgBC5rSLwUZARXDPBEJ5vZUh/NKHKM8rQsRCCzqmKZldVh7DYomMkRDVR6VMrvU8bwJRBUHocxYSAd+nDwaMx8UvOGCMAlCKwRzURotxGIJCeZMJBMiYJOlkEjJSUfHUw0WNfRuNXH6WlPggJK0uZrQsZtKx5Ddo1OFvY1Jptla2KSik46iszaazVpLQZBUdaKKCGffceFr4gBrgWKsyFiyNwQo/RAv9qDoUwq6YouEv4oT/iRcgiBAFTgntRKetEFyzwgQPPQBgyAiBHvhKsdh2AKw5hI+hPjpJoP1EbVp2DDFVOMVQqJHNzEbT5s0gWoL6Eiz6R89JziwkRICQU7hUNeF+IUUkoqJUHHiyRWCzJ0iGrpDkTi/JzifHqJGpoq+2jdFlL+gtYFzLObvHqZCppawYXdNfPC955lPnopZddNht1IlfJ4b4t6H1SZOOJQYipqLYWishv9dKsN3jxNhYk9VvShVJRFci6R2S9G5JGeqopTYSn0wBaEoF1IQX8rMXU4hljHLQpsbimhdDOn4mlga/FHTxYDMUQq0ZwyI2qyjRrcZkF8wt1Qssssqyllty2SAB5TyXkmF2T2FNg9DlPyAZPAglywFzxAAvWJMCjG7A3lJA2fyMG1DUUNOlY1GXTRAO2kAxSu32v7Xw0g/z+3w28MkAAqnIAAkisLwUzDyJtrogKsMFn6pubuu/umbmwNohAWpADdi2ZAAWW85IAQJgSrTc2t0CMB8EPfEJtIAfmyVbYujtdqGWTV7f2wddMr7ftlWQcdqxqAQCnWAWdC6+1OD3BfaZq75mbvgmmpCVY92bIPcC3Yx7ECnuIueo5JyqI9graA+izYH3Lyfd0Po8DxajoxNvPeB91Dbh6CfCZiHz6XxmXM6shYlkPyQim/deB0If0br3IsBzSN90vZRm9pAMB3to1A+jq8ZjMcVqxreO996H247xyZyGV03yTeu0TGGd2Sdw9JmYhGllnpHGRlTICZ7gObCuAw2ENzHEahZwTScU6unPJea8Fk7wPifIIF8ngYofivt+QEf5SAAQvLwNT4FUN9xrGRezqzHOvywoCQj2HFMeaQL2Lzro8uaeXHc9LHwgtbh3Px5dV9wunii7wK8XRbz3iBs+V8KXWCfja58fg/5AK5dAupiC1m13NWK9u0rL926umwlV/u7nh59lygOaAlGzQWitF1ViRpswGHHAIResReAAHIAAC/pAzxjzuwKAL3VSqn89d7CgSvg3ddkHRgjA+BXBaLwRgZN34YhezvLIAAhGw39CzYeUMwXsyE2HISKyIMiyFv4wHwgAUUp72MihZN38GUPj/g38awj0LCIfCL2KBqWKBiHNzzXk87ci+1KL2P3oO5wDoyMvBIyYxMgFHtAbC9mUPwdnZEyIbpeMhIwhY9dkRgjBIwNZv7f17NT5gyEYLMCrGRb+ZF8L8GalWGAL2QiKO4NwaX2FVQOlJDhRAoABidEiHgHyIBxzjiAA=="}
+const erc721Abi = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'address', name: 'owner' }],
+    outputs: [{ type: 'uint256' }],
+  },
+  {
+    name: 'isApprovedForAll',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { type: 'address', name: 'owner' },
+      { type: 'address', name: 'operator' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+  {
+    name: 'getApproved',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'uint256', name: 'tokenId' }],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    name: 'ownerOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'uint256', name: 'tokenId' }],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    name: 'tokenURI',
+    type: 'function',
+    stateMutability: 'pure',
+    inputs: [{ type: 'uint256', name: 'tokenId' }],
+    outputs: [{ type: 'string' }],
+  },
+] as const
+// ---cut---
+import { useReadContract } from '@wagmi/solid'
+
+const { data } = useReadContract(() => ({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: erc721Abi,
+  functionName: 'balanceOf',
+  // ^?
+
+
+
+  args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e'],
+  // ^?
+}))
+
+data
+// ^?
+```
+```ts twoslash [Not Const-Asserted]
+// @twoslash-cache: {"v":1,"hash":"32049753cbd54692b7d3bf9ee3c0c319131f5a4f222c2d2401ececdcd5564dac","data":"N4Igdg9gJgpgziAXAbVAFwJ4AcZJACwgDcYAnEAGhDRgA808AKAQwBsBLZuASgAIAzAK5gAxmnYQwvQXBgAlGMygBhSWlLMxAHhGS4aXswBG7XnRpgocXgEETvAD69SiqJNYZpYANaQA7mDIALoUAsJiEmAAcswAtjBm9DCW1qpg6ppoAGLh4pIx8VrG7KEAOiBYgi7ljrzlROwwfuUAfKG6YPqGpADm1ubJVrxpGWI5onlgNr1wRSZlFVUwNU71jc2UYRORBTBtvB387D2JFkNpRycAvMOSl6GyrDBiACLMaMy8NwpKIxqv72YcxKWwi+TiMFCzBmLRajCw0IhNFIcAA/IhpLIfio1P80AA6AAKiPiyNmxVCQm24PiUJm7TuxweMCeAI+LW4GJk8lcf0y+IUaCqYAAKtgYMDKbkdhC6X1may0G92aUwCwOFw+GAIXAESIEtzsXyxKr2LEsBBSAZDbzcZlKCA3CIEIgCGg0Fg4IgAPTevzMHqxdj4uD4b1wCAcKDe5hYdjerCkM3scQkODem2/O1iB36aEMRAATioTzAPTQ+CQAEYAKxUD69GAFkCZnHpPEOjhgXCIAAMVBE+ERYjISELAF8KOhxXhCCRyPXzHgOl0oICuT5/GAHU6XSARfgEqwuAY4IIRPq4HAhKwPM54JGSFBeGuPgJLbwKwkAI6CMgYfFcwbAsawANhLZJy0rRAABZ62hHomzwV9mE7dhuyQAAmAchzxUdEAADknaccFnYhR0XegmDYTgeExHks3bTItGAVVeHY3htXiDF9CTMsAG42I4zAcB49R0J6QSpA4vMaAAWUED4TA4TAxL4yShPY9DKjQL1eFY6SOOE8U1IkqSjKMriYFMgTNN4cdgnMjiIEUnS9IMizjNE3heLMuyHKCKSAoWIw2GYUQYAAeX4cpQhcJR3E8ZByl7WgbF7ZR+AAdkLAiCKrUCXhgoxCxKgjQNAowawAZmq3sAFF6uYGDQOYKsCOqgjMP4TCayrZYQBCW4wHuLxfAgAI4QRDRSTINEuSxW0mLEIkSSbOaWLsqybI0wzPxMnzxNsvbZJgBSlPYFSMB2pytLANyMQ8zz9u83zjueziIRu/zHLslyPUU9y7KMkTrMO9Tbvs36wGCuoQFC48Iui2L7wSsA72SkBUvSzKcrygqipKsqKqq2qGqalq2o6rqer6gahouJkxq3DkFoYttRgJQVhTFHBNr27bwb8vbQe+k6PnkxTiiusWjO0wHHuBrywbe3aPsF1XIYCyH/oe/SlfY0WhfejjtdVWHygR8L9WRzZ4rcdGkvxZ2huEcbJtNc1LWtRbGM5ncIGdWd3U9H0/QDIMQzDCMoxjOMEyTINU3gDNfY5jsqDzK0kFAusQFLKDqzzhtEObVtjQYEt0J7bCQEHYdkWrLLiOoGdXTnCjqCXV14VICAcCtDA+CUKAXCvdFeAAA1SgASYBVfHSfamEWAjm7KAgPzMda4LiskCy+DG2bEex4QKuMMQaqcIb/DMJb0GyPnB0aConvE37shMGHkwJ6e9iNaOmrZWssZISzOlLZSKZrrGyAXdPWf8LJG01gbT63EYFa2hkZXWCt9Z7RBgdZBe0zYw2CMvSwMA14wA3pnYC1YYLFnzpBPel9D6lzwMUNCF84J11wpkW+9824EHIguLur8656AMGQEQWVMJVjsOwRWAsvroLskgwBkNTrnWllAkBcCcEIPwa9dRKCAEQx+oFP6rl9EoLUWYoh0MAqb2zogWs3Dd7QQYSXJCropEyLkSYThPZuH1zwuQRAzcpyt1Iu3YRz9u4gF7h/QefAqRgmiBCCeqsyGr2rtQkAWcCwFQPowsszCqy1y8c2VJkxdiBKQHnEJfCwl30iQ/V0v5/xxLEYkgeX9QQ1IyTtbJFDclOMKaBYp7jqwVIQt4kA1SZTxDqYgBpvCRzNIEdEoRT9KLNh6Z/Ie3Q+gT3tolZmE1AhBGGZQvJBTqyFgYVM2CrC5kITPvnauY5r6hKwpsnsIAOmkAwF0vZ79emHLeSc1wZy3ZblIU4FeIz15jPuY8ph0FuGVPYTMZZDDGnrN+a0wRHcREv2bCuAwKENzu23FQXceADxHhPD5c8l5ryCFvJ4Mej4qEvkBO+Ugn5Dy8EBQBFFiBeoEQgqUjFLzmwoWWeU75TSkC9j+XgUVILlwSL5R8alW4A5B1dIy3gx4uhngvPAdlnL7wxyfLqz4/APxfhFX+IFgEaFbwlTWKVJTC7POoLM+VgJFW13xY3Ps44QjiNgHgM0ForT6XokabMBhxwCD7rEXgAByAAAv6QM8YY7sCgNm1UqoKVJpQvZL4yalqc0YIwPgVwWi8EYE9E+VqMTZtSlkAAQjYaqhZynKGYL2GCUAoAwR9SIAiMFqowEwo1XsBFCwTP4Mocd/Bqo1hyiITC2aKBCWKBiXxsj5FHukgsmkYNs1WyRvwQ95awDPvYm8jEyAe1pQytlXK+VCrFVKrlEmNU6qNWaq1dqnVuq9X6tmkI5tuDcGfShVUDpSSoUQKAAYnRIh4F0iAcc44gA="}
+declare const erc721Abi: {
+  name: string;
+  type: string;
+  stateMutability: string;
+  inputs: {
+    type: string;
+    name: string;
+  }[];
+  outputs: {
+    type: string;
+  }[];
+}[]
+// ---cut---
+import { useReadContract } from '@wagmi/solid'
+
+const { data } = useReadContract(() => ({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: erc721Abi,
+  functionName: 'balanceOf',
+  // ^?
+
+
+
+  args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e'],
+  // ^?
+}))
+
+data
+// ^?
+```
+:::
+
+<br/>
+<br/>
+
+You can prevent runtime errors and be more productive by making sure your ABIs and Typed Data definitions are set up appropriately. 🎉
+
+```ts twoslash
+// @errors: 2820
+const erc721Abi = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'address', name: 'owner' }],
+    outputs: [{ type: 'uint256' }],
+  },
+  {
+    name: 'isApprovedForAll',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { type: 'address', name: 'owner' },
+      { type: 'address', name: 'operator' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+  {
+    name: 'getApproved',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'uint256', name: 'tokenId' }],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    name: 'ownerOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'uint256', name: 'tokenId' }],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    name: 'tokenURI',
+    type: 'function',
+    stateMutability: 'pure',
+    inputs: [{ type: 'uint256', name: 'tokenId' }],
+    outputs: [{ type: 'string' }],
+  },
+] as const
+// ---cut---
+import { useReadContract } from '@wagmi/solid'
+
+useReadContract(() => ({
+  abi: erc721Abi,
+  functionName: 'balanecOf',
+}))
 ```
 
 ## Configure Internal Types


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->
## Summary
- Add 7 contract interaction primitives to `@wagmi/solid`: `useReadContract`, `useReadContracts`, `useInfiniteReadContracts`, `useSimulateContract`, `useWriteContract`, `useWriteContractSync`, and `useWatchContractEvent`
- Each primitive follows SolidJS conventions (Accessor-based parameters, `createMemo`/`createEffect`/`onCleanup`, namespace-based type exports) while staying close to the `@wagmi/react` implementations
- Includes runtime tests, type-level tests (`test-d.ts`), and barrel exports

## Test plan
- [x] `useReadContract` — reads a single contract view/pure function (e.g. `balanceOf`), supports chainId override and deployless reads
- [x] `useReadContracts` — multicall reads across same and different chains
- [x] `useInfiniteReadContracts` — paginated infinite query for contract reads with `getNextPageParam`
- [x] `useSimulateContract` — simulates a write call with connected account, verifies disabled state when params missing
- [x] `useWriteContract` — sends a write transaction via `mutate`, confirms tx hash returned
- [x] `useWriteContractSync` — sends a write transaction and waits for receipt with block confirmation
- [x] `useWatchContractEvent` — watches ERC-20 Transfer events in real-time, verifies log collection
- [x] Type tests pass for all 7 primitives (`vitest typecheck`)
- [x] Exports are correctly re-exported from `@wagmi/solid`