### PR TITLE
docs(react): add tip for automated v1 to v2 migration codemod

### DIFF
--- a/site/react/guides/migrate-from-v1-to-v2.md
+++ b/site/react/guides/migrate-from-v1-to-v2.md
@@ -80,6 +80,14 @@ Wagmi v2 no longer publishes a separate `cjs` tag since very few people use this
 
 ## Hooks
 
+:::tip[Automate the migration]
+You can automate ~80% of this migration, including the complex TanStack Query v5 callback refactoring, using the community codemod [`@zerosky1221/wagmi-v1-to-v2`](https://app.codemod.com/registry/@zerosky1221/wagmi-v1-to-v2):
+
+```bash
+npx codemod@latest @zerosky1221/wagmi-v1-to-v2 -t ./src
+```
+:::
+
 ### Removed mutation setup arguments
 
 Mutation hooks are hooks that change network or application state, sign data, or perform write operations through mutation functions. With Wagmi v1, you could pass arguments directly to these hooks instead of using them with their mutation functions. For example:


### PR DESCRIPTION
Hi @jxom and @tmm! 

I noticed migrating to v2 (especially rewriting query callbacks into `useEffect` for TanStack v5) is a major friction point. 

I've built a hybrid AST+AI Codemod specifically designed for this migration guide. It successfully migrates 100% of the core hooks in `scaffold-eth-2` with zero false positives.

Link: https://app.codemod.com/registry/@zerosky1221/wagmi-v1-to-v2
Case Study/Coverage: https://github.com/zerosky1221/wagmi-v1-to-v2/blob/main/CASE_STUDY.md
Full Video Demo (40s): https://youtu.be/6LeSqNmRGNI

Demo: - https://raw.githubusercontent.com/zerosky1221/wagmi-v1-to-v2/main/demo.gif

Added a small tip to the docs to save users hours of refactoring. Happy to iterate on wording or scope!