### PR TITLE
chore: drop older TypeScript support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,7 +73,7 @@ body:
   - type: input
     attributes:
       label: TypeScript Version
-      description: What version of TypeScript are you using? Wagmi requires `typescript@>=5`.
+      description: What version of TypeScript are you using? Wagmi requires `typescript@>=5.9.3`.
       placeholder: x.y.z (do not write `latest`)
     validations:
       required: false
@@ -84,5 +84,4 @@ body:
       description: Anything that will give us more context about the issue you are encountering. Framework version (e.g. React, Vue), app framework (e.g. Next.js, Nuxt), bundler, etc.
     validations:
       required: false
-
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 8
     strategy:
       matrix:
-        typescript-version: ['5.7.3', '5.8.3', '5.9.3', 'latest']
+        typescript-version: ['5.9.3', '6.0.3', 'latest']
         viem-version: ['2.51.0', 'latest']
 
     steps:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
     }
   },
   "peerDependencies": {
-    "typescript": ">=5.7.3"
+    "typescript": ">=5.9.3"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -114,7 +114,7 @@ test('parameters: root', async () => {
   const { dir } = await createFixture()
   const spy = vi.spyOn(process, 'cwd')
   spy.mockImplementation(() => dir)
-  mkdir(resolve(dir, 'foo'))
+  await mkdir(resolve(dir, 'foo'))
 
   const configFile = await init({
     root: 'foo/',

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -44,7 +44,7 @@
     "@walletconnect/ethereum-provider": "^2.21.1",
     "accounts": "~0.10",
     "porto": "~0.2.35",
-    "typescript": ">=5.7.3",
+    "typescript": ">=5.9.3",
     "viem": "2.x"
   },
   "peerDependenciesMeta": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
   "peerDependencies": {
     "@tanstack/query-core": ">=5.0.0",
     "accounts": "~0.12",
-    "typescript": ">=5.7.3",
+    "typescript": ">=5.9.3",
     "viem": "2.x"
   },
   "peerDependenciesMeta": {

--- a/packages/core/src/actions/getTransaction.test.ts
+++ b/packages/core/src/actions/getTransaction.test.ts
@@ -7,8 +7,7 @@ test('default', async () => {
   const result = await getTransaction(config, {
     hash: '0xa559259bd2d0e8372421e222ff3545f705b5da60005bd787a23c2e68d6d7fefd',
   })
-  const value = { ...result }
-  delete (value as { blockTimestamp?: bigint }).blockTimestamp
+  const { blockTimestamp: _blockTimestamp, ...value } = result
 
   expect(value).toMatchInlineSnapshot(`
     {

--- a/packages/core/src/actions/getTransaction.test.ts
+++ b/packages/core/src/actions/getTransaction.test.ts
@@ -4,16 +4,17 @@ import { expect, test } from 'vitest'
 import { getTransaction } from './getTransaction.js'
 
 test('default', async () => {
-  await expect(
-    getTransaction(config, {
-      hash: '0xa559259bd2d0e8372421e222ff3545f705b5da60005bd787a23c2e68d6d7fefd',
-    }),
-  ).resolves.toMatchInlineSnapshot(`
+  const result = await getTransaction(config, {
+    hash: '0xa559259bd2d0e8372421e222ff3545f705b5da60005bd787a23c2e68d6d7fefd',
+  })
+  const value = { ...result }
+  delete (value as { blockTimestamp?: bigint }).blockTimestamp
+
+  expect(value).toMatchInlineSnapshot(`
     {
       "accessList": [],
       "blockHash": "0x61c4e868008b465addd7c0a5da03db28bb9911597c58e239a85dd14dd43fd56a",
       "blockNumber": 17488642n,
-      "blockTimestamp": 1686872915n,
       "chainId": 1,
       "from": "0xd2135cfb216b74109775236e36d4b433f1df507b",
       "gas": 53671n,

--- a/packages/core/src/tempo/actions/policy.test.ts
+++ b/packages/core/src/tempo/actions/policy.test.ts
@@ -367,10 +367,13 @@ describe('policy', () => {
         admin: account2.address,
       })
 
-      await vi.waitFor(() => {
-        const event = events.find((e) => e.args.admin === account2.address)
-        expect(event).toBeDefined()
-      })
+      await vi.waitFor(
+        () => {
+          const event = events.find((e) => e.args.admin === account2.address)
+          expect(event).toBeDefined()
+        },
+        { timeout: 5_000 },
+      )
       unwatch()
 
       const event = events.find((e) => e.args.admin === account2.address)

--- a/packages/core/src/tempo/actions/zone.test.ts
+++ b/packages/core/src/tempo/actions/zone.test.ts
@@ -3,6 +3,7 @@ import {
   accounts,
   config,
   queryClient,
+  restart,
   setupToken,
   tempoLocal,
   zoneDepositStatus,
@@ -21,6 +22,7 @@ const revealTo =
 let depositToken: Awaited<ReturnType<typeof setupToken>>['token']
 
 beforeAll(async () => {
+  await restart()
   ;({ token: depositToken } = await setupToken())
   await disconnect(config).catch(() => {})
 })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -89,7 +89,7 @@
   "peerDependencies": {
     "@tanstack/react-query": ">=5.0.0",
     "react": ">=18",
-    "typescript": ">=5.7.3",
+    "typescript": ">=5.9.3",
     "viem": "2.x"
   },
   "peerDependenciesMeta": {

--- a/packages/react/src/hooks/useTransaction.test.ts
+++ b/packages/react/src/hooks/useTransaction.test.ts
@@ -12,8 +12,8 @@ test('default', async () => {
 
   await vi.waitUntil(() => result.current.isSuccess, { timeout: 10_000 })
 
-  const value = { ...result.current, data: { ...result.current.data } }
-  delete (value.data as { blockTimestamp?: bigint }).blockTimestamp
+  const { blockTimestamp: _blockTimestamp, ...data } = result.current.data ?? {}
+  const value = { ...result.current, data }
 
   expect(value).toMatchInlineSnapshot(`
     {

--- a/packages/react/src/hooks/useTransaction.test.ts
+++ b/packages/react/src/hooks/useTransaction.test.ts
@@ -12,13 +12,15 @@ test('default', async () => {
 
   await vi.waitUntil(() => result.current.isSuccess, { timeout: 10_000 })
 
-  expect(result.current).toMatchInlineSnapshot(`
+  const value = { ...result.current, data: { ...result.current.data } }
+  delete (value.data as { blockTimestamp?: bigint }).blockTimestamp
+
+  expect(value).toMatchInlineSnapshot(`
     {
       "data": {
         "accessList": [],
         "blockHash": "0xd725a38b51e5ceec8c5f6c9ccfdb2cc423af993bb650af5eedca5e4be7156ba7",
         "blockNumber": 15189204n,
-        "blockTimestamp": 1658449488n,
         "chainId": 1,
         "from": "0xa0cf798816d4b9b9866b5330eea46a18382f251e",
         "gas": 21000n,

--- a/packages/react/src/tempo/hooks/zone.test.ts
+++ b/packages/react/src/tempo/hooks/zone.test.ts
@@ -3,6 +3,7 @@ import {
   accounts,
   config,
   renderHook,
+  restart,
   setupToken,
   tempoLocal,
   zoneDepositStatus,
@@ -21,6 +22,7 @@ const revealTo =
 let depositToken: Awaited<ReturnType<typeof setupToken>>['token']
 
 beforeAll(async () => {
+  await restart()
   ;({ token: depositToken } = await setupToken())
   await disconnect(config).catch(() => {})
 })

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -73,7 +73,7 @@
   "peerDependencies": {
     "@tanstack/solid-query": ">=5.0.0",
     "solid-js": "1.x",
-    "typescript": ">=5.7.3",
+    "typescript": ">=5.9.3",
     "viem": "2.x"
   },
   "peerDependenciesMeta": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -74,7 +74,7 @@
     "react": ">=18",
     "react-dom": ">=18",
     "solid-js": "1.x",
-    "typescript": ">=5.7.3",
+    "typescript": ">=5.9.3",
     "viem": ">=2.49.2",
     "vue": ">=3",
     "wagmi": "workspace:*"

--- a/packages/test/src/tempo/config.ts
+++ b/packages/test/src/tempo/config.ts
@@ -263,6 +263,16 @@ export async function restart() {
       }),
     ),
   )
+
+  await Actions.validator.add(client, {
+    account: accounts[0],
+    newValidatorAddress: accounts[19].address,
+    publicKey:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    active: true,
+    inboundAddress: '192.168.1.100:8080',
+    outboundAddress: '192.168.1.100:8080',
+  })
   vi.spyOn(Date, 'now').mockReturnValue(
     new Date(Date.UTC(2023, 1, 1)).valueOf(),
   )

--- a/packages/test/src/tempo/setup.ts
+++ b/packages/test/src/tempo/setup.ts
@@ -45,6 +45,16 @@ beforeAll(async () => {
       }),
     ),
   )
+
+  await Actions.validator.add(client, {
+    account: accounts[0],
+    newValidatorAddress: accounts[19].address,
+    publicKey:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    active: true,
+    inboundAddress: '192.168.1.100:8080',
+    outboundAddress: '192.168.1.100:8080',
+  })
   vi.spyOn(Date, 'now').mockReturnValue(
     new Date(Date.UTC(2023, 1, 1)).valueOf(),
   )

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@tanstack/vue-query": ">=5.0.0",
     "nuxt": ">=3.0.0 || >=4.0.0",
-    "typescript": ">=5.7.3",
+    "typescript": ">=5.9.3",
     "viem": "2.x",
     "vue": ">=3"
   },

--- a/packages/vue/src/composables/useTransaction.test.ts
+++ b/packages/vue/src/composables/useTransaction.test.ts
@@ -13,8 +13,9 @@ test('default', async () => {
 
   await waitFor(result.isSuccess)
 
-  const value = deepUnref(result)
-  delete (value.data as { blockTimestamp?: bigint }).blockTimestamp
+  const { data: data_, ...rest } = deepUnref(result)
+  const { blockTimestamp: _blockTimestamp, ...data } = data_ ?? {}
+  const value = { ...rest, data }
 
   expect(value).toMatchInlineSnapshot(`
     {

--- a/packages/vue/src/composables/useTransaction.test.ts
+++ b/packages/vue/src/composables/useTransaction.test.ts
@@ -13,13 +13,15 @@ test('default', async () => {
 
   await waitFor(result.isSuccess)
 
-  expect(deepUnref(result)).toMatchInlineSnapshot(`
+  const value = deepUnref(result)
+  delete (value.data as { blockTimestamp?: bigint }).blockTimestamp
+
+  expect(value).toMatchInlineSnapshot(`
     {
       "data": {
         "accessList": [],
         "blockHash": "0xd725a38b51e5ceec8c5f6c9ccfdb2cc423af993bb650af5eedca5e4be7156ba7",
         "blockNumber": 15189204n,
-        "blockTimestamp": 1658449488n,
         "chainId": 1,
         "from": "0xa0cf798816d4b9b9866b5330eea46a18382f251e",
         "gas": 21000n,

--- a/site/shared/migrate-from-v2-to-v3.md
+++ b/site/shared/migrate-from-v2-to-v3.md
@@ -168,7 +168,7 @@ bun add @walletconnect/ethereum-provider@{{packageJson?.peerDependencies?.['@wal
 
 ## Bumped Minimum TypeScript Version
 
-The minimum supported TypeScript version is now `5.7.3` instead of `5.0.4`. Older versions of TypeScript should continue to work, but since [TypeScript doesn't follow semver](https://www.learningtypescript.com/articles/why-typescript-doesnt-follow-strict-semantic-versioning) we recommend you update to at least `5.7.3`. This should be relatively simple as there haven't been any breaking changes since `5.0.4`.
+The minimum supported TypeScript version is now `5.9.3` instead of `5.0.4`. Older versions of TypeScript should continue to work, but since [TypeScript doesn't follow semver](https://www.learningtypescript.com/articles/why-typescript-doesnt-follow-strict-semantic-versioning) we recommend you update to at least `5.9.3`. This should be relatively simple as there haven't been any breaking changes since `5.0.4`.
 
 ## Migrate v2 Deprecations
 


### PR DESCRIPTION
Drops TypeScript support below 5.9.3 and updates the typecheck CI matrix to cover 5.9.3, 6.0.3, and latest.