### PR TITLE
fix(core): clean up injected switchChain listener on failure

### DIFF
--- a/.changeset/injected-switchchain-listener-leak.md
+++ b/.changeset/injected-switchchain-listener-leak.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed listener leak in injected connector `switchChain` when chain switch fails.

--- a/packages/core/src/connectors/injected.test.ts
+++ b/packages/core/src/connectors/injected.test.ts
@@ -1,5 +1,6 @@
-import { config } from '@wagmi/test'
-import { expect, test } from 'vitest'
+import { chain, config } from '@wagmi/test'
+import { numberToHex, UserRejectedRequestError } from 'viem'
+import { expect, test, vi } from 'vitest'
 
 import { injected } from './injected.js'
 
@@ -22,4 +23,34 @@ test.each([
   const connectorFn = injected({ target: wallet })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual(expected)
+})
+
+test('switchChain removes change listener when the switch request fails', async () => {
+  const provider = {
+    request: vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'eth_chainId') return numberToHex(chain.mainnet.id)
+      if (method === 'eth_accounts') return []
+      if (method === 'wallet_switchEthereumChain')
+        throw Object.assign(new Error('User rejected the request.'), {
+          code: UserRejectedRequestError.code,
+        })
+      return undefined
+    }),
+  }
+  const connector = config._internal.connectors.setup(
+    injected({
+      target: {
+        id: 'mockInjected',
+        name: 'Mock Injected',
+        provider,
+      },
+    }),
+  )
+  const before = config.emitter.listenerCount('change')
+
+  await expect(
+    connector.switchChain({ chainId: chain.optimism.id }),
+  ).rejects.toThrow('User rejected')
+
+  expect(config.emitter.listenerCount('change')).toBe(before)
 })

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -357,8 +357,9 @@ export function injected(parameters: InjectedParameters = {}) {
       const chain = config.chains.find((x) => x.id === chainId)
       if (!chain) throw new SwitchChainError(new ChainNotConfiguredError())
 
+      let listener: Parameters<typeof config.emitter.on>[1] = () => {}
       const promise = new Promise<void>((resolve) => {
-        const listener = ((data) => {
+        listener = ((data) => {
           if ('chainId' in data && data.chainId === chainId) {
             config.emitter.off('change', listener)
             resolve()
@@ -446,10 +447,12 @@ export function injected(parameters: InjectedParameters = {}) {
 
             return chain
           } catch (error) {
+            config.emitter.off('change', listener)
             throw new UserRejectedRequestError(error as Error)
           }
         }
 
+        config.emitter.off('change', listener)
         if (error.code === UserRejectedRequestError.code)
           throw new UserRejectedRequestError(error)
         throw new SwitchChainError(error)


### PR DESCRIPTION
## Summary

- remove the injected connector `change` listener when `switchChain` fails before the chain-change confirmation arrives
- keep the listener active for the 4902 `wallet_addEthereumChain` retry flow, and clean it up if that retry fails
- add a regression test plus a patch changeset for `@wagmi/core`

This mirrors the leak pattern fixed for WalletConnect in #5033 and the behavior reported in #5032, but applies it to the injected connector path that still had the same failure cleanup gap.

## Tests

- `pnpm dlx @biomejs/biome@2.2.4 check packages/core/src/connectors/injected.ts packages/core/src/connectors/injected.test.ts .changeset/injected-switchchain-listener-leak.md`
- `git diff --check HEAD~1..HEAD`

Not run successfully:

- `pnpm exec vitest packages/core/src/connectors/injected.test.ts --run` (blocked because `vitest` was unavailable; `pnpm install --frozen-lockfile --ignore-scripts` repeatedly failed with registry `ECONNRESET` before dependencies were fully installed)
