### PR TITLE
Fix Vue connectors sidebar namespace

### DIFF
--- a/site/vue/api/connectors.md
+++ b/site/vue/api/connectors.md
@@ -1,7 +1,7 @@
 <script setup>
 import { getSidebar } from '../../.vitepress/sidebar'
 
-const connectors = getSidebar()['/react']
+const connectors = getSidebar()['/vue']
   .find(x => x.text.includes('Configuration')).items
   .find(x => x.text.includes('Connectors')).items
   .sort((a, b) => a.text.localeCompare(b.text))


### PR DESCRIPTION
  ## What is this PR solving?                                                                                                                                                                   
                                                                                                                                                                                                
  This fixes a docs navigation mismatch on `site/vue/api/connectors.md`: the page currently reads connector links from `getSidebar()['/react']`, even though the page is in the Vue docs and imports from `@wagmi/vue/connectors`.                                                                                                                                                         
  Using the React namespace can route users to React paths from the Vue API page. This PR switches it to `getSidebar()['/vue']` so the links stay within the Vue docs tree.
                                                                                                                                                                                                
  ## What alternatives have you explored?
                                                                                                                                                                                                
  I considered hardcoding connector links in the page, but that would duplicate sidebar data and increase maintenance cost.                                                                     
  Using the existing Vue sidebar namespace is the minimal, correct fix.                                                                                                                         
                                                                                                                                                                                                
  ## Any parts that require more reviewer attention?                                                                                                                                            
                                                                                                                                                                                                
  Please focus on verifying that the "Available Connectors" links under `/vue/api/connectors` resolve to `/vue/api/connectors/*` and no longer point to `/react/*`.                             

  ## Notes                                                                                                                                                                                      
                                                                                                                                                                                                
  This is a one-line docs fix with no runtime/package behavior change.  