### PR TITLE
fix(connectors): widen `@metamask/connect-evm` peer-dep to `^1.0.0`

### DIFF
--- a/.changeset/widen-connect-evm-peer.md
+++ b/.changeset/widen-connect-evm-peer.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Widened `@metamask/connect-evm` peer dependency range from `~1.0.0` to `^1.0.0` so consumers automatically pick up non-breaking 1.x releases (e.g. the bundle-size improvements in `@metamask/connect-evm@1.1.0+`, which transitively brings `@metamask/connect-multichain@0.13.0` with lazy-loaded MWP infrastructure) without needing a manual `overrides` / `resolutions` entry.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "@base-org/account": "^2.5.1",
     "@coinbase/wallet-sdk": "^4.3.6",
-    "@metamask/connect-evm": "~1.0.0",
+    "@metamask/connect-evm": "^1.0.0",
     "@safe-global/safe-apps-provider": "~0.18.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@wagmi/core": "workspace:*",


### PR DESCRIPTION
## What

Widens the `@metamask/connect-evm` peer-dependency in `@wagmi/connectors` from `~1.0.0` to `^1.0.0`.

```diff
// packages/connectors/package.json
- "@metamask/connect-evm": "~1.0.0",
+ "@metamask/connect-evm": "^1.0.0",
```

## Why

`~1.0.0` only allows `1.0.x` patch releases, so consumers of `@wagmi/connectors@8` are pinned to `@metamask/connect-evm@1.0.x` and cannot pick up `1.1.x` / `1.2.x` without adding a manual `pnpm.overrides` / `resolutions` entry.

`@metamask/connect-evm@1.1.0` and `1.2.0` are explicitly non-breaking ([CHANGELOG](https://github.com/MetaMask/connect-monorepo/blob/main/packages/connect-evm/CHANGELOG.md)) and they transitively pull in `@metamask/connect-multichain@0.13.0`, which lazy-loads the MetaMask Wallet Protocol (MWP) infrastructure ([MetaMask/connect-monorepo#244](https://github.com/MetaMask/connect-monorepo/pull/244)). For wagmi apps where most users connect via the extension, that's a sizeable initial-bundle reduction (the MWP transport, websocket client, key manager, etc. only get fetched when a mobile QR/deeplink path is actually exercised).

The wagmi connector itself only imports the long-stable surface (`createEVMClient`, `EIP1193Provider`, `MetamaskConnectEVM`) — see [`packages/connectors/src/metaMask.ts`](https://github.com/wevm/wagmi/blob/main/packages/connectors/src/metaMask.ts) — so widening the range is safe.

This also brings `@metamask/connect-evm` in line with the convention used elsewhere in this same `peerDependencies` block: every other ≥1.0 peer (`@base-org/account`, `@coinbase/wallet-sdk`, `@safe-global/safe-apps-sdk`, `@walletconnect/ethereum-provider`) uses `^`, and `~` is reserved for `0.x` packages where minor bumps can break (`@safe-global/safe-apps-provider ~0.18.6`, `accounts ~0.8.1`, `porto ~0.2.35`). The current `~1.0.0` looks like a leftover from when the entry was bumped from `~0.9.0` in #5070 — the version was incremented but the qualifier wasn't revisited.

## Impact

- No code changes in `@wagmi/connectors`; peer-dep range only.
- Existing consumers on `connect-evm@1.0.x` continue to satisfy the constraint.
- Consumers (e.g. LiFi/Jumper, see [related discussion](https://github.com/MetaMask/connect-monorepo/pull/244)) automatically inherit `connect-evm@1.1.0+` once installed/refreshed, dropping the need for an `overrides` workaround.

## Changeset

`@wagmi/connectors`: patch (peer-dep range widening, no API change).