### PR TITLE
Add MYRX-MAINNET (Chain ID 8472)

### DIFF
--- a/packages/core/src/exports/chains.ts
+++ b/packages/core/src/exports/chains.ts
@@ -5,3 +5,4 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 // biome-ignore lint/performance/noReExportAll: entrypoint module
 export * from 'viem/chains'
+export { myrx } from "viem/chains"

--- a/packages/solid/src/exports/chains.ts
+++ b/packages/solid/src/exports/chains.ts
@@ -5,3 +5,4 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 // biome-ignore lint/performance/noReExportAll: entrypoint module
 export * from 'viem/chains'
+export { myrx } from "viem/chains"

--- a/packages/vue/src/exports/chains.ts
+++ b/packages/vue/src/exports/chains.ts
@@ -5,3 +5,4 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 // biome-ignore lint/performance/noReExportAll: entrypoint module
 export * from 'viem/chains'
+export { myrx } from "viem/chains"


### PR DESCRIPTION
## MYRX-MAINNET — Chain ID 8472

Sovereign EVM blockchain operated by MyRxWallet North America Corporation. Mainnet live since 2026-05-07.

**Changes:** Re-export `myrx` chain from `viem/chains` in wagmi chain package index files.

### Verification
```
cast chain-id --rpc-url https://rpc.myrxwallet.io
# Returns: 8472
```
- Repository: https://github.com/MyRxWallet/mainnet
- Explorer: https://explorer.myrxwallet.io (EIP-3091)
- Treasury multisig: 0x7636345d9d3c375ac9af0d98eb2eed588d7a61d7

### Use case
Healthcare data and payments infrastructure. HIPAA-aligned data flows, provider settlement, patient-controlled data licensing.

### Contact
developer@myrxwallet.io | https://myrxwallet.io