### PR TITLE
docs: add coinbaseWallet connector links to sidebars

### DIFF
--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -89,6 +89,10 @@ export function getSidebar() {
                 text: 'baseAccount',
                 link: '/react/api/connectors/baseAccount',
               },
+              {
+                text: 'coinbaseWallet',
+                link: '/react/api/connectors/coinbaseWallet',
+              },
               { text: 'injected', link: '/react/api/connectors/injected' },
               {
                 text: 'metaMask',
@@ -459,6 +463,10 @@ export function getSidebar() {
                 text: 'baseAccount',
                 link: '/vue/api/connectors/baseAccount',
               },
+              {
+                text: 'coinbaseWallet',
+                link: '/vue/api/connectors/coinbaseWallet',
+              },
               { text: 'injected', link: '/vue/api/connectors/injected' },
               {
                 text: 'metaMask',
@@ -718,6 +726,10 @@ export function getSidebar() {
               {
                 text: 'baseAccount',
                 link: '/core/api/connectors/baseAccount',
+              },
+              {
+                text: 'coinbaseWallet',
+                link: '/core/api/connectors/coinbaseWallet',
               },
               { text: 'injected', link: '/core/api/connectors/injected' },
               {


### PR DESCRIPTION
This adds missing coinbaseWallet entries to the React, Vue, and Core connectors sidebar lists, ensuring the existing connector docs are discoverable from aggregated connectors pages.