### PR TITLE
fix(core): prevent distributive conditional type in GetClientReturnType

### DIFF
--- a/.changeset/fix-getClient-multichain-type.md
+++ b/.changeset/fix-getClient-multichain-type.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/core": patch
+---
+
+fix(core): prevent distributive conditional type in `GetClientReturnType`
+
+Wrap the conditional in `GetClientReturnType` with tuple types to prevent TypeScript from distributing over multi-chain `resolvedChainId` unions. This allows the client returned by `getClient` to be passed directly into viem actions like `waitForTransactionReceipt`, `getBlock`, and `getTransaction` when the config has multiple chains.

--- a/packages/core/src/actions/getClient.test-d.ts
+++ b/packages/core/src/actions/getClient.test-d.ts
@@ -1,6 +1,14 @@
 import { chain, config } from '@wagmi/test'
+import { http } from 'viem'
+import {
+  getBlock,
+  getTransaction,
+  waitForTransactionReceipt,
+} from 'viem/actions'
+import { arbitrumNova, optimism } from 'viem/chains'
 import { expectTypeOf, test } from 'vitest'
 
+import { createConfig } from '../createConfig.js'
 import { getClient } from './getClient.js'
 
 test('default', () => {
@@ -24,4 +32,19 @@ test('behavior: unconfigured chain', () => {
     chainId: 123456,
   })
   expectTypeOf(client).toEqualTypeOf<undefined>()
+})
+
+test('behavior: viem actions with multi-chain client', () => {
+  const twoChainConfig = createConfig({
+    chains: [arbitrumNova, optimism],
+    transports: {
+      [arbitrumNova.id]: http(),
+      [optimism.id]: http(),
+    },
+  })
+  const client = getClient(twoChainConfig)
+
+  waitForTransactionReceipt(client, { hash: '0x' })
+  getBlock(client)
+  getTransaction(client, { hash: '0x' })
 })

--- a/packages/core/src/actions/getClient.ts
+++ b/packages/core/src/actions/getClient.ts
@@ -28,7 +28,7 @@ export type GetClientReturnType<
       ? chainId
       : config['chains'][number]['id']
     : config['chains'][number]['id'] | undefined,
-> = resolvedChainId extends config['chains'][number]['id']
+> = [resolvedChainId] extends [config['chains'][number]['id']]
   ? Compute<
       Client<
         config['_internal']['transports'][resolvedChainId],


### PR DESCRIPTION
## Summary

Wraps the conditional in `GetClientReturnType` with tuple types (`[resolvedChainId] extends [...]`) to prevent TypeScript from distributing over multi-chain `resolvedChainId` unions.

Without this fix, `getClient(config)` on a multi-chain config returns `Client<_, chainA> | Client<_, chainB>` (a union of clients), which is incompatible with viem actions that expect `Client<Transport, chain>`. With the fix, it returns `Client<_, chainA | chainB>` (a single client with a union chain), which TypeScript can match correctly.

## Changes

- **`packages/core/src/actions/getClient.ts`** — one-line fix: `[resolvedChainId] extends [config['chains'][number]['id']]`
- **`packages/core/src/actions/getClient.test-d.ts`** — type regression test covering `waitForTransactionReceipt`, `getBlock`, and `getTransaction` with a two-chain config
- **`.changeset/fix-getClient-multichain-type.md`** — patch changeset for `@wagmi/core`

## Validation

- `pnpm --filter @wagmi/core check:types` passes with no errors
- `biome check` passes

Closes #3635