### PR TITLE
fix(tempo): use accounts SDK default storage in tempoWallet connector

### DIFF
--- a/.changeset/tempo-connector-storage-default.md
+++ b/.changeset/tempo-connector-storage-default.md
@@ -1,0 +1,7 @@
+---
+'@wagmi/core': patch
+---
+
+Made `tempoWallet` connector use the accounts SDK's default storage (`Storage.idb`) instead of wrapping wagmi's `config.storage`. Access keys now share state with other `Provider.create` consumers on the same origin, so silent signing works cross-page.
+
+Users may need to reconnect once — old state at `wagmi.accounts.xyz.tempo.*` in localStorage is no longer read.

--- a/.changeset/tempo-connector-storage-default.md
+++ b/.changeset/tempo-connector-storage-default.md
@@ -2,6 +2,4 @@
 '@wagmi/core': patch
 ---
 
-Made `tempoWallet` connector use the accounts SDK's default storage (`Storage.idb`) instead of wrapping wagmi's `config.storage`. Access keys now share state with other `Provider.create` consumers on the same origin, so silent signing works cross-page.
-
-Users may need to reconnect once — old state at `wagmi.accounts.xyz.tempo.*` in localStorage is no longer read.
+Fixed `tempoWallet` connector to use default storage on `accounts`.

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -35,7 +35,6 @@ type AccountsAdapter = NonNullable<AccountsProviderParameters['adapter']>
 type AccountsDangerousSecp256k1Parameters = NonNullable<
   Parameters<typeof accountsDangerousSecp256k1>[0]
 >
-type AccountsStorage = NonNullable<AccountsProviderParameters['storage']>
 type AccountsWebAuthnParameters = NonNullable<
   Parameters<typeof accountsWebAuthn>[0]
 >
@@ -171,44 +170,6 @@ export declare namespace dangerous_secp256k1 {
     Omit<AccountsProviderParameters, 'adapter' | 'chains'>
 }
 
-function createAccountsStorage(
-  storage: {
-    getItem(key: string, defaultValue?: null | undefined): unknown
-    setItem(key: string, value: unknown): void | Promise<void>
-    removeItem(key: string): void | Promise<void>
-  },
-  namespace: string,
-): AccountsStorage {
-  const prefix = `accounts.${namespace}`
-  return {
-    async getItem<value>(key: string) {
-      return ((await storage.getItem(`${prefix}.${key}`, null)) ??
-        null) as value | null
-    },
-    async removeItem(key) {
-      await storage.removeItem(`${prefix}.${key}`)
-    },
-    async setItem(key, value) {
-      await storage.setItem(`${prefix}.${key}`, value)
-    },
-  }
-}
-
-function createMemoryAccountsStorage(): AccountsStorage {
-  const map = new Map<string, unknown>()
-  return {
-    async getItem<value>(key: string) {
-      return (map.get(key) ?? null) as value | null
-    },
-    async removeItem(key) {
-      map.delete(key)
-    },
-    async setItem(key, value) {
-      map.set(key, value)
-    },
-  }
-}
-
 function _setup(parameters: setup.Parameters) {
   type Properties = {
     connect<withCapabilities extends boolean = false>(
@@ -238,11 +199,6 @@ function _setup(parameters: setup.Parameters) {
           ...parameters.providerParameters,
           adapter: parameters.createAdapter(accounts),
           chains: config.chains as never,
-          storage:
-            parameters.providerParameters.storage ??
-            (config.storage
-              ? createAccountsStorage(config.storage, parameters.id)
-              : createMemoryAccountsStorage()),
         }) as unknown as Provider
       })()
 


### PR DESCRIPTION
Fixes tempoxyz/accounts#259.

The `tempoWallet` connector was wrapping wagmi's `config.storage` (localStorage) for accounts-SDK state, writing under `wagmi.accounts.xyz.tempo.*`. Any other `Provider.create` consumer on the same origin, including mppx's bundled payment UI, defaults to `Storage.idb({ key: 'tempo' })` and reads/writes `tempo.store` in IndexedDB.

Two persistence paths on one origin meant access keys authorized via `tempoWallet` were invisible to those other consumers, so silent signing on e.g. a payment-link page fell back to the approval dialog.

This drops the storage override so `Provider.create`'s default fires and both sides share a single storage path. Consumers who want custom storage can still pass `providerParameters.storage` as before.

## Migration

Users on the previous version have state at `localStorage["wagmi.accounts.xyz.tempo.store"]`. After upgrade the connector reads from IndexedDB, so that state is effectively ignored. Users may need to reconnect wallet and re-authorize access keys once.

## Diff

~45 lines removed, 0 added. Drops the storage override block plus the now-unused `createAccountsStorage`, `createMemoryAccountsStorage` helpers and the local `AccountsStorage` type. Tested locally against the mpp-playground, silent signing cross-page works without any consumer-side storage pin.