### PR TITLE
fix(react): respect explicit chainId in useReadContracts

### DIFF
--- a/.changeset/fuzzy-lions-read.md
+++ b/.changeset/fuzzy-lions-read.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Fixed `useReadContracts` to prefer an explicit `chainId` parameter over inferred or connected chain ids.

--- a/packages/react/src/hooks/useReadContracts.test-d.ts
+++ b/packages/react/src/hooks/useReadContracts.test-d.ts
@@ -5,6 +5,7 @@ import { useReadContracts } from './useReadContracts.js'
 
 test('select data', () => {
   const result = useReadContracts({
+    chainId: 1,
     allowFailure: false,
     contracts: [
       {

--- a/packages/react/src/hooks/useReadContracts.test.ts
+++ b/packages/react/src/hooks/useReadContracts.test.ts
@@ -345,3 +345,43 @@ test('behavior: all same chainId', async () => {
     }
   `)
 })
+
+test('behavior: explicit chainId overrides connected chain', async () => {
+  const { mainnet, mainnet2 } = chain
+  await switchChain(config, { chainId: mainnet2.id })
+  const { result } = await renderHook(() =>
+    useReadContracts({
+      chainId: mainnet.id,
+      contracts: [
+        {
+          abi: abi.wagmigotchi,
+          address: address.wagmigotchi,
+          functionName: 'love',
+          args: ['0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c'],
+        },
+      ],
+      query: {
+        enabled: false,
+      },
+    }),
+  )
+
+  expect(result.current.queryKey).toMatchInlineSnapshot(`
+    [
+      "readContracts",
+      {
+        "chainId": 1,
+        "contracts": [
+          {
+            "address": "0xecb504d39723b0be0e3a9aa33d646642d1051ee1",
+            "args": [
+              "0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c",
+            ],
+            "chainId": 1,
+            "functionName": "love",
+          },
+        ],
+      },
+    ]
+  `)
+})

--- a/packages/react/src/hooks/useReadContracts.ts
+++ b/packages/react/src/hooks/useReadContracts.ts
@@ -4,7 +4,11 @@ import type {
   ReadContractsErrorType,
   ResolvedRegister,
 } from '@wagmi/core'
-import type { Compute, ConfigParameter } from '@wagmi/core/internal'
+import type {
+  ChainIdParameter,
+  Compute,
+  ConfigParameter,
+} from '@wagmi/core/internal'
 import {
   type ReadContractsData,
   type ReadContractsOptions,
@@ -23,6 +27,7 @@ export type UseReadContractsParameters<
   selectData = ReadContractsData<contracts, allowFailure>,
 > = Compute<
   ReadContractsOptions<contracts, allowFailure, config, selectData> &
+    ChainIdParameter<config> &
     ConfigParameter<config>
 >
 
@@ -62,7 +67,7 @@ export function useReadContracts<
   }, [parameters.contracts])
   const options = readContractsQueryOptions(config, {
     ...parameters,
-    chainId: contractsChainId ?? chainId,
+    chainId: parameters.chainId ?? contractsChainId ?? chainId,
   })
   return useQuery(options) as any
 }


### PR DESCRIPTION
## Description

`useReadContracts` already infers a shared contract `chainId` before falling back to the connected chain, but it ignored an explicit top-level `chainId` parameter when building `readContractsQueryOptions`.

This updates the React hook so explicit user input takes precedence:

1. `parameters.chainId`
2. inferred shared `contracts[*].chainId`
3. current connected chain

It also exposes the top-level `chainId` on the React hook parameter type and adds regression coverage for the query key behavior when the connected chain differs from the explicit chain.

## Tests

- `pnpm --filter wagmi check:types`
- `pnpm exec biome check packages/react/src/hooks/useReadContracts.ts packages/react/src/hooks/useReadContracts.test.ts packages/react/src/hooks/useReadContracts.test-d.ts`
- `git diff --check`
- `pnpm exec vitest run packages/react/src/hooks/useReadContracts.test.ts -t 'explicit chainId overrides connected chain'`

Note: running the full `useReadContracts.test.ts` file in my local environment currently times out on the existing local RPC-backed tests, but the new focused regression passes with the query disabled.
