### PR TITLE
docs(walletConnect): update Reown dashboard sign-in URL

### DIFF
--- a/site/shared/connectors/walletConnect.md
+++ b/site/shared/connectors/walletConnect.md
@@ -161,7 +161,7 @@ const connector = walletConnect({
 
 `string`
 
-WalletConnect Cloud project identifier. You can find your `projectId` on your [WalletConnect dashboard](https://cloud.reown.com/sign-in).
+WalletConnect Cloud project identifier. You can find your `projectId` on your [WalletConnect dashboard](https://dashboard.reown.com/sign-in).
 
 ```ts-vue
 import { walletConnect } from '{{connectorsPackageName}}'


### PR DESCRIPTION
Update the WalletConnect dashboard link to the direct Reown sign-in URL, avoiding an unnecessary redirect for docs users.