### PR TITLE
fix(cli): support shared foundry artifact deployments

### DIFF
--- a/packages/cli/src/plugins/foundry.test.ts
+++ b/packages/cli/src/plugins/foundry.test.ts
@@ -407,3 +407,54 @@ test('watch callbacks use broadcast deployments', async () => {
     },
   })
 })
+
+test('contracts supports multiple deployment names sharing one ABI artifact', async () => {
+  const dir = await createTempDir()
+  const spy = vi.spyOn(process, 'cwd')
+  spy.mockImplementation(() => dir)
+
+  const artifactsDir = resolve(dir, 'out')
+  await fs.mkdir(artifactsDir, { recursive: true })
+  const erc20Artifact = {
+    abi: [
+      {
+        inputs: [],
+        name: 'totalSupply',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ],
+  }
+  await fs.writeFile(
+    resolve(artifactsDir, 'ERC20.json'),
+    JSON.stringify(erc20Artifact, null, 2),
+  )
+
+  await expect(
+    foundry({
+      forge: { build: false, clean: false },
+      deployments: {
+        DAI: '0x1111111111111111111111111111111111111111',
+        WETH: '0x2222222222222222222222222222222222222222',
+      },
+      deploymentArtifacts: {
+        DAI: 'ERC20',
+        WETH: 'ERC20',
+      },
+    }).contracts?.(),
+  ).resolves.toMatchObject([
+    {
+      address: undefined,
+      name: 'ERC20',
+    },
+    {
+      address: '0x1111111111111111111111111111111111111111',
+      name: 'DAI',
+    },
+    {
+      address: '0x2222222222222222222222222222222222222222',
+      name: 'WETH',
+    },
+  ])
+})

--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -62,6 +62,8 @@ export type FoundryConfig = {
   includeBroadcasts?: boolean | undefined
   /** Mapping of addresses to attach to artifacts. */
   deployments?: { [key: string]: ContractConfig['address'] } | undefined
+  /** Mapping of deployment names to Foundry artifact names. */
+  deploymentArtifacts?: { [key: string]: string } | undefined
   /** Artifact files to exclude. */
   exclude?: string[] | undefined
   /** [Forge](https://book.getfoundry.sh/forge) configuration */
@@ -116,6 +118,7 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     artifacts,
     includeBroadcasts = false,
     deployments = {},
+    deploymentArtifacts = {},
     exclude = foundryDefaultExcludes,
     forge: {
       clean = false,
@@ -127,12 +130,24 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     namePrefix = '',
   } = config
 
+  const deploymentNamesByArtifact = Object.entries(deploymentArtifacts).reduce<{
+    [key: string]: string[]
+  }>((acc, [deploymentName, artifactName]) => {
+    if (!acc[artifactName]) acc[artifactName] = []
+    acc[artifactName]?.push(deploymentName)
+    return acc
+  }, {})
+
   let allDeployments: { [key: string]: ContractConfig['address'] } = deployments
 
   function getContractName(artifactPath: string, usePrefix = true) {
     const filename = basename(artifactPath)
     const extension = extname(artifactPath)
     return `${usePrefix ? namePrefix : ''}${filename.replace(extension, '')}`
+  }
+
+  function getArtifactName(artifactPath: string) {
+    return getContractName(artifactPath, false)
   }
 
   async function getContract(
@@ -142,11 +157,25 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
     } = allDeployments,
   ) {
     const artifact = await JSON.parse(await readFile(artifactPath, 'utf8'))
-    return {
-      abi: artifact.abi,
-      address: contractDeployments[getContractName(artifactPath, false)],
-      name: getContractName(artifactPath),
+    const artifactName = getArtifactName(artifactPath)
+    const contracts = [
+      {
+        abi: artifact.abi,
+        address: contractDeployments[artifactName],
+        name: getContractName(artifactPath),
+      },
+    ]
+
+    for (const deploymentName of deploymentNamesByArtifact[artifactName] ??
+      []) {
+      contracts.push({
+        abi: artifact.abi,
+        address: contractDeployments[deploymentName],
+        name: `${namePrefix}${deploymentName}`,
+      })
     }
+
+    return contracts
   }
 
   function getArtifactPaths(artifactsDirectory: string) {
@@ -274,9 +303,14 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
       const artifactPaths = await getArtifactPaths(artifactsDirectory)
       const contracts = []
       for (const artifactPath of artifactPaths) {
-        const contract = await getContract(artifactPath, allDeployments)
-        if (!contract.abi?.length) continue
-        contracts.push(contract)
+        const resolvedContracts = await getContract(
+          artifactPath,
+          allDeployments,
+        )
+        for (const contract of resolvedContracts) {
+          if (!contract.abi?.length) continue
+          contracts.push(contract)
+        }
       }
       return contracts
     },
@@ -330,10 +364,10 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
         ...exclude.map((x) => `!${artifactsDirectory}/**/${x}`),
       ],
       async onAdd(path) {
-        return getContract(path)
+        return (await getContract(path))[0]
       },
       async onChange(path) {
-        return getContract(path)
+        return (await getContract(path))[0]
       },
       async onRemove(path) {
         return getContractName(path)


### PR DESCRIPTION
## Summary

Adds support for multiple named deployments sharing one Foundry ABI artifact in the CLI Foundry plugin.

## Problem

When several deployed contracts share the same ABI artifact (for example `DAI` and `WETH` both using `ERC20.json`), the Foundry plugin can currently only emit the artifact contract name. That means only one generated config/address pair is available for the shared ABI use case.

## Changes

- Add a `deploymentArtifacts` mapping from deployment name to Foundry artifact name.
- When resolving an artifact, emit additional contract entries for deployment names mapped to that artifact.
- Keep the existing `deployments` address mapping behavior intact.
- Add test coverage for two deployment names sharing one `ERC20` ABI artifact.

Example:

```ts
foundry({
  deployments: {
    DAI: '0x1111111111111111111111111111111111111111',
    WETH: '0x2222222222222222222222222222222222222222',
  },
  deploymentArtifacts: {
    DAI: 'ERC20',
    WETH: 'ERC20',
  },
})
```

This allows generated exports such as both `daiConfig` and `wethConfig` while reusing `erc20Abi`.

## Verification

- `corepack pnpm install --ignore-scripts --frozen-lockfile --filter @wagmi/cli...`
- `corepack pnpm exec biome check --write packages/cli/src/plugins/foundry.ts packages/cli/src/plugins/foundry.test.ts`
- `corepack pnpm exec vitest run packages/cli/src/plugins/foundry.test.ts -t 'contracts supports multiple deployment names sharing one ABI artifact'`
- `corepack pnpm --filter @wagmi/cli run check:types`

Closes #4396
