### PR TITLE
feat(tempo): pass `theme` option through `tempoWallet` connector

### DIFF
--- a/.changeset/tempo-wallet-theme.md
+++ b/.changeset/tempo-wallet-theme.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+feat(tempo): Pass `theme` option through to `tempoWallet` connector.

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -66,6 +66,7 @@ export function tempoWallet(parameters: tempoWallet.Parameters = {}) {
     icon = tempoWalletIcon,
     name,
     rdns,
+    theme,
     ...providerParameters
   } = parameters
 
@@ -77,6 +78,7 @@ export function tempoWallet(parameters: tempoWallet.Parameters = {}) {
         icon,
         name,
         rdns,
+        theme,
       })
     },
     icon,


### PR DESCRIPTION
The `tempoWallet` connector accepts `AccountsDialogParameters` which includes `theme`, but it wasn't being destructured or passed through to `accounts.dialog()`. This adds the missing passthrough so consumers can customize the dialog theme via `tempoWallet({ theme: { accent: 'blue' } })`.