### PR TITLE
fix(connectors): add MetaMask chain fallback

### DIFF
--- a/.changeset/metamask-add-chain-fallback.md
+++ b/.changeset/metamask-add-chain-fallback.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Added a MetaMask switch-chain fallback that requests `wallet_addEthereumChain` when the target chain is missing.

--- a/packages/connectors/src/metaMask.test.ts
+++ b/packages/connectors/src/metaMask.test.ts
@@ -1,10 +1,84 @@
-import { config } from '@wagmi/test'
-import { expect, test } from 'vitest'
+import { chain, config } from '@wagmi/test'
+import { numberToHex } from 'viem'
+import { beforeEach, expect, test, vi } from 'vitest'
 
 import { metaMask } from './metaMask.js'
+
+const mocks = vi.hoisted(() => {
+  const provider = {
+    request: vi.fn(),
+  }
+  const instance = {
+    accounts: [],
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getChainId: vi.fn(),
+    getProvider: vi.fn(() => provider),
+    switchChain: vi.fn(),
+  }
+  return {
+    createEVMClient: vi.fn(async () => instance),
+    instance,
+    provider,
+  }
+})
+
+vi.mock('@metamask/connect-evm', () => ({
+  createEVMClient: mocks.createEVMClient,
+}))
+
+beforeEach(() => {
+  mocks.createEVMClient.mockClear()
+  mocks.provider.request.mockReset()
+  mocks.provider.request.mockResolvedValue(undefined)
+  mocks.instance.accounts = []
+  mocks.instance.connect.mockReset()
+  mocks.instance.disconnect.mockReset()
+  mocks.instance.getChainId.mockReset()
+  mocks.instance.getChainId.mockReturnValue(numberToHex(chain.mainnet.id))
+  mocks.instance.getProvider.mockClear()
+  mocks.instance.switchChain.mockReset()
+  mocks.instance.switchChain.mockResolvedValue(undefined)
+})
 
 test('setup', () => {
   const connectorFn = metaMask()
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual('MetaMask')
+})
+
+test('switchChain adds the chain when MetaMask reports it is missing', async () => {
+  mocks.instance.switchChain.mockRejectedValueOnce(
+    Object.assign(new Error('Unrecognized chain ID'), { code: 4902 }),
+  )
+  const connectorFn = metaMask()
+  const connector = config._internal.connectors.setup(connectorFn)
+
+  const result = await connector.switchChain!({ chainId: chain.mainnet2.id })
+
+  expect(result).toEqual(chain.mainnet2)
+  expect(mocks.instance.switchChain).toHaveBeenCalledWith({
+    chainId: numberToHex(chain.mainnet2.id),
+    chainConfiguration: {
+      blockExplorerUrls: [chain.mainnet2.blockExplorers.default.url],
+      chainId: numberToHex(chain.mainnet2.id),
+      chainName: chain.mainnet2.name,
+      iconUrls: undefined,
+      nativeCurrency: chain.mainnet2.nativeCurrency,
+      rpcUrls: [...chain.mainnet2.rpcUrls.default.http],
+    },
+  })
+  expect(mocks.provider.request).toHaveBeenCalledWith({
+    method: 'wallet_addEthereumChain',
+    params: [
+      {
+        blockExplorerUrls: [chain.mainnet2.blockExplorers.default.url],
+        chainId: numberToHex(chain.mainnet2.id),
+        chainName: chain.mainnet2.name,
+        iconUrls: undefined,
+        nativeCurrency: chain.mainnet2.nativeCurrency,
+        rpcUrls: [chain.mainnet2.rpcUrls.default.http[0]],
+      },
+    ],
+  })
 })

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -6,6 +6,7 @@ import type {
 import { ChainNotConfiguredError, createConnector } from '@wagmi/core'
 import type { ExactPartial, OneOf, UnionCompute } from '@wagmi/core/internal'
 import {
+  type AddEthereumChainParameter,
   type Address,
   getAddress,
   type Hex,
@@ -241,6 +242,49 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
         if (error.code === UserRejectedRequestError.code)
           throw new UserRejectedRequestError(error)
+
+        // Indicates chain is not added to provider
+        if (error.code === 4902) {
+          try {
+            const provider = await this.getProvider()
+
+            let blockExplorerUrls: string[] | undefined
+            if (addEthereumChainParameter?.blockExplorerUrls)
+              blockExplorerUrls = addEthereumChainParameter.blockExplorerUrls
+            else
+              blockExplorerUrls = chain.blockExplorers?.default.url
+                ? [chain.blockExplorers.default.url]
+                : []
+
+            let rpcUrls: readonly string[]
+            if (addEthereumChainParameter?.rpcUrls?.length)
+              rpcUrls = addEthereumChainParameter.rpcUrls
+            else rpcUrls = [chain.rpcUrls.default?.http[0] ?? '']
+
+            const addEthereumChain = {
+              blockExplorerUrls,
+              chainId: hexChainId,
+              chainName: addEthereumChainParameter?.chainName ?? chain.name,
+              iconUrls: addEthereumChainParameter?.iconUrls,
+              nativeCurrency:
+                addEthereumChainParameter?.nativeCurrency ??
+                chain.nativeCurrency,
+              rpcUrls,
+            } satisfies AddEthereumChainParameter
+
+            await provider.request({
+              method: 'wallet_addEthereumChain',
+              params: [addEthereumChain],
+            })
+
+            return chain
+          } catch (err) {
+            const error = err as RpcError
+            if (error.code === UserRejectedRequestError.code)
+              throw new UserRejectedRequestError(error)
+            throw new SwitchChainError(error)
+          }
+        }
 
         throw new SwitchChainError(error)
       }


### PR DESCRIPTION
## Summary

- add a MetaMask `switchChain` fallback for provider error `4902`
- request `wallet_addEthereumChain` with the configured chain metadata when the chain is missing from MetaMask
- cover the fallback with a connector unit test and add a patch changeset

This keeps the MetaMask connector aligned with the existing Base Account and Coinbase Wallet connector behavior for missing chains. Related historical reports: #3252 and #4223.

## Tests

- `pnpm test packages/connectors/src/metaMask.test.ts --run`
- `pnpm --filter @wagmi/connectors check:types`
- `pnpm exec biome check --write packages/connectors/src/metaMask.ts packages/connectors/src/metaMask.test.ts .changeset/metamask-add-chain-fallback.md`
- `git diff --check`
