### PR TITLE
docs: fix broken README references in .github/README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,7 @@
       <img src="https://img.shields.io/npm/v/wagmi?colorA=f6f8fa&colorB=f6f8fa" alt="Version">
     </picture>
   </a>
-  <a href="https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard">
+  <a href="https://scorecard.dev/viewer/?uri=github.com/wevm/wagmi">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/ossf-scorecard/github.com/wevm/wagmi?label=openssf+scorecard&style=flat&color=21262d&labelColor=21262d">
       <img src="https://img.shields.io/ossf-scorecard/github.com/wevm/wagmi?label=openssf+scorecard&style=flat&color=f6f8fa&labelColor=f6f8fa" alt="OpenSSF Best Practices">
@@ -50,8 +50,8 @@
   </a>
   <a href="https://bestofjs.org/projects/wagmi">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/endpoint?colorA=21262d&colorB=21262d&url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=wevm%2Fviem%26since=daily">
-      <img src="https://img.shields.io/endpoint?colorA=f6f8fa&colorB=f6f8fa&url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=wevm%2Fviem%26since=daily" alt="Best of JS">
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/endpoint?colorA=21262d&colorB=21262d&url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=wevm%2Fwagmi%26since=daily">
+      <img src="https://img.shields.io/endpoint?colorA=f6f8fa&colorB=f6f8fa&url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=wevm%2Fwagmi%26since=daily" alt="Best of JS">
     </picture>
   </a>
   <a href="https://app.codecov.io/gh/wevm/wagmi">
@@ -196,5 +196,3 @@ If you find Wagmi useful or use it for work, please consider [sponsoring Wagmi](
 <a href="https://vercel.com/?utm_source=wevm&utm_campaign=oss">
   <img src="https://www.datocms-assets.com/31049/1618983297-powered-by-vercel.svg" alt="Powered by Vercel" height="35">
 </a>
-
-


### PR DESCRIPTION
## Summary
- Automated README maintenance for `wevm/wagmi` focused on dead links and stale API references.

## Changed files
- `.github/README.md`: 3 edit(s)

## Validation
- Reviewed README Markdown files only.
- Kept edits minimal and localized to broken references or outdated API endpoints.

Automated README maintenance pass focused on dead links and stale API references. If this saved you time, coffee on Base is always appreciated: 0x85a7d7eefac69d5f90615cf72a4dcc5657370e2c