### PR TITLE
fix(tempo): always provide JSON-RPC account in `getClient`

### DIFF
--- a/.changeset/tempo-connector-json-rpc-account.md
+++ b/.changeset/tempo-connector-json-rpc-account.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+**`wagmi/tempo`:** Fixed `getClient` on Tempo connectors to always provide a JSON-RPC account.

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -14,6 +14,7 @@ import {
   UserRejectedRequestError,
   withRetry,
 } from 'viem'
+import { parseAccount } from 'viem/utils'
 
 import { createConnector } from '../connectors/createConnector.js'
 import type { Connector } from '../createConfig.js'
@@ -311,7 +312,7 @@ function _setup(parameters: setup.Parameters) {
         // access key orchestration internally before signing.
         const { address } = provider.getAccount({ accessKey: false })
         return Object.assign(provider.getClient({ chainId }), {
-          account: address,
+          account: parseAccount(address),
         }) as never
       },
       async getProvider() {

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -307,10 +307,11 @@ function _setup(parameters: setup.Parameters) {
       },
       async getClient({ chainId } = {}) {
         const provider = await getProvider()
+        // Always provide a JSON-RPC account; the SDK provider performs
+        // access key orchestration internally before signing.
+        const { address } = provider.getAccount({ accessKey: false })
         return Object.assign(provider.getClient({ chainId }), {
-          // Always use the root account; the SDK provider performs
-          // access key orchestration internally before signing.
-          account: provider.getAccount({ accessKey: false }),
+          account: address,
         }) as never
       },
       async getProvider() {


### PR DESCRIPTION
Updates the Tempo connector's `getClient` to pass the address directly as the `account`.
