### PR TITLE
fix(core): clean up injected switchChain listener

### DIFF
--- a/packages/core/src/connectors/injected.test.ts
+++ b/packages/core/src/connectors/injected.test.ts
@@ -1,5 +1,6 @@
-import { config } from '@wagmi/test'
-import { expect, test } from 'vitest'
+import { chain, config } from '@wagmi/test'
+import { UserRejectedRequestError } from 'viem'
+import { expect, test, vi } from 'vitest'
 
 import { injected } from './injected.js'
 
@@ -22,4 +23,69 @@ test.each([
   const connectorFn = injected({ target: wallet })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual(expected)
+})
+
+test('behavior: switchChain cleans up listener on switch failure', async () => {
+  const provider = {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    request: vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'wallet_switchEthereumChain')
+        throw {
+          code: UserRejectedRequestError.code,
+          message: 'User rejected the request.',
+        }
+    }),
+  }
+
+  const connectorFn = injected({
+    target: {
+      id: 'test',
+      name: 'Test',
+      provider: provider as any,
+    },
+  })
+  const connector = config._internal.connectors.setup(connectorFn)
+
+  expect(connector.emitter.listenerCount('change')).toBe(0)
+
+  await expect(
+    connector.switchChain!({ chainId: chain.mainnet2.id }),
+  ).rejects.toBeInstanceOf(UserRejectedRequestError)
+
+  expect(connector.emitter.listenerCount('change')).toBe(0)
+})
+
+test('behavior: switchChain cleans up listener when add chain is rejected', async () => {
+  const provider = {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    request: vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'wallet_switchEthereumChain')
+        throw { code: 4902, message: 'Unrecognized chain.' }
+      if (method === 'wallet_addEthereumChain')
+        throw {
+          code: UserRejectedRequestError.code,
+          message: 'User rejected the request.',
+        }
+    }),
+  }
+
+  const connectorFn = injected({
+    target: {
+      id: 'test',
+      name: 'Test',
+      provider: provider as any,
+    },
+  })
+  const connector = config._internal.connectors.setup(connectorFn)
+
+  expect(connector.emitter.listenerCount('change')).toBe(0)
+
+  await expect(
+    connector.switchChain!({ chainId: chain.mainnet2.id }),
+  ).rejects.toBeInstanceOf(UserRejectedRequestError)
+
+  expect(provider.request).toHaveBeenCalledTimes(2)
+  expect(connector.emitter.listenerCount('change')).toBe(0)
 })

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -357,15 +357,23 @@ export function injected(parameters: InjectedParameters = {}) {
       const chain = config.chains.find((x) => x.id === chainId)
       if (!chain) throw new SwitchChainError(new ChainNotConfiguredError())
 
-      const promise = new Promise<void>((resolve) => {
-        const listener = ((data) => {
-          if ('chainId' in data && data.chainId === chainId) {
-            config.emitter.off('change', listener)
-            resolve()
-          }
-        }) satisfies Parameters<typeof config.emitter.on>[1]
-        config.emitter.on('change', listener)
-      })
+      const createChainChangeListener = () => {
+        let cleanup = () => {}
+        const promise = new Promise<void>((resolve) => {
+          const listener = ((data) => {
+            if ('chainId' in data && data.chainId === chainId) {
+              cleanup()
+              resolve()
+            }
+          }) satisfies Parameters<typeof config.emitter.on>[1]
+          cleanup = () => config.emitter.off('change', listener)
+          config.emitter.on('change', listener)
+        })
+
+        return { cleanup, promise }
+      }
+
+      let { cleanup, promise } = createChainChangeListener()
 
       try {
         await Promise.all([
@@ -388,6 +396,7 @@ export function injected(parameters: InjectedParameters = {}) {
         ])
         return chain
       } catch (err) {
+        cleanup()
         const error = err as RpcError
 
         // Indicates chain is not added to provider
@@ -426,6 +435,7 @@ export function injected(parameters: InjectedParameters = {}) {
               rpcUrls,
             } satisfies AddEthereumChainParameter
 
+            ;({ cleanup, promise } = createChainChangeListener())
             await Promise.all([
               provider
                 .request({
@@ -446,6 +456,7 @@ export function injected(parameters: InjectedParameters = {}) {
 
             return chain
           } catch (error) {
+            cleanup()
             throw new UserRejectedRequestError(error as Error)
           }
         }


### PR DESCRIPTION
This cleans up the pending `change` listener in `injected.switchChain()` whenever the switch request fails, and recreates the listener for the `wallet_addEthereumChain` fallback path so rejected switches do not leave stale subscriptions behind.

Adds focused regression tests for both direct `wallet_switchEthereumChain` rejection and `wallet_addEthereumChain` rejection.