### PR TITLE
docs: update Tempo WebAuthn examples

### DIFF
--- a/site/tempo/actions/zone.getAuthorizationTokenInfo.md
+++ b/site/tempo/actions/zone.getAuthorizationTokenInfo.md
@@ -14,16 +14,14 @@ Zone actions and hooks require `viem >=2.48.0`.
 
 ```ts [example.ts]
 import { createConfig } from 'wagmi'
-import { KeyManager, webAuthn } from 'wagmi/tempo'
+import { webAuthn } from 'wagmi/tempo'
 import { http as zoneHttp, zone } from 'viem/tempo/zones'
 
 const zoneChain = zone(7)
 
 const config = createConfig({
   connectors: [
-    webAuthn({
-      keyManager: KeyManager.localStorage(),
-    }),
+    webAuthn(),
   ],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,

--- a/site/tempo/actions/zone.getAuthorizationTokenInfo.md
+++ b/site/tempo/actions/zone.getAuthorizationTokenInfo.md
@@ -20,9 +20,7 @@ import { http as zoneHttp, zone } from 'viem/tempo/zones'
 const zoneChain = zone(7)
 
 const config = createConfig({
-  connectors: [
-    webAuthn(),
-  ],
+  connectors: [webAuthn()],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,
   transports: {

--- a/site/tempo/actions/zone.getDepositStatus.md
+++ b/site/tempo/actions/zone.getDepositStatus.md
@@ -14,16 +14,14 @@ Zone actions and hooks require `viem >=2.48.0`.
 
 ```ts [example.ts]
 import { createConfig } from 'wagmi'
