### PR TITLE
Handle malformed SSR cookie state

### DIFF
--- a/.changeset/calm-cookies-smile.md
+++ b/.changeset/calm-cookies-smile.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Handled malformed cookie state in `cookieToInitialState`.

--- a/packages/core/src/utils/cookie.test.ts
+++ b/packages/core/src/utils/cookie.test.ts
@@ -42,6 +42,8 @@ test('cookieToInitialState', () => {
 
   expect(cookieToInitialState(config)).toMatchInlineSnapshot('undefined')
   expect(cookieToInitialState(config), 'foo').toMatchInlineSnapshot('undefined')
+  expect(cookieToInitialState(config, 'wagmi.store=invalid; ')).toBeUndefined()
+  expect(cookieToInitialState(config, 'wagmi.store=null; ')).toBeUndefined()
 })
 
 test('parseCookie', () => {

--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -26,7 +26,7 @@ export function cookieToInitialState(config: Config, cookie?: string | null) {
   const parsed = parseCookie(cookie, key)
   if (!parsed) return undefined
   try {
-    return deserialize<{ state?: State }>(parsed)?.state
+    return deserialize<{ state?: State } | null>(parsed)?.state
   } catch {
     return undefined
   }

--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -25,7 +25,11 @@ export function cookieToInitialState(config: Config, cookie?: string | null) {
   const key = `${config.storage?.key}.store`
   const parsed = parseCookie(cookie, key)
   if (!parsed) return undefined
-  return deserialize<{ state: State }>(parsed).state
+  try {
+    return deserialize<{ state?: State }>(parsed)?.state
+  } catch {
+    return undefined
+  }
 }
 
 export function parseCookie(cookie: string, key: string) {


### PR DESCRIPTION
Fixes #5115.

## Summary

- return `undefined` when `cookieToInitialState` receives malformed persisted cookie state
- keep valid cookie hydration behavior unchanged
- add regression coverage for invalid JSON and unexpected `null` cookie state

## Testing

- `corepack pnpm vitest run packages/core/src/utils/cookie.test.ts`
- `corepack pnpm --filter @wagmi/core check:types`
- `corepack pnpm biome check --write packages/core/src/utils/cookie.ts packages/core/src/utils/cookie.test.ts`
- `pnpm check` via pre-commit hook
