### PR TITLE
fix(core): scope previous caches by config in getters

### DIFF
--- a/packages/core/src/actions/getChains.test.ts
+++ b/packages/core/src/actions/getChains.test.ts
@@ -1,6 +1,8 @@
 import { chain, config } from '@wagmi/test'
+import { http } from 'viem'
 import { expect, test } from 'vitest'
 
+import { createConfig } from '../createConfig.js'
 import { getChains } from './getChains.js'
 
 test('default', async () => {
@@ -11,4 +13,28 @@ test('default', async () => {
   ])
   config._internal.chains.setState([chain.mainnet, chain.mainnet2])
   expect(getChains(config)).toEqual([chain.mainnet, chain.mainnet2])
+})
+
+test('behavior: isolates cache per config', () => {
+  const config1 = createConfig({
+    chains: [chain.mainnet, chain.mainnet2],
+    transports: {
+      [chain.mainnet.id]: http(),
+      [chain.mainnet2.id]: http(),
+    },
+  })
+  const config2 = createConfig({
+    chains: [chain.mainnet, chain.mainnet2],
+    transports: {
+      [chain.mainnet.id]: http(),
+      [chain.mainnet2.id]: http(),
+    },
+  })
+
+  const chains1 = getChains(config1)
+  const chains2 = getChains(config2)
+
+  expect(chains1).toBe(config1.chains)
+  expect(chains2).toBe(config2.chains)
+  expect(chains1).not.toBe(chains2)
 })

--- a/packages/core/src/actions/getChains.ts
+++ b/packages/core/src/actions/getChains.ts
@@ -5,15 +5,18 @@ import { deepEqual } from '../utils/deepEqual.js'
 export type GetChainsReturnType<config extends Config = Config> =
   config['chains']
 
-let previousChains: readonly Chain[] = []
+const previousChainsByConfig = new WeakMap<Config, readonly Chain[]>()
 
 /** https://wagmi.sh/core/api/actions/getChains */
 export function getChains<config extends Config>(
   config: config,
 ): GetChainsReturnType<config> {
+  const previousChains = previousChainsByConfig.get(config)
   const chains = config.chains
-  if (deepEqual(previousChains, chains))
+
+  if (previousChains && deepEqual(previousChains, chains))
     return previousChains as GetChainsReturnType<config>
-  previousChains = chains
+
+  previousChainsByConfig.set(config, chains)
   return chains as unknown as GetChainsReturnType<config>
 }

--- a/packages/core/src/actions/getConnections.test.ts
+++ b/packages/core/src/actions/getConnections.test.ts
@@ -1,6 +1,9 @@
-import { config } from '@wagmi/test'
+import { accounts, chain, config } from '@wagmi/test'
+import { http } from 'viem'
 import { expect, test } from 'vitest'
 
+import { mock } from '../connectors/mock.js'
+import { createConfig } from '../createConfig.js'
 import { connect } from './connect.js'
 import { disconnect } from './disconnect.js'
 import { getConnections } from './getConnections.js'
@@ -12,4 +15,31 @@ test('default', async () => {
   expect(getConnections(config).length).toEqual(1)
   await disconnect(config, { connector })
   expect(getConnections(config)).toEqual([])
+})
+
+test('behavior: isolates reconnecting snapshot per config', async () => {
+  const config1 = createConfig({
+    chains: [chain.mainnet],
+    connectors: [mock({ accounts })],
+    transports: {
+      [chain.mainnet.id]: http(),
+    },
+  })
+  const config2 = createConfig({
+    chains: [chain.mainnet],
+    connectors: [mock({ accounts })],
+    transports: {
+      [chain.mainnet.id]: http(),
+    },
+  })
+
+  const connector = config1.connectors[0]!
+  await connect(config1, { connector })
+
+  expect(getConnections(config1).length).toBe(1)
+
+  config2.setState((state) => ({ ...state, status: 'reconnecting' }))
+  expect(getConnections(config2)).toEqual([])
+
+  await disconnect(config1, { connector })
 })

--- a/packages/core/src/actions/getConnections.ts
+++ b/packages/core/src/actions/getConnections.ts
@@ -4,13 +4,16 @@ import { deepEqual } from '../utils/deepEqual.js'
 
 export type GetConnectionsReturnType = Compute<Connection>[]
 
-let previousConnections: Connection[] = []
+const previousConnectionsByConfig = new WeakMap<Config, Connection[]>()
 
 /** https://wagmi.sh/core/api/actions/getConnections */
 export function getConnections(config: Config): GetConnectionsReturnType {
+  const previousConnections = previousConnectionsByConfig.get(config) ?? []
   const connections = [...config.state.connections.values()]
+
   if (config.state.status === 'reconnecting') return previousConnections
   if (deepEqual(previousConnections, connections)) return previousConnections
-  previousConnections = connections
+
+  previousConnectionsByConfig.set(config, connections)
   return connections
 }

--- a/packages/core/src/actions/getConnectors.test.ts
+++ b/packages/core/src/actions/getConnectors.test.ts
@@ -1,9 +1,38 @@
-import { config } from '@wagmi/test'
+import { accounts, chain, config } from '@wagmi/test'
+import { http } from 'viem'
 import { expect, test } from 'vitest'
 
+import { mock } from '../connectors/mock.js'
+import { createConfig } from '../createConfig.js'
 import { getConnectors } from './getConnectors.js'
 
 test('default', () => {
   expect(getConnectors(config)).toEqual(config.connectors)
   expect(getConnectors(config)).toEqual(config.connectors)
+})
+
+test('behavior: isolates cache per config', () => {
+  const config1 = createConfig({
+    chains: [chain.mainnet],
+    connectors: [mock({ accounts })],
+    transports: {
+      [chain.mainnet.id]: http(),
+    },
+  })
+  const config2 = createConfig({
+    chains: [chain.mainnet],
+    connectors: [mock({ accounts })],
+    transports: {
+      [chain.mainnet.id]: http(),
+    },
+  })
+
+  config2._internal.connectors.setState(() => [...config1.connectors])
+
+  const connectors1 = getConnectors(config1)
+  const connectors2 = getConnectors(config2)
+
+  expect(connectors1).toBe(config1.connectors)
+  expect(connectors2).toBe(config2.connectors)
+  expect(connectors1).not.toBe(connectors2)
 })

--- a/packages/core/src/actions/getConnectors.ts
+++ b/packages/core/src/actions/getConnectors.ts
@@ -3,20 +3,24 @@ import type { Config, Connector } from '../createConfig.js'
 export type GetConnectorsReturnType<config extends Config = Config> =
   config['connectors']
 
-let previousConnectors: readonly Connector[] = []
+const previousConnectorsByConfig = new WeakMap<Config, readonly Connector[]>()
 
 /** https://wagmi.sh/core/api/actions/getConnectors */
 export function getConnectors<config extends Config>(
   config: config,
 ): GetConnectorsReturnType<config> {
+  const previousConnectors = previousConnectorsByConfig.get(config)
   const connectors = config.connectors
+
   if (
+    previousConnectors &&
     previousConnectors.length === connectors.length &&
     previousConnectors.every(
       (connector, index) => connector === connectors[index],
     )
   )
-    return previousConnectors
-  previousConnectors = connectors
+    return previousConnectors as GetConnectorsReturnType<config>
+
+  previousConnectorsByConfig.set(config, connectors)
   return connectors
 }


### PR DESCRIPTION
Scope previous cache snapshots by config for getter actions, preventing cross-instance stale values during reconnecting. 