### PR TITLE
docs(ens): fix error types and gatewayUrls snippets

### DIFF
--- a/site/core/api/actions/getEnsAvatar.md
+++ b/site/core/api/actions/getEnsAvatar.md
@@ -140,7 +140,7 @@ import { normalize } from 'viem/ens'
 import { config } from './config'
 
 const ensAvatar = await getEnsAvatar(config, {
-  gatewayUrls: ['https://cloudflare-ipfs.com'] { // [!code focus]
+  gatewayUrls: ['https://cloudflare-ipfs.com'], // [!code focus]
   name: normalize('wevm.eth'),
 })
 ```
@@ -200,7 +200,7 @@ The avatar URI for ENS name.
 ## Error
 
 ```ts
-import { type getEnsAvatarError } from '@wagmi/core'
+import { type GetEnsAvatarErrorType } from '@wagmi/core'
 ```
 
 <!--@include: @shared/query-imports.md-->

--- a/site/core/api/actions/getEnsResolver.md
+++ b/site/core/api/actions/getEnsResolver.md
@@ -157,7 +157,7 @@ The address of the resolver.
 ## Error
 
 ```ts
-import { type getEnsResolverError } from '@wagmi/core'
+import { type GetEnsResolverErrorType } from '@wagmi/core'
 ```
 
 <!--@include: @shared/query-imports.md-->

--- a/site/core/api/actions/getEnsText.md
+++ b/site/core/api/actions/getEnsText.md
@@ -185,7 +185,7 @@ Returns `null` if name does not have text assigned.
 ## Error
 
 ```ts
-import { type getEnsTextError } from '@wagmi/core'
+import { type GetEnsTextErrorType } from '@wagmi/core'
 ```
 
 <!--@include: @shared/query-imports.md-->

--- a/site/react/api/hooks/useDeployContract.md
+++ b/site/react/api/hooks/useDeployContract.md
@@ -105,7 +105,7 @@ export const wagmiAbi = [
 ## Parameters
 
 ```ts
-import { type useDeployContractParameters } from 'wagmi'
+import { type UseDeployContractParameters } from 'wagmi'
 ```
 
 ### config
@@ -133,7 +133,7 @@ function App() {
 ## Return Type
 
 ```ts
-import { type useDeployContractReturnType } from 'wagmi'
+import { type UseDeployContractReturnType } from 'wagmi'
 ```
 
 <!--@include: @shared/mutation-result.md-->

--- a/site/react/api/hooks/useEnsAvatar.md
+++ b/site/react/api/hooks/useEnsAvatar.md
@@ -174,7 +174,7 @@ import { normalize } from 'viem/ens'
 
 function App() {
   const result = useEnsAvatar({
-    gatewayUrls: ['https://cloudflare-ipfs.com'] { // [!code focus]
+    gatewayUrls: ['https://cloudflare-ipfs.com'], // [!code focus]
     name: normalize('wevm.eth'),
   })
 }

--- a/site/shared/connectors/baseAccount.md
+++ b/site/shared/connectors/baseAccount.md
@@ -60,7 +60,7 @@ Before going to production, it is highly recommended to set an [`appName`](#appn
 ## Parameters
 
 ```ts-vue
-import { type baseAccountParameters } from '{{connectorsPackageName}}'
+import { type BaseAccountParameters } from '{{connectorsPackageName}}'
 ```
 
 Check out the [Base Account SDK docs](https://www.base.org/build/base-account) for more info.

--- a/site/shared/connectors/walletConnect.md
+++ b/site/shared/connectors/walletConnect.md
@@ -80,19 +80,6 @@ const connector = walletConnect({
 })
 ```
 
-### disableProviderPing
-
-`boolean | undefined`
-
-```ts-vue
-import { walletConnect } from '{{connectorsPackageName}}'
-
-const connector = walletConnect({
-  disableProviderPing: false, // [!code focus]
-  projectId: '3fcc6bba6f1de962d911bb5b5c3dba68',
-})
-```
-
 ### isNewChainsStale
 
 `boolean | undefined`
@@ -200,7 +187,7 @@ import { walletConnect } from '{{connectorsPackageName}}'
 
 const connector = walletConnect({
   projectId: '3fcc6bba6f1de962d911bb5b5c3dba68',
-  relayUrl: 'wss://relay.walletconnect.org', // [!code focus]
+  relayUrl: 'wss://relay.walletconnect.com', // [!code focus]
 })
 ```
 

--- a/site/vue/api/composables/useConnectionEffect.md
+++ b/site/vue/api/composables/useConnectionEffect.md
@@ -36,7 +36,7 @@ useConnectionEffect({
 ## Parameters
 
 ```ts
-import { type useConnectionEffectParameters } from '@wagmi/vue'
+import { type UseConnectionEffectParameters } from '@wagmi/vue'
 ```
 
 ### config


### PR DESCRIPTION
Fix ENS docs to use the correct exported error types, and correct gatewayUrls snippet syntax in core and react pages.