### PR TITLE
fix(cli): support named Foundry deployments sharing one ABI

### DIFF
--- a/.changeset/soft-points-brake.md
+++ b/.changeset/soft-points-brake.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+fix(foundry): support named deployments so multiple generated contracts can share one artifact ABI

--- a/.changeset/soft-points-brake.md
+++ b/.changeset/soft-points-brake.md
@@ -2,4 +2,4 @@
 "@wagmi/cli": patch
 ---
 
-fix(foundry): support named deployments so multiple generated contracts can share one artifact ABI
+fix(foundry): support named deployments sharing one artifact ABI, including watch-mode add/change/remove updates

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -183,13 +183,23 @@ export async function generate(options: Generate = {}) {
               event === 'change' ? watchConfig.onChange : watchConfig.onAdd
             const config = await eventFn?.(path)
             if (!config) return
-            const contract = await getContract({ ...config, isTypeScript })
-            contractMap.set(contract.name, contract)
+
+            const contractConfigs = Array.isArray(config) ? config : [config]
+            for (const contractConfig of contractConfigs) {
+              const contract = await getContract({
+                ...contractConfig,
+                isTypeScript,
+              })
+              contractMap.set(contract.name, contract)
+            }
             needsWrite = true
           } else if (event === 'unlink') {
             const name = await watchConfig.onRemove?.(path)
             if (!name) return
-            contractMap.delete(name)
+
+            const contractNames = Array.isArray(name) ? name : [name]
+            for (const contractName of contractNames)
+              contractMap.delete(contractName)
             needsWrite = true
           }
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -182,7 +182,7 @@ export async function generate(options: Generate = {}) {
             const eventFn =
               event === 'change'
                 ? watchConfig.onChange
-                : watchConfig.onAdd ?? watchConfig.onChange
+                : (watchConfig.onAdd ?? watchConfig.onChange)
             const config = await eventFn?.(path)
             if (!config) return
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -180,7 +180,9 @@ export async function generate(options: Generate = {}) {
           let needsWrite = false
           if (event === 'change' || event === 'add') {
             const eventFn =
-              event === 'change' ? watchConfig.onChange : watchConfig.onAdd
+              event === 'change'
+                ? watchConfig.onChange
+                : watchConfig.onAdd ?? watchConfig.onChange
             const config = await eventFn?.(path)
             if (!config) return
 

--- a/packages/cli/src/commands/generate.watch.test.ts
+++ b/packages/cli/src/commands/generate.watch.test.ts
@@ -89,9 +89,9 @@ test('watch: add falls back to onChange when onAdd is omitted', async () => {
   await getPluginWatcher()?.emit('all', 'add', 'contracts/bar.json')
   await new Promise((resolve) => setTimeout(resolve, 250))
 
-  await expect(readFile(resolve(dir, 'generated.js'), 'utf8')).resolves.toContain(
-    'export const barAbi = []',
-  )
+  await expect(
+    readFile(resolve(dir, 'generated.js'), 'utf8'),
+  ).resolves.toContain('export const barAbi = []')
 })
 
 test('watch: unlink supports removing multiple contracts', async () => {

--- a/packages/cli/src/commands/generate.watch.test.ts
+++ b/packages/cli/src/commands/generate.watch.test.ts
@@ -1,0 +1,133 @@
+import { readFile } from 'node:fs/promises'
+import dedent from 'dedent'
+import { resolve } from 'pathe'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import { createFixture } from '../../test/utils.js'
+
+type EventHandler = (...args: any[]) => unknown
+
+type MockWatcher = {
+  close: ReturnType<typeof vi.fn>
+  emit: (event: string, ...args: any[]) => Promise<void>
+  on: (event: string, handler: EventHandler) => MockWatcher
+}
+
+const mocks = vi.hoisted(() => {
+  const mockWatchers: MockWatcher[] = []
+  const watchMock = vi.fn(() => {
+    const handlers = new Map<string, EventHandler>()
+    const watcher: MockWatcher = {
+      close: vi.fn(async () => {}),
+      async emit(event: string, ...args: any[]) {
+        await handlers.get(event)?.(...args)
+      },
+      on(event: string, handler: EventHandler) {
+        handlers.set(event, handler)
+        return watcher
+      },
+    }
+    mockWatchers.push(watcher)
+    return watcher
+  })
+
+  return { mockWatchers, watchMock }
+})
+
+vi.mock('chokidar', () => ({
+  watch: mocks.watchMock,
+}))
+
+import { generate } from './generate.js'
+
+beforeEach(() => {
+  mocks.mockWatchers.length = 0
+  mocks.watchMock.mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function getPluginWatcher() {
+  const index = mocks.watchMock.mock.calls.findIndex((call) => {
+    const args = call as unknown[]
+    const paths = args[0] as string[] | string | undefined
+    return Array.isArray(paths) && paths.includes('contracts/*.json')
+  })
+  if (index === -1) throw new Error('Expected plugin watcher to be registered.')
+  return mocks.mockWatchers[index]
+}
+
+test('watch: add falls back to onChange when onAdd is omitted', async () => {
+  const { dir } = await createFixture({
+    files: {
+      'wagmi.config.js': dedent`
+        export default {
+          out: 'generated.js',
+          plugins: [{
+            name: 'Test',
+            watch: {
+              paths: ['contracts/*.json'],
+              async onChange(path) {
+                return {
+                  abi: [],
+                  name: path.includes('bar') ? 'Bar' : 'Foo',
+                }
+              },
+            },
+          }],
+        }
+      `,
+    },
+  })
+  vi.spyOn(process, 'cwd').mockImplementation(() => dir)
+
+  await generate({ watch: true })
+
+  expect(mocks.mockWatchers).toHaveLength(2)
+  await getPluginWatcher()?.emit('all', 'add', 'contracts/bar.json')
+  await new Promise((resolve) => setTimeout(resolve, 250))
+
+  await expect(readFile(resolve(dir, 'generated.js'), 'utf8')).resolves.toContain(
+    'export const barAbi = []',
+  )
+})
+
+test('watch: unlink supports removing multiple contracts', async () => {
+  const { dir } = await createFixture({
+    files: {
+      'wagmi.config.js': dedent`
+        export default {
+          out: 'generated.js',
+          contracts: [
+            { abi: [], name: 'Foo' },
+            { abi: [], name: 'Bar' },
+          ],
+          plugins: [{
+            name: 'Test',
+            watch: {
+              paths: ['contracts/*.json'],
+              async onChange() {
+                return undefined
+              },
+              async onRemove() {
+                return ['Foo', 'Bar']
+              },
+            },
+          }],
+        }
+      `,
+    },
+  })
+  vi.spyOn(process, 'cwd').mockImplementation(() => dir)
+
+  await generate({ watch: true })
+
+  await getPluginWatcher()?.emit('all', 'unlink', 'contracts/bar.json')
+  await new Promise((resolve) => setTimeout(resolve, 250))
+
+  const output = await readFile(resolve(dir, 'generated.js'), 'utf8')
+  expect(output).not.toContain('export const fooAbi = []')
+  expect(output).not.toContain('export const barAbi = []')
+})

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -65,7 +65,9 @@ export type Watch = {
   /** Callback that fires when watcher is shutdown */
   onClose?: (() => MaybePromise<void>) | undefined
   /** Callback that fires when file is removed */
-  onRemove?: ((path: string) => MaybePromise<MaybeArray<string> | undefined>) | undefined
+  onRemove?:
+    | ((path: string) => MaybePromise<MaybeArray<string> | undefined>)
+    | undefined
 }
 
 export type Plugin = {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -56,14 +56,16 @@ export type Watch = {
   paths: string[] | (() => MaybePromise<string[]>)
   /** Callback that fires when file is added */
   onAdd?:
-    | ((path: string) => MaybePromise<ContractConfig | undefined>)
+    | ((path: string) => MaybePromise<MaybeArray<ContractConfig> | undefined>)
     | undefined
   /** Callback that fires when file changes */
-  onChange: (path: string) => MaybePromise<ContractConfig | undefined>
+  onChange: (
+    path: string,
+  ) => MaybePromise<MaybeArray<ContractConfig> | undefined>
   /** Callback that fires when watcher is shutdown */
   onClose?: (() => MaybePromise<void>) | undefined
   /** Callback that fires when file is removed */
-  onRemove?: ((path: string) => MaybePromise<string | undefined>) | undefined
+  onRemove?: ((path: string) => MaybePromise<MaybeArray<string> | undefined>) | undefined
 }
 
 export type Plugin = {

--- a/packages/cli/src/plugins/foundry.test.ts
+++ b/packages/cli/src/plugins/foundry.test.ts
@@ -401,6 +401,75 @@ test('watch callbacks use broadcast deployments', async () => {
   })
 })
 
+test('watch callbacks include named deployments for one artifact', async () => {
+  const dir = f.temp()
+  const spy = vi.spyOn(process, 'cwd')
+  spy.mockImplementation(() => dir)
+
+  const artifactsDir = resolve(dir, 'out')
+  await fs.mkdir(artifactsDir, { recursive: true })
+  const erc20Artifact = {
+    abi: [
+      {
+        inputs: [],
+        name: 'totalSupply',
+        outputs: [{ type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ],
+  }
+  const artifactPath = resolve(artifactsDir, 'ERC20.json')
+  await fs.writeFile(artifactPath, JSON.stringify(erc20Artifact, null, 2))
+
+  const plugin = foundry({
+    deployments: {
+      DAI: {
+        artifact: 'ERC20',
+        address: {
+          1: '0x0000000000000000000000000000000000000001',
+        },
+      },
+      WETH: {
+        artifact: 'ERC20',
+        address: {
+          1: '0x0000000000000000000000000000000000000002',
+        },
+      },
+    },
+    forge: {
+      build: false,
+      rebuild: false,
+    },
+  })
+
+  const contracts = await plugin.watch.onChange?.(artifactPath)
+  expect(contracts).toEqual([
+    {
+      abi: erc20Artifact.abi,
+      address: undefined,
+      name: 'ERC20',
+    },
+    {
+      abi: erc20Artifact.abi,
+      address: {
+        1: '0x0000000000000000000000000000000000000001',
+      },
+      name: 'DAI',
+    },
+    {
+      abi: erc20Artifact.abi,
+      address: {
+        1: '0x0000000000000000000000000000000000000002',
+      },
+      name: 'WETH',
+    },
+  ])
+
+  const removed = await plugin.watch.onRemove?.(artifactPath)
+  expect(removed).toEqual(['ERC20', 'DAI', 'WETH'])
+})
+
 test('named deployments can share one artifact ABI', async () => {
   const dir = f.temp()
   const spy = vi.spyOn(process, 'cwd')

--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -188,6 +188,41 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     }
   }
 
+  async function getContractsForArtifact(artifactPath: string) {
+    const artifactName = getArtifactName(artifactPath)
+    const contracts: ContractConfig[] = []
+
+    const artifactContract = await getContract(artifactPath)
+    if (artifactContract.abi?.length) contracts.push(artifactContract)
+
+    for (const [name, deployment] of Object.entries(namedDeployments)) {
+      if (deployment.artifact !== artifactName) continue
+
+      const contract = await getContract(artifactPath, {
+        address: deployment.address,
+        name,
+      })
+      if (!contract.abi?.length) continue
+      contracts.push(contract)
+    }
+
+    if (contracts.length === 0) return undefined
+    return contracts.length === 1 ? contracts[0] : contracts
+  }
+
+  function getContractNamesForArtifact(artifactPath: string) {
+    const artifactName = getArtifactName(artifactPath)
+    const contractNames = new Set<string>([getContractName(artifactName)])
+
+    for (const [name, deployment] of Object.entries(namedDeployments)) {
+      if (deployment.artifact !== artifactName) continue
+      contractNames.add(getContractName(name))
+    }
+
+    const names = [...contractNames]
+    return names.length === 1 ? names[0] : names
+  }
+
   function getArtifactPaths(artifactsDirectory: string) {
     const crawler = new fdir().withBasePath().globWithOptions(
       include.map((x) => `${artifactsDirectory}/**/${x}`),
@@ -391,13 +426,13 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
         ...exclude.map((x) => `!${artifactsDirectory}/**/${x}`),
       ],
       async onAdd(path) {
-        return getContract(path)
+        return getContractsForArtifact(path)
       },
       async onChange(path) {
-        return getContract(path)
+        return getContractsForArtifact(path)
       },
       async onRemove(path) {
-        return getContractName(getArtifactName(path))
+        return getContractNamesForArtifact(path)
       },
     },
   }

--- a/site/cli/api/plugins/foundry.md
+++ b/site/cli/api/plugins/foundry.md
@@ -74,7 +74,7 @@ export default defineConfig({
 
 ### deployments
 
-`{ [key: string]: address?: Address | Record<chainId, Address> | undefined } | undefined`
+`{ [key: string]: Address | Record<chainId, Address> | { artifact: string; address: Address | Record<chainId, Address> } } | undefined`
 
 Mapping of addresses to attach to artifacts.
 
@@ -91,6 +91,35 @@ export default defineConfig({
           5: '0x112234455c3a32fd11230c42e7bccd4a84e02010', // [!code focus]
         }, // [!code focus]
       }, // [!code focus]
+    }),
+  ],
+})
+```
+
+To generate multiple contract configs from one artifact ABI, use named
+deployments:
+
+```ts
+import { defineConfig } from '@wagmi/cli'
+import { foundry } from '@wagmi/cli/plugins'
+
+export default defineConfig({
+  plugins: [
+    foundry({
+      deployments: {
+        DAI: {
+          artifact: 'ERC20',
+          address: {
+            1: '0x0000000000000000000000000000000000000001',
+          },
+        },
+        WETH: {
+          artifact: 'ERC20',
+          address: {
+            1: '0x0000000000000000000000000000000000000002',
+          },
+        },
+      },
     }),
   ],
 })


### PR DESCRIPTION
## Summary
This fixes `foundry` plugin deployments so multiple generated contracts can share a single artifact ABI.

Issue: when one ABI is reused for multiple deployments on the same chain (e.g. `DAI` + `WETH` both using `ERC20`), users currently can't express this in `deployments` without overwriting values.

## What changed
- Added **named deployment** support to Foundry plugin config:
  - existing (unchanged):
    - `Counter: { 1: '0x...' }`
  - new:
    - `DAI: { artifact: 'ERC20', address: { 1: '0x...' } }`
    - `WETH: { artifact: 'ERC20', address: { 1: '0x...' } }`
- Foundry plugin now generates extra contract entries for named deployments using the referenced artifact ABI.
- Added docs for the new deployment shape in `site/cli/api/plugins/foundry.md`.
- Added regression test: `named deployments can share one artifact ABI`.
- Added changeset for `@wagmi/cli` patch bump.

## Validation
- `pnpm --filter @wagmi/cli check:types`
- `pnpm exec vitest run --project cli packages/cli/src/plugins/foundry.test.ts -t "named deployments can share one artifact ABI"`

Note: running the full `foundry.test.ts` suite locally requires `forge` to be installed; this environment does not have `forge` available.

Closes #4396
