### PR TITLE
docs: fix article and grammar errors across guides

### DIFF
--- a/site/.vitepress/theme/style.css
+++ b/site/.vitepress/theme/style.css
@@ -24,7 +24,7 @@
  *
  *   The soft color must be semi transparent alpha channel. This is crucial
  *   because it allows adding multiple "soft" colors on top of each other
- *   to create a accent, such as when having inline code block inside
+ *   to create an accent, such as when having inline code block inside
  *   custom containers.
  *
  * - `default`: The color used purely for subtle indication without any

--- a/site/cli/config/configuring-cli.md
+++ b/site/cli/config/configuring-cli.md
@@ -69,7 +69,7 @@ export default defineConfig(() => {
 
 ## Async Config
 
-If the config needs to call async function, it can export a async function instead:
+If the config needs to call an async function, it can export an async function instead:
 
 ::: code-group
 ```js [wagmi.config.js]

--- a/site/react/guides/connect-wallet.md
+++ b/site/react/guides/connect-wallet.md
@@ -184,7 +184,7 @@ export const config = createConfig({
 
 ### 4. Display Connection
 
-Lastly, if an connection is made, we want to show some basic information, like the connected address and ENS name and avatar.
+Lastly, if a connection is made, we want to show some basic information, like the connected address and ENS name and avatar.
 
 Below, we are using hooks like `useConnection`, `useEnsAvatar` and `useEnsName` to extract this information.
 

--- a/site/vue/guides/connect-wallet.md
+++ b/site/vue/guides/connect-wallet.md
@@ -185,7 +185,7 @@ export const config = createConfig({
 
 ### 4. Display Connection
 
-Lastly, if an connection is made, we want to show some basic information, like the connected address and ENS name and avatar.
+Lastly, if a connection is made, we want to show some basic information, like the connected address and ENS name and avatar.
 
 Below, we are using hooks like `useConnection`, `useEnsAvatar` and `useEnsName` to extract this information.
 

--- a/site/vue/guides/viem.md
+++ b/site/vue/guides/viem.md
@@ -89,6 +89,6 @@ sendTransaction({
 
 ::: info
 
-Wagmi currently does not support hoisting Private Key & Mnemonic Accounts to the top-level Wagmi Config – meaning you have to explicitly pass through the account to every Action. If you feel like this is a feature that should be added, please [open an discussion](https://github.com/wevm/wagmi/discussions/new?category=ideas).
+Wagmi currently does not support hoisting Private Key & Mnemonic Accounts to the top-level Wagmi Config – meaning you have to explicitly pass through the account to every Action. If you feel like this is a feature that should be added, please [open a discussion](https://github.com/wevm/wagmi/discussions/new?category=ideas).
 
 :::

--- a/site/vue/typescript.md
+++ b/site/vue/typescript.md
@@ -30,7 +30,7 @@ To ensure everything works correctly, make sure your `tsconfig.json` has [`stric
 
 ## Config Types
 
-By default Vue Plugins does not work well with type inference. To support strong type-safety across the Vue Plugins boundary, there are two options available:
+By default Vue Plugin does not work well with type inference. To support strong type-safety across the Vue Plugin boundary, there are two options available:
 
 - Declaration merging to "register" your `config` globally with TypeScript.
 - `config` property to pass your `config` directly to composables.


### PR DESCRIPTION
Cleans up small grammar issues spotted while reading through the docs. Each fix is verified against parallel content in the same repo.

- `an connection` -> `a connection` in the React and Vue connect-wallet guides
- `an discussion` -> `a discussion` in the Vue viem guide (the corresponding React and core guides already use `a`)
- `a accent` -> `an accent` in the VitePress theme stylesheet comment
- `a async function` -> `an async function` in the CLI `configuring-cli` guide (both occurrences in the same sentence)
- `Vue Plugins does not work well` -> `Vue Plugin does not work well` in the Vue TypeScript guide. The same file uses singular `Vue Plugin` lower down, and the React/Solid equivalents use singular `React Context` / `Solid Context` for the parallel sentence

No source/code changes, so no changeset added (matches #4989, #4990, #5120).