### PR TITLE
fix(core): accept multi-chain getClient in viem actions

### DIFF
--- a/packages/core/src/actions/getClient.test-d.ts
+++ b/packages/core/src/actions/getClient.test-d.ts
@@ -1,6 +1,10 @@
 import { chain, config } from '@wagmi/test'
 import { expectTypeOf, test } from 'vitest'
 
+import { http } from 'viem'
+import { waitForTransactionReceipt } from 'viem/actions'
+import { arbitrumNova, optimism } from 'viem/chains'
+import { createConfig } from '../createConfig.js'
 import { getClient } from './getClient.js'
 
 test('default', () => {
@@ -24,4 +28,16 @@ test('behavior: unconfigured chain', () => {
     chainId: 123456,
   })
   expectTypeOf(client).toEqualTypeOf<undefined>()
+})
+
+test('behavior: viem actions', () => {
+  const config = createConfig({
+    chains: [arbitrumNova, optimism],
+    transports: {
+      [arbitrumNova.id]: http(),
+      [optimism.id]: http(),
+    },
+  })
+  const client = getClient(config)
+  waitForTransactionReceipt(client, { hash: '0x123' })
 })

--- a/packages/core/src/actions/getClient.ts
+++ b/packages/core/src/actions/getClient.ts
@@ -28,7 +28,7 @@ export type GetClientReturnType<
       ? chainId
       : config['chains'][number]['id']
     : config['chains'][number]['id'] | undefined,
-> = resolvedChainId extends config['chains'][number]['id']
+> = [resolvedChainId] extends [config['chains'][number]['id']]
   ? Compute<
       Client<
         config['_internal']['transports'][resolvedChainId],


### PR DESCRIPTION
## Summary
- stop `GetClientReturnType` from distributing over multi-chain `resolvedChainId` unions
- add a type regression for passing `getClient(config)` from a two-chain config into `viem/actions` `waitForTransactionReceipt`

## Validation
- ran a minimal TypeScript reproduction that failed with the old distributive return type and passes with this change

Closes #3635