### PR TITLE
fix(core): preserve tempo prepare transaction types

### DIFF
--- a/.changeset/rare-shirts-check.md
+++ b/.changeset/rare-shirts-check.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Updated viem and preserved Tempo transaction type narrowing in `prepareTransactionRequest`.

--- a/packages/core/src/actions/prepareTransactionRequest.test-d.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.test-d.ts
@@ -71,6 +71,13 @@ test('chain formatters', async () => {
   expectTypeOf<Result3>().not.toMatchTypeOf<{
     feeCurrency?: `0x${string}` | undefined
   }>()
+  prepareTransactionRequest(config, {
+    chainId: mainnet.id,
+    to: targetAccount,
+    value: parseEther('0.01'),
+    // @ts-expect-error
+    feeCurrency: '0x',
+  })
 })
 
 test('parameters: calls without to', async () => {

--- a/packages/core/src/actions/prepareTransactionRequest.test-d.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.test-d.ts
@@ -1,6 +1,7 @@
 import { accounts, config } from '@wagmi/test'
 import { http, parseEther } from 'viem'
-import { celo, mainnet } from 'viem/chains'
+import { privateKeyToAccount } from 'viem/accounts'
+import { celo, mainnet, tempoLocalnet } from 'viem/chains'
 import { expectTypeOf, test } from 'vitest'
 
 import { createConfig } from '../createConfig.js'
@@ -70,13 +71,6 @@ test('chain formatters', async () => {
   expectTypeOf<Result3>().not.toMatchTypeOf<{
     feeCurrency?: `0x${string}` | undefined
   }>()
-  prepareTransactionRequest(config, {
-    chainId: mainnet.id,
-    to: targetAccount,
-    value: parseEther('0.01'),
-    // @ts-expect-error
-    feeCurrency: '0x',
-  })
 })
 
 test('parameters: calls without to', async () => {
@@ -93,4 +87,25 @@ test('parameters: calls without to', async () => {
 test('parameters: to or calls required', () => {
   // @ts-expect-error
   prepareTransactionRequest(config, {})
+})
+
+test('tempo transaction type', async () => {
+  const feePayer = privateKeyToAccount(
+    '0x0123456789012345678901234567890123456789012345678901234567890123',
+  )
+
+  const config = createConfig({
+    chains: [mainnet, tempoLocalnet],
+    transports: { [mainnet.id]: http(), [tempoLocalnet.id]: http() },
+  })
+
+  const request = await prepareTransactionRequest(config, {
+    calls: [],
+    chainId: tempoLocalnet.id,
+    feePayer,
+    type: 'tempo',
+  })
+
+  expectTypeOf(request.chainId).toEqualTypeOf<typeof tempoLocalnet.id>()
+  expectTypeOf(request.type).toEqualTypeOf<'tempo'>()
 })

--- a/packages/core/src/actions/prepareTransactionRequest.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.ts
@@ -114,17 +114,33 @@ export type PrepareTransactionRequestErrorType =
   viem_PrepareTransactionRequestErrorType
 
 /** https://wagmi.sh/core/api/actions/prepareTransactionRequest */
-export async function prepareTransactionRequest<
+export function prepareTransactionRequest<
   config extends Config,
-  chainId extends config['chains'][number]['id'] | undefined,
+  const chainId extends config['chains'][number]['id'],
   const request extends viem_PrepareTransactionRequestRequest<
-    SelectChains<config, chainId>['0'],
-    SelectChains<config, chainId>['0']
+    SelectChains<config, chainId>[0],
+    SelectChains<config, chainId>[0]
   >,
 >(
   config: config,
-  parameters: PrepareTransactionRequestParameters<config, chainId, request>,
-): Promise<PrepareTransactionRequestReturnType<config, chainId, request>> {
+  parameters: PrepareTransactionRequestParameters<config, chainId, request> &
+    request & { chainId: chainId },
+): Promise<PrepareTransactionRequestReturnType<config, chainId, request>>
+export function prepareTransactionRequest<
+  config extends Config,
+  const request extends viem_PrepareTransactionRequestRequest<
+    SelectChains<config, undefined>[0],
+    SelectChains<config, undefined>[0]
+  >,
+>(
+  config: config,
+  parameters: PrepareTransactionRequestParameters<config, undefined, request> &
+    request & { chainId?: undefined },
+): Promise<PrepareTransactionRequestReturnType<config, undefined, request>>
+export async function prepareTransactionRequest(
+  config: Config,
+  parameters: PrepareTransactionRequestParameters,
+): Promise<PrepareTransactionRequestReturnType> {
   const { account: account_, chainId, ...rest } = parameters
 
   let account: Address | Account | undefined
@@ -148,7 +164,5 @@ export async function prepareTransactionRequest<
   return action({
     ...rest,
     ...(account ? { account } : {}),
-  } as unknown as viem_PrepareTransactionRequestParameters) as unknown as Promise<
-    PrepareTransactionRequestReturnType<config, chainId, request>
-  >
+  } as unknown as viem_PrepareTransactionRequestParameters) as unknown as Promise<PrepareTransactionRequestReturnType>
 }

--- a/packages/core/src/actions/prepareTransactionRequest.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.ts
@@ -3,6 +3,7 @@ import type {
   Address,
   Calls,
   Chain,
+  ExtractFormattedTransactionRequest as viem_ExtractFormattedTransactionRequest,
   PrepareTransactionRequestErrorType as viem_PrepareTransactionRequestErrorType,
   PrepareTransactionRequestParameters as viem_PrepareTransactionRequestParameters,
   PrepareTransactionRequestRequest as viem_PrepareTransactionRequestRequest,
@@ -113,34 +114,65 @@ export type PrepareTransactionRequestReturnType<
 export type PrepareTransactionRequestErrorType =
   viem_PrepareTransactionRequestErrorType
 
+type PrepareTransactionRequestExactParameters<
+  config extends Config,
+  parameters,
+  chainId extends config['chains'][number]['id'] | undefined,
+  allowed = PrepareTransactionRequestParameters<config, chainId>,
+> = parameters &
+  allowed &
+  Record<Exclude<keyof parameters, keyof allowed>, never>
+
+type PrepareTransactionRequestRequestForReturn<
+  config extends Config,
+  parameters,
+  chainId extends config['chains'][number]['id'] | undefined,
+> = parameters extends viem_PrepareTransactionRequestRequest<
+  SelectChains<config, chainId>[0],
+  SelectChains<config, chainId>[0]
+>
+  ? parameters
+  : viem_ExtractFormattedTransactionRequest<
+      SelectChains<config, chainId>[0],
+      {
+        type?: parameters extends { type?: infer type extends string }
+          ? type
+          : undefined
+      }
+    > &
+      Pick<
+        viem_PrepareTransactionRequestRequest<
+          SelectChains<config, chainId>[0],
+          SelectChains<config, chainId>[0]
+        >,
+        'kzg' | 'parameters'
+      >
+
 /** https://wagmi.sh/core/api/actions/prepareTransactionRequest */
-export function prepareTransactionRequest<
+export async function prepareTransactionRequest<
   config extends Config,
-  const chainId extends config['chains'][number]['id'],
-  const request extends viem_PrepareTransactionRequestRequest<
-    SelectChains<config, chainId>[0],
-    SelectChains<config, chainId>[0]
-  >,
+  const parameters,
+  chainId extends
+    | config['chains'][number]['id']
+    | undefined = parameters extends {
+    chainId?: infer chainId extends config['chains'][number]['id']
+  }
+    ? chainId
+    : undefined,
 >(
   config: config,
-  parameters: PrepareTransactionRequestParameters<config, chainId, request> &
-    request & { chainId: chainId },
-): Promise<PrepareTransactionRequestReturnType<config, chainId, request>>
-export function prepareTransactionRequest<
-  config extends Config,
-  const request extends viem_PrepareTransactionRequestRequest<
-    SelectChains<config, undefined>[0],
-    SelectChains<config, undefined>[0]
+  parameters: PrepareTransactionRequestExactParameters<
+    config,
+    parameters,
+    chainId
   >,
->(
-  config: config,
-  parameters: PrepareTransactionRequestParameters<config, undefined, request> &
-    request & { chainId?: undefined },
-): Promise<PrepareTransactionRequestReturnType<config, undefined, request>>
-export async function prepareTransactionRequest(
-  config: Config,
-  parameters: PrepareTransactionRequestParameters,
-): Promise<PrepareTransactionRequestReturnType> {
+): Promise<
+  PrepareTransactionRequestReturnType<
+    config,
+    chainId,
+    PrepareTransactionRequestRequestForReturn<config, parameters, chainId>
+  >
+> {
   const { account: account_, chainId, ...rest } = parameters
 
   let account: Address | Account | undefined
@@ -164,5 +196,11 @@ export async function prepareTransactionRequest(
   return action({
     ...rest,
     ...(account ? { account } : {}),
-  } as unknown as viem_PrepareTransactionRequestParameters) as unknown as Promise<PrepareTransactionRequestReturnType>
+  } as unknown as viem_PrepareTransactionRequestParameters) as unknown as Promise<
+    PrepareTransactionRequestReturnType<
+      config,
+      chainId,
+      PrepareTransactionRequestRequestForReturn<config, parameters, chainId>
+    >
+  >
 }

--- a/packages/core/src/query/prepareTransactionRequest.test-d.ts
+++ b/packages/core/src/query/prepareTransactionRequest.test-d.ts
@@ -61,6 +61,8 @@ test('chain formatters', async () => {
       chainId: mainnet.id,
       to: targetAccount,
       value: parseEther('0.01'),
+      // @ts-expect-error
+      feeCurrency: '0x',
     })
     const request = await options.queryFn(context)
     expectTypeOf(request.chainId).toEqualTypeOf(mainnet.id)

--- a/packages/core/src/query/prepareTransactionRequest.test-d.ts
+++ b/packages/core/src/query/prepareTransactionRequest.test-d.ts
@@ -61,8 +61,6 @@ test('chain formatters', async () => {
       chainId: mainnet.id,
       to: targetAccount,
       value: parseEther('0.01'),
-      // @ts-expect-error
-      feeCurrency: '0x',
     })
     const request = await options.queryFn(context)
     expectTypeOf(request.chainId).toEqualTypeOf(mainnet.id)

--- a/packages/core/src/tempo/actions/wallet.test.ts
+++ b/packages/core/src/tempo/actions/wallet.test.ts
@@ -94,6 +94,7 @@ describe('deposit', () => {
         chainId: 1,
         displayName: 'Account',
         token: '0x0000000000000000000000000000000000000004',
+        amount: '3.5',
       }),
     ).resolves.toMatchInlineSnapshot(`
       {


### PR DESCRIPTION
## Summary
Preserve Tempo transaction request narrowing through wagmi's prepareTransactionRequest types.

## Motivation
viem 2.50.4 includes the Tempo prepareTransactionRequest narrowing fix, but wagmi still needed coverage and overloads that infer the literal request shape when a chainId is supplied.

## Changes
- Bumped viem to 2.50.4.
- Added prepareTransactionRequest overloads that keep chainId and request literals available to the return type.
- Added a Tempo type regression for prepared requests with type: 'tempo'.
- Updated the Tempo wallet deposit test for viem's amount parameter rename.

## Testing
- pnpm --filter @wagmi/core check:types
- pnpm vitest run packages/core/src/actions/prepareTransactionRequest.test.ts packages/core/src/tempo/actions/wallet.test.ts (fails in this environment: prepareTransactionRequest tests hit local RPC 400/timeouts after binding the test port; the Tempo wallet test file passed)