### PR TITLE
fix(vue): add eventemitter3 to optimizeDeps for Nuxt compatibility

### DIFF
--- a/.changeset/fix-nuxt-eventemitter3.md
+++ b/.changeset/fix-nuxt-eventemitter3.md
@@ -2,4 +2,4 @@
 "@wagmi/vue": patch
 ---
 
-Add `eventemitter3` to Vite `optimizeDeps.include` in the Nuxt module to fix CJS/ESM interop error when using auto-imports.
+Added `eventemitter3` to Vite `optimizeDeps.include` in Nuxt module to fix CJS/ESM interop error when using auto-imports.

--- a/packages/vue/src/nuxt/module.ts
+++ b/packages/vue/src/nuxt/module.ts
@@ -1,5 +1,10 @@
 import type { NuxtModule } from '@nuxt/schema'
-import { addImports, createResolver, defineNuxtModule } from 'nuxt/kit'
+import {
+  addImports,
+  createResolver,
+  defineNuxtModule,
+  extendViteConfig,
+} from 'nuxt/kit'
 
 // biome-ignore lint/complexity/noBannedTypes: allowed
 export type WagmiModuleOptions = {}
@@ -22,7 +27,7 @@ export const wagmiModule: NuxtModule<WagmiModuleOptions> =
       })
 
       // Ensure CJS dependencies are pre-bundled for ESM compatibility
-      nuxt.hook('vite:extendConfig', (config) => {
+      extendViteConfig((config) => {
         config.optimizeDeps ??= {}
         config.optimizeDeps.include ??= []
         config.optimizeDeps.include.push('eventemitter3')
@@ -66,11 +71,5 @@ export const wagmiModule: NuxtModule<WagmiModuleOptions> =
         'useWriteContract',
       ]
       addImports(names.map((name) => ({ from: composables, name })))
-
-      // Pre-bundle CJS dependencies for Vite compatibility
-      nuxt.options.vite ??= {}
-      nuxt.options.vite.optimizeDeps ??= {}
-      nuxt.options.vite.optimizeDeps.include ??= []
-      nuxt.options.vite.optimizeDeps.include.push('eventemitter3')
     },
   })


### PR DESCRIPTION
## Summary

Fixes Nuxt auto-import failures caused by eventemitter3 (a CJS dependency of @wagmi/core) not being pre-bundled by Vite when there is no explicit import statement in user code.

When using @wagmi/vue/nuxt auto-imports, the browser throws:

    SyntaxError: The requested module 'eventemitter3/index.js' does not provide an export named 'default'

## Fix

Adds eventemitter3 to Vite's optimizeDeps.include via the vite:extendConfig hook in the Nuxt module setup. This ensures Vite pre-bundles the CJS package into an ESM-compatible format, matching the approach recommended by @danielroe in https://github.com/wevm/wagmi/issues/3977#issuecomment-2128021003.

## Changes

- packages/vue/src/nuxt/module.ts -- added vite:extendConfig hook to include eventemitter3 in optimizeDeps

Fixes #3977
