### PR TITLE
fix(core): preserve multi-chain getClient action typing

### DIFF
--- a/.changeset/fuzzy-koalas-carry.md
+++ b/.changeset/fuzzy-koalas-carry.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Preserved `getClient` viem action typing when the config contains multiple chains.

--- a/packages/core/src/actions/getClient.test-d.ts
+++ b/packages/core/src/actions/getClient.test-d.ts
@@ -1,6 +1,9 @@
 import { chain, config } from '@wagmi/test'
+import { http } from 'viem'
+import { waitForTransactionReceipt } from 'viem/actions'
 import { expectTypeOf, test } from 'vitest'
-
+import { createConfig } from '../createConfig.js'
+import { arbitrumNova, optimism } from '../exports/chains.js'
 import { getClient } from './getClient.js'
 
 test('default', () => {
@@ -24,4 +27,16 @@ test('behavior: unconfigured chain', () => {
     chainId: 123456,
   })
   expectTypeOf(client).toEqualTypeOf<undefined>()
+})
+
+test('behavior: viem actions', () => {
+  const config = createConfig({
+    chains: [arbitrumNova, optimism],
+    transports: {
+      [arbitrumNova.id]: http(),
+      [optimism.id]: http(),
+    },
+  })
+  const client = getClient(config)
+  waitForTransactionReceipt(client, { hash: '0x123' })
 })

--- a/packages/core/src/actions/getClient.ts
+++ b/packages/core/src/actions/getClient.ts
@@ -28,7 +28,7 @@ export type GetClientReturnType<
       ? chainId
       : config['chains'][number]['id']
     : config['chains'][number]['id'] | undefined,
-> = resolvedChainId extends config['chains'][number]['id']
+> = [resolvedChainId] extends [config['chains'][number]['id']]
   ? Compute<
       Client<
         config['_internal']['transports'][resolvedChainId],


### PR DESCRIPTION
## Summary
- add a type regression covering `waitForTransactionReceipt(getClient(config), ...)` with a multi-chain config
- preserve the full multi-chain action client type by avoiding distributive conditional behavior in `GetClientReturnType`

## Testing
- pnpm bench:types packages/core/src/actions/getClient.test-d.ts

Closes #3635
