### PR TITLE
fix(vue): scope Nuxt runtime auto-import exports to composables

### DIFF
--- a/.changeset/smart-comics-appear.md
+++ b/.changeset/smart-comics-appear.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/vue": patch
+---
+
+fix(vue): scope Nuxt runtime auto-import exports to composables

--- a/packages/vue/src/nuxt/runtime/composables.test.ts
+++ b/packages/vue/src/nuxt/runtime/composables.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+
+import * as composables from './composables.js'
+
+test('exports only Nuxt auto-import composables', () => {
+  expect(Object.keys(composables).sort()).toMatchInlineSnapshot(`
+    [
+      "useAccount",
+      "useAccountEffect",
+      "useBalance",
+      "useBlockNumber",
+      "useChainId",
+      "useChains",
+      "useClient",
+      "useConfig",
+      "useConnect",
+      "useConnection",
+      "useConnections",
+      "useConnectorClient",
+      "useConnectors",
+      "useDisconnect",
+      "useEnsAddress",
+      "useEnsAvatar",
+      "useEnsName",
+      "useEstimateGas",
+      "useReadContract",
+      "useReconnect",
+      "useSendTransaction",
+      "useSignMessage",
+      "useSignTypedData",
+      "useSimulateContract",
+      "useSwitchAccount",
+      "useSwitchChain",
+      "useSwitchConnection",
+      "useTransaction",
+      "useTransactionReceipt",
+      "useWaitForTransactionReceipt",
+      "useWatchBlockNumber",
+      "useWriteContract",
+    ]
+  `)
+})

--- a/packages/vue/src/nuxt/runtime/composables.ts
+++ b/packages/vue/src/nuxt/runtime/composables.ts
@@ -1,3 +1,41 @@
+// Nuxt auto-imports should only expose composables.
+//
+// Re-exporting `../../exports/index.js` pulls in plugin & core utility exports,
+// which can trigger module interop issues in Nuxt when resolving auto-imports.
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
-// biome-ignore lint/performance/noReExportAll: entrypoint module
-export * from '../../exports/index.js'
+export { useBalance } from '../../composables/useBalance.js'
+export { useBlockNumber } from '../../composables/useBlockNumber.js'
+export { useChainId } from '../../composables/useChainId.js'
+export { useChains } from '../../composables/useChains.js'
+export { useClient } from '../../composables/useClient.js'
+export { useConfig } from '../../composables/useConfig.js'
+export { useConnect } from '../../composables/useConnect.js'
+export {
+  useConnection as useAccount,
+  useConnection,
+} from '../../composables/useConnection.js'
+export { useConnectionEffect as useAccountEffect } from '../../composables/useConnectionEffect.js'
+export { useConnections } from '../../composables/useConnections.js'
+export { useConnectorClient } from '../../composables/useConnectorClient.js'
+export { useConnectors } from '../../composables/useConnectors.js'
+export { useDisconnect } from '../../composables/useDisconnect.js'
+export { useEnsAddress } from '../../composables/useEnsAddress.js'
+export { useEnsAvatar } from '../../composables/useEnsAvatar.js'
+export { useEnsName } from '../../composables/useEnsName.js'
+export { useEstimateGas } from '../../composables/useEstimateGas.js'
+export { useReadContract } from '../../composables/useReadContract.js'
+export { useReconnect } from '../../composables/useReconnect.js'
+export { useSendTransaction } from '../../composables/useSendTransaction.js'
+export { useSignMessage } from '../../composables/useSignMessage.js'
+export { useSignTypedData } from '../../composables/useSignTypedData.js'
+export { useSimulateContract } from '../../composables/useSimulateContract.js'
+export { useSwitchChain } from '../../composables/useSwitchChain.js'
+export {
+  useSwitchConnection as useSwitchAccount,
+  useSwitchConnection,
+} from '../../composables/useSwitchConnection.js'
+export { useTransaction } from '../../composables/useTransaction.js'
+export { useTransactionReceipt } from '../../composables/useTransactionReceipt.js'
+export { useWaitForTransactionReceipt } from '../../composables/useWaitForTransactionReceipt.js'
+export { useWatchBlockNumber } from '../../composables/useWatchBlockNumber.js'
+export { useWriteContract } from '../../composables/useWriteContract.js'


### PR DESCRIPTION
## Summary
Fixes Nuxt auto-import failures in `@wagmi/vue` by narrowing the Nuxt runtime composables entrypoint to composable exports only.

## Problem
`packages/vue/src/nuxt/runtime/composables.ts` re-exported `../../exports/index.js`, which also includes plugin/core utility exports. In Nuxt auto-import paths, this can pull in module interop that triggers:
`eventemitter3 ... does not provide an export named 'default'`.

## Changes
- Replaced broad re-export with explicit composable-only exports in the Nuxt runtime entrypoint.
- Preserved deprecated alias names used by the Nuxt module (`useAccount`, `useAccountEffect`, `useSwitchAccount`) via explicit alias exports.
- Added regression test to assert Nuxt runtime entrypoint only exposes the intended auto-import composables.

## Tests
- `pnpm vitest run packages/vue/src/nuxt/runtime/composables.test.ts packages/vue/src/exports/nuxt.test.ts`
- `pnpm biome check packages/vue/src/nuxt/runtime/composables.ts packages/vue/src/nuxt/runtime/composables.test.ts`

Closes #3977.
