### PR TITLE
fix(core): correct ConnectorChainMismatchErrorType alias

### DIFF
--- a/packages/core/src/errors/config.ts
+++ b/packages/core/src/errors/config.ts
@@ -61,7 +61,7 @@ export class ConnectorAccountNotFoundError extends BaseError {
   }
 }
 
-export type ConnectorChainMismatchErrorType = ConnectorAccountNotFoundError & {
+export type ConnectorChainMismatchErrorType = ConnectorChainMismatchError & {
   name: 'ConnectorChainMismatchError'
 }
 export class ConnectorChainMismatchError extends BaseError {


### PR DESCRIPTION
Correct ConnectorChainMismatchErrorType to reference ConnectorChainMismatchError, ensuring getConnectorClient error unions stay semantically accurate. 