### PR TITLE
docs: add automated v1 to v2 codemod reference

### DIFF
--- a/site/react/guides/migrate-from-v1-to-v2.md
+++ b/site/react/guides/migrate-from-v1-to-v2.md
@@ -43,6 +43,29 @@ Moving forward after Wagmi v2, new functionality will be opt-in with old functio
 The Wagmi v1 docs are still available at [1.x.wagmi.sh/react](https://1.x.wagmi.sh/react).
 :::
 
+
+## Automated Migration
+
+::: tip Run a codemod to automate ~85% of this migration
+
+```bash [npm]
+npx codemod waleedbhattiii-wagmi-v1-to-v2
+```
+
+```bash [pnpm]
+pnpm dlx codemod waleedbhattiii-wagmi-v1-to-v2
+```
+
+```bash [yarn]
+yarn dlx codemod waleedbhattiii-wagmi-v1-to-v2
+```
+
+The codemod handles all hook renames, provider changes, connector refactors, TanStack Query param restructuring, and import cleanup. Patterns requiring manual review are flagged with `TODO(wagmi-codemod)` comments.
+
+- Source: [github.com/Waleedbhattiii/wagmi-v1-to-v2](https://github.com/Waleedbhattiii/wagmi-v1-to-v2)
+- Registry: [app.codemod.com/registry/waleedbhattiii-wagmi-v1-to-v2](https://app.codemod.com/registry/waleedbhattiii-wagmi-v1-to-v2)
+:::
+
 ## Dependencies
 
 ### Moved TanStack Query to peer dependencies


### PR DESCRIPTION
### Summary

Adds a reference to a community codemod that automates ~85% of the 
v1 → v2 migration deterministically with zero false positives.

### What the codemod automates

- All 11 hook renames (useContractRead → useReadContract, useSwitchNetwork → useSwitchChain, etc.)
- `<WagmiConfig>` → `<WagmiProvider>`
- `usePrepareContractWrite` → `useSimulateContract`
- TanStack Query params moved into `query: {}`
- `watch: true` removal (preserved on `useBlockNumber`/`useBlock`)
- Connector class → factory function (`new MetaMaskConnector()` → `metaMask()`)
- `createClient` → `createConfig`, `useNetwork` → `useChainId`/`useChains`
- Stale import cleanup (handles multiline and type imports)

### Tested on this repo

Ran against the `1.x` branch of wevm/wagmi official examples:
- 27 files scanned
- 10 files changed automatically
- 7 TODO comments for patterns requiring semantic understanding
- **0 false positives**

### Links

- GitHub: https://github.com/Waleedbhattiii/wagmi-v1-to-v2
- Registry: https://app.codemod.com/registry/waleedbhattiii-wagmi-v1-to-v2