### PR TITLE
fix(react): narrow generated simulate hook types

### DIFF
--- a/.changeset/quiet-tigers-cheer.md
+++ b/.changeset/quiet-tigers-cheer.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/react': patch
+---
+
+Narrowed generated `useSimulateContract` hook result types for functions that share argument shapes.

--- a/packages/react/src/hooks/codegen/createUseSimulateContract.test-d.ts
+++ b/packages/react/src/hooks/codegen/createUseSimulateContract.test-d.ts
@@ -193,3 +193,64 @@ test('functionName with overloads', () => {
     | undefined
   >(result4.data?.result)
 })
+
+test('narrows data for functions with matching argument shapes', () => {
+  const abiSameArgsDifferentReturns = [
+    {
+      type: 'function',
+      name: 'foo',
+      stateMutability: 'nonpayable',
+      inputs: [{ name: 'ilk', type: 'bytes32' }],
+      outputs: [{ type: 'uint256' }],
+    },
+    {
+      type: 'function',
+      name: 'bar',
+      stateMutability: 'nonpayable',
+      inputs: [{ name: 'ilk', type: 'bytes32' }],
+      outputs: [
+        { name: 'art', type: 'uint256' },
+        { name: 'rate', type: 'uint256' },
+      ],
+    },
+  ] as const
+  const useSimulateContractSameArgs = createUseSimulateContract({
+    abi: abiSameArgsDifferentReturns,
+  })
+
+  {
+    const result = useSimulateContractSameArgs({
+      functionName: 'foo',
+      args: [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ],
+    })
+    assertType<bigint | undefined>(result.data?.result)
+  }
+  {
+    const result = useSimulateContractSameArgs({
+      functionName: 'bar',
+      args: [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ],
+    })
+    assertType<readonly [bigint, bigint] | undefined>(result.data?.result)
+  }
+
+  useSimulateContractSameArgs({
+    // @ts-expect-error invalid functionName
+    functionName: 'baz',
+  })
+
+  useSimulateContractSameArgs({
+    functionName: 'foo',
+    // @ts-expect-error wrong args for foo (expects bytes32)
+    args: [123n],
+  })
+
+  useSimulateContractSameArgs({
+    functionName: 'foo',
+    // @ts-expect-error abi not allowed on generated hook
+    abi: abiSameArgsDifferentReturns,
+  })
+})

--- a/packages/react/src/hooks/codegen/createUseSimulateContract.ts
+++ b/packages/react/src/hooks/codegen/createUseSimulateContract.ts
@@ -8,7 +8,7 @@ import type {
   ConfigParameter,
   QueryParameter,
   ScopeKeyParameter,
-  UnionExactPartial,
+  UnionCompute,
 } from '@wagmi/core/internal'
 import type {
   SimulateContractData,
@@ -44,6 +44,12 @@ export type CreateUseSimulateContractParameters<
     | undefined
 }
 
+/** Call-level options from SimulateContractParameters (excludes abi, address, functionName, args). */
+type SimulateContractCallOptions<config extends Config> = Omit<
+  SimulateContractParameters<Abi, string, readonly unknown[], config>,
+  'abi' | 'address' | 'functionName' | 'args'
+>
+
 export type CreateUseSimulateContractReturnType<
   abi extends Abi | readonly unknown[],
   address extends Address | Record<number, Address> | undefined,
@@ -57,28 +63,28 @@ export type CreateUseSimulateContractReturnType<
   chainId extends config['chains'][number]['id'] | undefined = undefined,
   selectData = SimulateContractData<abi, name, args, config, chainId>,
 >(
-  parameters?: {
-    abi?: undefined
-    address?: address extends undefined ? Address : undefined
-    functionName?: functionName extends undefined ? name : undefined
-    chainId?: address extends Record<number, Address>
-      ?
-          | keyof address
-          | (chainId extends keyof address ? chainId : never)
-          | undefined
-      : chainId | number | undefined
-  } & UnionExactPartial<
-    // TODO: Take `abi` and `address` from above and omit from below (currently breaks inference)
-    SimulateContractParameters<abi, name, args, config, chainId>
-  > &
-    ScopeKeyParameter &
-    ConfigParameter<config> &
-    QueryParameter<
-      SimulateContractQueryFnData<abi, name, args, config, chainId>,
-      SimulateContractErrorType,
-      selectData
-      // TODO: Add `SimulateContractQueryKey<abi, name, args, config, chainId>` as 4th type param (currently causes TS2589)
-    >,
+  parameters?: UnionCompute<
+    {
+      abi?: undefined
+      address?: address extends undefined ? Address : undefined
+      functionName?: functionName extends undefined ? name : undefined
+      args?: args | undefined
+      chainId?: address extends Record<number, Address>
+        ?
+            | keyof address
+            | (chainId extends keyof address ? chainId : never)
+            | undefined
+        : chainId | number | undefined
+    } & Partial<SimulateContractCallOptions<config>> &
+      ScopeKeyParameter &
+      ConfigParameter<config> &
+      QueryParameter<
+        SimulateContractQueryFnData<abi, name, args, config, chainId>,
+        SimulateContractErrorType,
+        selectData
+        // TODO: Add `SimulateContractQueryKey<abi, name, args, config, chainId>` as 4th type param (currently causes TS2589)
+      >
+  >,
 ) => UseSimulateContractReturnType<abi, name, args, config, chainId, selectData>
 
 export function createUseSimulateContract<


### PR DESCRIPTION
## Summary
- narrow generated simulate hook call-site types to omit generated fields such as `abi`, `address`, `functionName`, and `args`
- add a dts regression for functions with matching argument shapes but different return types
- keep generated simulate hook result narrowing aligned with the recent generated read hook fix

## Testing
- pnpm bench:types packages/react/src/hooks/codegen/createUseSimulateContract.test-d.ts