-import { KeyManager, webAuthn } from 'wagmi/tempo'
+import { webAuthn } from 'wagmi/tempo'
 import { http as zoneHttp, zone } from 'viem/tempo/zones'
 
 const zoneChain = zone(7)
 
 const config = createConfig({
   connectors: [
-    webAuthn({
-      keyManager: KeyManager.localStorage(),
-    }),
+    webAuthn(),
   ],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,

--- a/site/tempo/actions/zone.getDepositStatus.md
+++ b/site/tempo/actions/zone.getDepositStatus.md
@@ -20,9 +20,7 @@ import { http as zoneHttp, zone } from 'viem/tempo/zones'
 const zoneChain = zone(7)
 
 const config = createConfig({
-  connectors: [
-    webAuthn(),
-  ],
+  connectors: [webAuthn()],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,
   transports: {

--- a/site/tempo/actions/zone.getZoneInfo.md
+++ b/site/tempo/actions/zone.getZoneInfo.md
@@ -14,16 +14,14 @@ Zone actions and hooks require `viem >=2.48.0`.
 
 ```ts [example.ts]
 import { createConfig } from 'wagmi'
-import { KeyManager, webAuthn } from 'wagmi/tempo'
+import { webAuthn } from 'wagmi/tempo'
 import { http as zoneHttp, zone } from 'viem/tempo/zones'
 
 const zoneChain = zone(7)
 
 const config = createConfig({
   connectors: [
-    webAuthn({
-      keyManager: KeyManager.localStorage(),
-    }),
+    webAuthn(),
   ],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,

--- a/site/tempo/actions/zone.getZoneInfo.md
+++ b/site/tempo/actions/zone.getZoneInfo.md
@@ -20,9 +20,7 @@ import { http as zoneHttp, zone } from 'viem/tempo/zones'
 const zoneChain = zone(7)
 
 const config = createConfig({
-  connectors: [
-    webAuthn(),
-  ],
+  connectors: [webAuthn()],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,
   transports: {

--- a/site/tempo/actions/zone.signAuthorizationToken.md
+++ b/site/tempo/actions/zone.signAuthorizationToken.md
@@ -14,16 +14,14 @@ Zone actions and hooks require `viem >=2.48.0`.
 
 ```ts [example.ts]
 import { createConfig } from 'wagmi'
-import { KeyManager, webAuthn } from 'wagmi/tempo'
+import { webAuthn } from 'wagmi/tempo'
 import { http as zoneHttp, zone } from 'viem/tempo/zones'
 
 const zoneChain = zone(7)
 
 const config = createConfig({
   connectors: [
-    webAuthn({
-      keyManager: KeyManager.localStorage(),
-    }),
+    webAuthn(),
   ],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,

--- a/site/tempo/actions/zone.signAuthorizationToken.md
+++ b/site/tempo/actions/zone.signAuthorizationToken.md
@@ -20,9 +20,7 @@ import { http as zoneHttp, zone } from 'viem/tempo/zones'
 const zoneChain = zone(7)
 
 const config = createConfig({
-  connectors: [
-    webAuthn(),
-  ],
+  connectors: [webAuthn()],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,
   transports: {

--- a/site/tempo/hooks/zone.useSignAuthorizationToken.md
+++ b/site/tempo/hooks/zone.useSignAuthorizationToken.md
@@ -35,9 +35,7 @@ import { http as zoneHttp, zone } from 'viem/tempo/zones'
 const zoneChain = zone(7)
 
 export const config = createConfig({
-  connectors: [
-    webAuthn(),
-  ],
+  connectors: [webAuthn()],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,
   transports: {

--- a/site/tempo/hooks/zone.useSignAuthorizationToken.md
+++ b/site/tempo/hooks/zone.useSignAuthorizationToken.md
@@ -29,16 +29,14 @@ console.log('Token:', result.token)
 ```ts [wagmi.config.ts] filename="wagmi.config.ts"
 // @noErrors
 import { createConfig } from 'wagmi'
-import { KeyManager, webAuthn } from 'wagmi/tempo'
+import { webAuthn } from 'wagmi/tempo'
 import { http as zoneHttp, zone } from 'viem/tempo/zones'
 
 const zoneChain = zone(7)
 
 export const config = createConfig({
   connectors: [
-    webAuthn({
-      keyManager: KeyManager.localStorage(),
-    }),
+    webAuthn(),
   ],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,

--- a/site/tempo/hooks/zone.useZoneInfo.md
+++ b/site/tempo/hooks/zone.useZoneInfo.md
@@ -42,9 +42,7 @@ import { http as zoneHttp, zone } from 'viem/tempo/zones'
 const zoneChain = zone(7)
 
 export const config = createConfig({
-  connectors: [
-    webAuthn(),
-  ],
+  connectors: [webAuthn()],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,
   transports: {

--- a/site/tempo/hooks/zone.useZoneInfo.md
+++ b/site/tempo/hooks/zone.useZoneInfo.md
@@ -36,16 +36,14 @@ console.log('Zone ID:', zoneInfo?.zoneId)
 ```ts [wagmi.config.ts] filename="wagmi.config.ts"
 // @noErrors
 import { createConfig } from 'wagmi'
-import { KeyManager, webAuthn } from 'wagmi/tempo'
+import { webAuthn } from 'wagmi/tempo'
 import { http as zoneHttp, zone } from 'viem/tempo/zones'
 
 const zoneChain = zone(7)
 
 export const config = createConfig({
   connectors: [
-    webAuthn({
-      keyManager: KeyManager.localStorage(),
-    }),
+    webAuthn(),
   ],
   chains: [zoneChain],
   multiInjectedProviderDiscovery: false,


### PR DESCRIPTION
## Summary
- remove the stale `KeyManager` import from Tempo zone docs examples
- switch the examples to call `webAuthn()` directly
- keep the existing chain/client setup unchanged

## Context
The Tempo docs examples still referenced `KeyManager.localStorage()`, but `KeyManager` is no longer exported from `wagmi/tempo`. This keeps the examples aligned with the current public API.

## Tests
- `git diff --check`
- Not run: documentation-only change; local commit hook could not run because this worktree has no installed `node_modules` (`biome: command not found`)
