### PR TITLE
fix(core): preserve connector signer context during prepare

### DIFF
--- a/.changeset/great-drinks-smoke.md
+++ b/.changeset/great-drinks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Preserved connector signer context during transaction preparation so connectors that expose richer local account details prepare requests consistently with connector-aware transaction flows.

--- a/packages/core/src/actions/estimateGas.ts
+++ b/packages/core/src/actions/estimateGas.ts
@@ -1,4 +1,4 @@
-import type { Account, Address, Chain } from 'viem'
+import type { Chain } from 'viem'
 import {
   type EstimateGasErrorType as viem_EstimateGasErrorType,
   type EstimateGasParameters as viem_EstimateGasParameters,
@@ -15,10 +15,8 @@ import type {
 } from '../types/properties.js'
 import type { UnionCompute, UnionLooseOmit } from '../types/utils.js'
 import { getAction } from '../utils/getAction.js'
-import {
-  type GetConnectorClientErrorType,
-  getConnectorClient,
-} from './getConnectorClient.js'
+import { getConnectorAccount } from './getConnectorAccount.js'
+import type { GetConnectorClientErrorType } from './getConnectorClient.js'
 
 export type EstimateGasParameters<
   config extends Config = Config,
@@ -56,17 +54,11 @@ export async function estimateGas<
 ): Promise<EstimateGasReturnType> {
   const { chainId, connector, ...rest } = parameters
 
-  let account: Address | Account
-  if (parameters.account) account = parameters.account
-  else {
-    const connectorClient = await getConnectorClient(config, {
-      account: parameters.account,
-      assertChainId: false,
-      chainId,
-      connector,
-    })
-    account = connectorClient.account
-  }
+  const account = await getConnectorAccount(config, {
+    account: parameters.account,
+    chainId,
+    connector,
+  })
 
   const client = config.getClient({ chainId })
   const action = getAction(client, viem_estimateGas, 'estimateGas')

--- a/packages/core/src/actions/getConnectorAccount.ts
+++ b/packages/core/src/actions/getConnectorAccount.ts
@@ -1,0 +1,84 @@
+import type { Account, Address } from 'viem'
+
+import type { Config, Connector } from '../createConfig.js'
+import { getConnectorClient } from './getConnectorClient.js'
+
+type Parameters<
+  config extends Config,
+  chainId extends config['chains'][number]['id'] | undefined,
+> = {
+  account?: Address | Account | undefined
+  chainId?: chainId | config['chains'][number]['id'] | undefined
+  connector?: Connector | undefined
+  required?: boolean | undefined
+}
+
+export function getConnectorAccount<
+  config extends Config,
+  chainId extends config['chains'][number]['id'] | undefined = undefined,
+>(
+  config: config,
+  parameters: Parameters<config, chainId> & { required: false },
+): Promise<Address | Account | undefined>
+
+export function getConnectorAccount<
+  config extends Config,
+  chainId extends config['chains'][number]['id'] | undefined = undefined,
+>(
+  config: config,
+  parameters: Parameters<config, chainId>,
+): Promise<Address | Account>
+
+export async function getConnectorAccount<
+  config extends Config,
+  chainId extends config['chains'][number]['id'] | undefined = undefined,
+>(
+  config: config,
+  parameters: Parameters<config, chainId>,
+): Promise<Address | Account | undefined> {
+  const { account, chainId, connector, required = true } = parameters
+
+  if (typeof account === 'object') return account
+
+  const currentConnection = (() => {
+    if (!config.state.current) return undefined
+    return config.state.connections.get(config.state.current)
+  })()
+
+  const connection = connector
+    ? config.state.connections.get(connector.uid)
+    : currentConnection
+
+  if (account) {
+    if (!connection) return account
+
+    if (!connector && !connection.connector.getClient) return account
+
+    const connectorClient = await getConnectorClient(config, {
+      assertChainId: false,
+      chainId,
+      connector,
+    })
+
+    if (
+      connectorClient.account.type !== 'json-rpc' &&
+      connectorClient.account.address.toLowerCase() === account.toLowerCase()
+    )
+      return connectorClient.account
+
+    return account
+  }
+
+  if (!connector) {
+    if (!currentConnection && !required) return undefined
+    if (currentConnection && !currentConnection.connector.getClient)
+      return currentConnection.accounts[0]
+  }
+
+  const connectorClient = await getConnectorClient(config, {
+    assertChainId: false,
+    chainId,
+    connector,
+  })
+  return connectorClient.account
+}

--- a/packages/core/src/actions/prepareTransactionRequest.connector.test.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.connector.test.ts
@@ -1,0 +1,138 @@
+import { privateKey } from '@wagmi/test'
+import { type Address, createClient, custom } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { mainnet } from 'viem/chains'
+import { expect, test, vi } from 'vitest'
+
+import { createConnector } from '../connectors/createConnector.js'
+import { mock } from '../connectors/mock.js'
+import { createConfig } from '../createConfig.js'
+import { connect } from './connect.js'
+import { disconnect } from './disconnect.js'
+import { prepareTransactionRequest } from './prepareTransactionRequest.js'
+
+const localAccount = Object.assign(privateKeyToAccount(privateKey), {
+  keyType: 'webAuthn' as const,
+})
+
+function createTestConfig(options: {
+  connectorAccount: { address: Address; type: 'json-rpc' } | typeof localAccount
+}) {
+  const { connectorAccount } = options
+  const prepareSpy = vi.fn(async (parameters: any) => ({
+    ...parameters,
+    chainId: mainnet.id,
+    from:
+      typeof parameters.account === 'string'
+        ? parameters.account
+        : parameters.account.address,
+    gas: 21_000n,
+    maxFeePerGas: 1n,
+    maxPriorityFeePerGas: 1n,
+    nonce: 0,
+    type: 'eip1559' as const,
+  }))
+
+  const config = createConfig({
+    chains: [mainnet],
+    connectors: [
+      createConnector((config) => {
+        const base = mock({ accounts: [connectorAccount.address] })(config)
+        return {
+          ...base,
+          async getClient({ chainId } = {}) {
+            const chain =
+              config.chains.find((chain) => chain.id === chainId) ??
+              config.chains[0]
+            return createClient({
+              account: connectorAccount,
+              chain,
+              transport: custom({ request: async () => null }),
+            })
+          },
+        }
+      }),
+    ],
+    storage: null,
+    transports: {
+      [mainnet.id]: custom({ request: async () => null }),
+    },
+  })
+  const client = createClient({
+    chain: mainnet,
+    transport: custom({ request: async () => null }),
+  }).extend(() => ({
+    prepareTransactionRequest: prepareSpy,
+  }))
+  vi.spyOn(config, 'getClient').mockReturnValue(client as never)
+
+  return { config, connector: config.connectors[0]!, prepareSpy }
+}
+
+test('behavior: preserves richer connected account details', async () => {
+  const { config, connector, prepareSpy } = createTestConfig({
+    connectorAccount: localAccount,
+  })
+  await connect(config, { connector })
+
+  await prepareTransactionRequest(config, {
+    to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  })
+
+  expect(prepareSpy.mock.calls[0]?.[0]?.account).toBe(localAccount)
+
+  await disconnect(config, { connector })
+})
+
+test('parameters: connector preserves richer connected account details', async () => {
+  const { config, connector, prepareSpy } = createTestConfig({
+    connectorAccount: localAccount,
+  })
+  await connect(config, { connector })
+
+  await prepareTransactionRequest(config, {
+    connector,
+    to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  })
+
+  expect(prepareSpy.mock.calls[0]?.[0]?.account).toBe(localAccount)
+
+  await disconnect(config, { connector })
+})
+
+test('behavior: upgrades the current address to the richer connector account', async () => {
+  const { config, connector, prepareSpy } = createTestConfig({
+    connectorAccount: localAccount,
+  })
+  await connect(config, { connector })
+
+  await prepareTransactionRequest(config, {
+    account: localAccount.address,
+    connector,
+    to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  })
+
+  expect(prepareSpy.mock.calls[0]?.[0]?.account).toBe(localAccount)
+
+  await disconnect(config, { connector })
+})
+
+test('behavior: preserves json-rpc connector accounts as addresses', async () => {
+  const jsonRpcAccount = {
+    address: localAccount.address,
+    type: 'json-rpc' as const,
+  }
+  const { config, connector, prepareSpy } = createTestConfig({
+    connectorAccount: jsonRpcAccount,
+  })
+  await connect(config, { connector })
+
+  await prepareTransactionRequest(config, {
+    connector,
+    to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  })
+
+  expect(prepareSpy.mock.calls[0]?.[0]?.account).toEqual(jsonRpcAccount)
+
+  await disconnect(config, { connector })
+})

--- a/packages/core/src/actions/prepareTransactionRequest.test-d.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.test-d.ts
@@ -14,6 +14,7 @@ const targetAccount = accounts[1]
 test('default', async () => {
   const response = await prepareTransactionRequest(config, {
     chainId: 1,
+    connector: config.connectors[0],
     to: '0x',
     value: parseEther('1'),
   })
@@ -56,6 +57,7 @@ test('chain formatters', async () => {
   }>()
   const request2 = await prepareTransactionRequest(config, {
     chainId: celo.id,
+    connector: config.connectors[0],
     to: targetAccount,
     value: parseEther('0.01'),
     feeCurrency: '0x',

--- a/packages/core/src/actions/prepareTransactionRequest.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.ts
@@ -10,15 +10,20 @@ import type {
 import { prepareTransactionRequest as viem_prepareTransactionRequest } from 'viem/actions'
 
 import type { Config } from '../createConfig.js'
+import type { BaseErrorType, ErrorType } from '../errors/base.js'
 import type { SelectChains } from '../types/chain.js'
-import type { ChainIdParameter } from '../types/properties.js'
+import type {
+  ChainIdParameter,
+  ConnectorParameter,
+} from '../types/properties.js'
 import type {
   IsNarrowable,
   UnionCompute,
   UnionStrictOmit,
 } from '../types/utils.js'
 import { getAction } from '../utils/getAction.js'
-import { getConnection } from './getConnection.js'
+import { getConnectorAccount } from './getConnectorAccount.js'
+import type { GetConnectorClientErrorType } from './getConnectorClient.js'
 
 export type PrepareTransactionRequestParameters<
   config extends Config = Config,
@@ -51,7 +56,8 @@ export type PrepareTransactionRequestParameters<
       >,
       'chain'
     > &
-      ChainIdParameter<config, chainId> & {
+      ChainIdParameter<config, chainId> &
+      ConnectorParameter & {
         to: Address
       }
   >
@@ -89,7 +95,10 @@ export type PrepareTransactionRequestReturnType<
 }[number]
 
 export type PrepareTransactionRequestErrorType =
-  viem_PrepareTransactionRequestErrorType
+  | GetConnectorClientErrorType
+  | BaseErrorType
+  | ErrorType
+  | viem_PrepareTransactionRequestErrorType
 
 /** https://wagmi.sh/core/api/actions/prepareTransactionRequest */
 export async function prepareTransactionRequest<
@@ -103,9 +112,15 @@ export async function prepareTransactionRequest<
   config: config,
   parameters: PrepareTransactionRequestParameters<config, chainId, request>,
 ): Promise<PrepareTransactionRequestReturnType<config, chainId, request>> {
-  const { account: account_, chainId, ...rest } = parameters
+  const { chainId, connector, ...rest } = parameters
 
-  const account = account_ ?? getConnection(config).address
+  const account = await getConnectorAccount(config, {
+    account: parameters.account,
+    chainId,
+    connector,
+    required: false,
+  })
+
   const client = config.getClient({ chainId })
 
   const action = getAction(

--- a/packages/core/src/actions/simulateContract.ts
+++ b/packages/core/src/actions/simulateContract.ts
@@ -22,10 +22,8 @@ import type {
 } from '../types/properties.js'
 import type { Compute, PartialBy, UnionCompute } from '../types/utils.js'
 import { getAction } from '../utils/getAction.js'
-import {
-  type GetConnectorClientErrorType,
-  getConnectorClient,
-} from './getConnectorClient.js'
+import { getConnectorAccount } from './getConnectorAccount.js'
+import type { GetConnectorClientErrorType } from './getConnectorClient.js'
 
 export type SimulateContractParameters<
   abi extends Abi | readonly unknown[] = Abi,
@@ -130,16 +128,11 @@ export async function simulateContract<
   const { abi, chainId, connector, ...rest } =
     parameters as SimulateContractParameters
 
-  let account: Address | Account
-  if (parameters.account) account = parameters.account
-  else {
-    const connectorClient = await getConnectorClient(config, {
-      assertChainId: false,
-      chainId,
-      connector,
-    })
-    account = connectorClient.account
-  }
+  const account = await getConnectorAccount(config, {
+    account: parameters.account,
+    chainId,
+    connector,
+  })
 
   const client = config.getClient({ chainId })
   const action = getAction(client, viem_simulateContract, 'simulateContract')

--- a/packages/core/src/query/prepareTransactionRequest.test-d.ts
+++ b/packages/core/src/query/prepareTransactionRequest.test-d.ts
@@ -12,6 +12,7 @@ const targetAccount = accounts[1]
 test('default', async () => {
   const options = prepareTransactionRequestQueryOptions(config, {
     chainId: 1,
+    connector: config.connectors[0],
     to: '0x',
     value: parseEther('1'),
   })
@@ -47,6 +48,7 @@ test('chain formatters', async () => {
   {
     const options = prepareTransactionRequestQueryOptions(config, {
       chainId: celo.id,
+      connector: config.connectors[0],
       to: targetAccount,
       value: parseEther('0.01'),
       feeCurrency: '0x',

--- a/packages/core/src/query/prepareTransactionRequest.test.ts
+++ b/packages/core/src/query/prepareTransactionRequest.test.ts
@@ -64,6 +64,29 @@ test('parameters: account', () => {
   `)
 })
 
+test('parameters: connector', () => {
+  expect(
+    prepareTransactionRequestQueryOptions(config, {
+      connector: config.connectors[0],
+      to: targetAccount,
+      value: parseEther('1'),
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "enabled": true,
+      "queryFn": [Function],
+      "queryKey": [
+        "prepareTransactionRequest",
+        {
+          "connectorUid": "${config.connectors[0]?.uid}",
+          "to": "0x95132632579b073D12a6673e18Ab05777a6B86f8",
+          "value": 1000000000000000000n,
+        },
+      ],
+    }
+  `)
+})
+
 test('parameters: data', () => {
   expect(
     prepareTransactionRequestQueryOptions(config, {

--- a/packages/core/src/query/prepareTransactionRequest.ts
+++ b/packages/core/src/query/prepareTransactionRequest.ts
@@ -57,6 +57,7 @@ export function prepareTransactionRequestQueryOptions<
       if (!parameters.to) throw new Error('to is required')
       return prepareTransactionRequest(config, {
         ...(parameters as any),
+        connector: options.connector,
         to: parameters.to,
       }) as unknown as Promise<
         PrepareTransactionRequestQueryFnData<config, chainId, request>


### PR DESCRIPTION
## Summary
- preserve connector signer context when preparing transactions
- align prepare-time account resolution with Wagmi's existing connector-aware transaction flows
- add regression coverage around richer local accounts and connector-driven preparation

## Why
Some connectors can provide more than just an address for the active signer. When that richer signer context is dropped during transaction preparation, downstream preparation and estimation can behave differently than the actual send path.

This change is intended to make preparation use the same signer identity that connector-aware transaction flows already rely on, so preparation stays consistent with execution for connectors that expose richer local account details.

## Notes
The goal is to preserve existing behavior for ordinary connectors while fixing the cases where the connector can provide a more specific signer representation.