### PR TITLE
test: simplify defineConfig function mocks

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -21,19 +21,11 @@ test('array', () => {
 })
 
 test('function', () => {
-  const config = vi.fn().mockImplementation(() => ({
-    contracts: [],
-    out: 'wagmi.ts',
-    plugins: [],
-  }))
+  const config = vi.fn()
   expect(defineConfig(config)).toEqual(config)
 })
 
 test('async function', () => {
-  const config = vi.fn().mockImplementation(async () => ({
-    contracts: [],
-    out: 'wagmi.ts',
-    plugins: [],
-  }))
+  const config = vi.fn()
   expect(defineConfig(config)).toEqual(config)
 })


### PR DESCRIPTION
Simplified tests by removing unused mock implementations. The function mocks are not executed, so plain vi.fn() is enough and keeps tests cleaner.