### PR TITLE
feat: resolve account via getConnectorClient in prepareTransactionRequest

### DIFF
--- a/.changeset/prepare-transaction-request-account.md
+++ b/.changeset/prepare-transaction-request-account.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+`prepareTransactionRequest` now resolves the account via `getConnectorClient` when no `account` is provided. This lets connectors that implement `getClient` (e.g. `webAuthn`) supply a local signing account instead of falling back to a json-rpc account. Also updated the `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.

--- a/.changeset/prepare-transaction-request-account.md
+++ b/.changeset/prepare-transaction-request-account.md
@@ -2,4 +2,4 @@
 '@wagmi/core': patch
 ---
 
-`prepareTransactionRequest` now resolves the account via `getConnectorClient` when no `account` is provided. This lets connectors that implement `getClient` (e.g. `webAuthn`) supply a local signing account instead of falling back to a json-rpc account. Also updated the `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.
+Resolved `account` in `prepareTransactionRequest` via `getConnectorClient` so connectors with a `getClient` method can supply a signable account. Updated `webAuthn` connector to return a signable account from `getClient`.

--- a/.changeset/prepare-transaction-request-account.md
+++ b/.changeset/prepare-transaction-request-account.md
@@ -2,4 +2,4 @@
 '@wagmi/core': patch
 ---
 
-Resolved `account` in `prepareTransactionRequest` via `getConnectorClient` so connectors with a `getClient` method can supply a signable account. Updated `webAuthn` connector to return a signable account from `getClient`.
+Resolved `account` in `prepareTransactionRequest` via `getConnectorClient` so connectors with a `getClient` method can supply a signable account.

--- a/.changeset/web-authn-signable-account.md
+++ b/.changeset/web-authn-signable-account.md
@@ -2,4 +2,4 @@
 '@wagmi/core': patch
 ---
 
-Updated `wagmi/tempo` `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.
+`wagmi/tempo`: Updated `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.

--- a/.changeset/web-authn-signable-account.md
+++ b/.changeset/web-authn-signable-account.md
@@ -2,4 +2,4 @@
 '@wagmi/core': patch
 ---
 
-Updated `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.
+Updated `wagmi/tempo` `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.

--- a/.changeset/web-authn-signable-account.md
+++ b/.changeset/web-authn-signable-account.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Updated `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.

--- a/packages/core/src/actions/prepareTransactionRequest.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.ts
@@ -18,7 +18,7 @@ import type {
   UnionStrictOmit,
 } from '../types/utils.js'
 import { getAction } from '../utils/getAction.js'
-import { getConnection } from './getConnection.js'
+import { getConnectorClient } from './getConnectorClient.js'
 
 export type PrepareTransactionRequestParameters<
   config extends Config = Config,
@@ -105,7 +105,17 @@ export async function prepareTransactionRequest<
 ): Promise<PrepareTransactionRequestReturnType<config, chainId, request>> {
   const { account: account_, chainId, ...rest } = parameters
 
-  const account = account_ ?? getConnection(config).address
+  let account: Address | Account | undefined
+  if (account_) account = account_
+  else {
+    const connectorClient = await getConnectorClient(config, {
+      account: account_,
+      assertChainId: false,
+      chainId,
+    })
+    account = connectorClient.account
+  }
+
   const client = config.getClient({ chainId })
 
   const action = getAction(

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -351,7 +351,7 @@ function _setup(parameters: setup.Parameters) {
       async getClient({ chainId } = {}) {
         const provider = await getProvider()
         return Object.assign(provider.getClient({ chainId }), {
-          account: provider.getAccount(),
+          account: provider.getAccount({ signable: true }),
         }) as never
       },
       async getProvider() {


### PR DESCRIPTION
## Summary

`prepareTransactionRequest` now resolves the account via `getConnectorClient` when no `account` is provided. This lets connectors that implement `getClient` (e.g. `webAuthn`) supply a local signing account instead of falling back to a json-rpc account derived from the connection's address.

Also updated the `webAuthn` connector's `getClient` to return a signable account via `provider.getAccount({ signable: true })`.

## Why

Previously `prepareTransactionRequest` used `getConnection(config).address` for the account, which gave a plain address. When the underlying viem action needed a local Account (e.g. for tempo `feePayer`/`keyAuthorization` flows), the call chain ended up with a json-rpc account, breaking signing flows that depend on the connector's local account.

## Changes

- `packages/core/src/actions/prepareTransactionRequest.ts`: resolve account via `getConnectorClient(config, { assertChainId: false, chainId, account })` when none is supplied.
- `packages/core/src/tempo/Connectors.ts`: `webAuthn` connector `getClient` now passes `{ signable: true }` to `provider.getAccount` so the returned client carries a signable Account.