### PR TITLE
test(core): cover `tempoWallet` provider parameters

### DIFF
--- a/packages/core/src/tempo/tempoWallet.test.ts
+++ b/packages/core/src/tempo/tempoWallet.test.ts
@@ -1,5 +1,6 @@
 import { config } from '@wagmi/test'
-import { expect, test, vi } from 'vitest'
+import type { Provider } from 'accounts'
+import { expect, expectTypeOf, test, vi } from 'vitest'
 
 vi.mock('accounts', () => ({
   Provider: {
@@ -22,6 +23,28 @@ test('tempoWallet: setup', () => {
 
   expect(connector.name).toEqual('Tempo Wallet')
   expect(connector.id).toEqual('xyz.tempo')
+})
+
+test('tempoWallet: accepts Provider.create parameters', () => {
+  type ProviderParameters = NonNullable<Parameters<typeof Provider.create>[0]>
+
+  expectTypeOf<tempoWallet.Parameters>().toMatchTypeOf<
+    Pick<
+      ProviderParameters,
+      'authorizeAccessKey' | 'feePayer' | 'mpp' | 'relay' | 'testnet'
+    >
+  >()
+
+  const authorizeAccessKey = () => ({ expiry: 1 })
+  const connectorFn = tempoWallet({
+    authorizeAccessKey,
+    feePayer: '/relay',
+    mpp: false,
+    relay: '/relay',
+    testnet: true,
+  })
+
+  expect(connectorFn).toBeTypeOf('function')
 })
 
 test('dangerous_secp256k1: setup', () => {


### PR DESCRIPTION
Adds a regression test covering the Tempo Wallet connector Accounts Provider parameter surface. The test type-checks `tempoWallet.Parameters` against `Provider.create` options for `authorizeAccessKey`, `feePayer`, `mpp`, `relay`, and `testnet`.

This locks in the documented fee sponsorship and access key setup path without changing runtime behavior.

Validated with `pnpm test packages/core/src/tempo/tempoWallet.test.ts`.
