### PR TITLE
fix(core): correct ConnectorChainMismatchErrorType alias

### DIFF
--- a/packages/core/src/errors/config.ts
+++ b/packages/core/src/errors/config.ts
@@ -61,7 +61,7 @@ export class ConnectorAccountNotFoundError extends BaseError {
   }
 }
 
-export type ConnectorChainMismatchErrorType = ConnectorAccountNotFoundError & {
+export type ConnectorChainMismatchErrorType = ConnectorChainMismatchError & {
   name: 'ConnectorChainMismatchError'
 }
 export class ConnectorChainMismatchError extends BaseError {


### PR DESCRIPTION
  ## What this PR solves
                                                                                                                                                                   
  This PR fixes an incorrect type alias in `@wagmi/core`:                                                                                                          
                                                                                                                                                                   
  - `ConnectorChainMismatchErrorType` was mistakenly aliased to `ConnectorAccountNotFoundError`.
  - It is now correctly aliased to `ConnectorChainMismatchError` in `packages/core/src/errors/config.ts`.                                                          

  This is a type-level correctness fix (no runtime behavior change), and it aligns the exported error type with the actual error class thrown by `getConnectorClient`.                                                                                                                                            
                                                                                                                                                                   
  ## Alternatives considered                                                                                                                                       
                                                                                                                                                                   
  - Keep current alias and rely on `name` narrowing only.                                                                                                          
    - Rejected because the underlying type shape is still wrong/misleading for consumers.                                                                          
  - Define a separate manual interface for `ConnectorChainMismatchErrorType`.                                                                                      
    - Rejected to avoid duplication and drift from the source error class.                                                                                         
  - Chosen approach: alias directly to `ConnectorChainMismatchError`, consistent with other error type aliases in this file.                                       
                                                                                                                                                                   
  ## Areas for reviewer attention                                                                                                                                  

  - Confirm this alias correction is semantically correct for all downstream exported unions (notably `GetConnectorClientErrorType`).                              
  - Confirm there is no code that accidentally depended on the previous incorrect alias shape.                                                                     
  - Confirm this should be treated as a patch-level type fix.
                                                                                                                                                                   
  ## Documentation

  No documentation updates were needed (internal type alias correction only).

  ## Tests

  Executed:
                                                                                                                                                                   
  - `pnpm vitest run --pool=threads --maxWorkers=1 packages/core/src/errors/config.test.ts` ✅                                                                     
                                                                                                                                                                   
  No runtime logic changed; this PR is focused on type correctness.       