### PR TITLE
ci: harden publish workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -2,32 +2,33 @@ name: Changesets
 on:
   push:
     branches: [main]
-permissions:
-  contents: read
+
+permissions: {} # each job should declare only the permissions it needs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   verify:
     name: Verify
     permissions:
-      contents: write
+      contents: write # commit formatting updates in the reusable workflow
     uses: ./.github/workflows/verify.yml
     secrets: inherit
 
   changesets:
-    name: Publish
+    name: Changesets
     needs: verify
     # prevents this action from running on forks
     if: github.repository == 'wevm/wagmi'
     permissions:
-      contents: write # to create release (changesets/action)
-      id-token: write # OpenID Connect token needed for provenance
-      pull-requests: write # to create pull request (changesets/action)
+      contents: write # commit version/changelog updates to the release pull request
+      pull-requests: write # create or update the Changesets release pull request
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
 
     steps:
       - name: Clone repository
@@ -37,28 +38,79 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        uses: wevm/actions/.github/actions/pnpm@f7ad7f00e16e73322562922c241f21f0c7ffbbec
+        uses: wevm/actions/.github/actions/pnpm@f95dc1dadcba18fe3f02b8205e653e98e4a93516
         with:
           node-version: 24.5
+          skip-cache: true # avoid cache poisoning attacks
 
-      - name: PR or publish
+      - name: Create version pull request
+        id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'
-          createGithubReleases: ${{ github.ref == 'refs/heads/main' }}
-          publish: pnpm changeset:publish
           version: pnpm changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish canary release
-        if: steps.changesets.outputs.published != 'true'
+  release:
+    name: Release
+    needs: [verify, changesets]
+    # prevents this action from running on forks
+    if: github.repository == 'wevm/wagmi' && needs.changesets.outputs.hasChangesets == 'false'
+    permissions:
+      contents: write # create GitHub releases and tags after npm publish
+      id-token: write # authenticate to npm via trusted publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Install dependencies
+        uses: wevm/actions/.github/actions/pnpm@f95dc1dadcba18fe3f02b8205e653e98e4a93516
+        with:
+          node-version: 24.5
+          skip-cache: true # avoid cache poisoning attacks
+
+      - name: Publish to npm
+        id: publish
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        with:
+          createGithubReleases: true
+          publish: pnpm changeset:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  canary:
+    name: Canary release
+    needs: [verify, changesets]
+    # prevents this action from running on forks
+    if: github.repository == 'wevm/wagmi' && needs.changesets.outputs.hasChangesets == 'true'
+    permissions:
+      contents: read # checkout repository contents
+      id-token: write # authenticate to npm via trusted publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Install dependencies
+        uses: wevm/actions/.github/actions/pnpm@f95dc1dadcba18fe3f02b8205e653e98e4a93516
+        with:
+          node-version: 24.5
+          skip-cache: true # avoid cache poisoning attacks
+
+      - name: Publish snapshot packages
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git reset --hard origin/main
           pnpm changeset version --no-git-tag --snapshot canary
           pnpm changeset:prepublish
           pnpm changeset publish --no-git-tag --snapshot canary --tag canary

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ overrides:
   srvx@<0.11.13: '>=0.11.13'
   svgo@=4.0.0: 4.0.1
   tar@<=7.5.10: 7.5.11
-  tmp@<=0.2.3: 0.2.4
+  tmp@<0.2.6: 0.2.6
   undici@<6.24.0: 6.24.0
   undici@>=7.0.0 <7.24.0: 7.24.0
   unhead@<2.1.13: 2.1.13
@@ -10436,12 +10436,8 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tmp@0.2.4:
-    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
-    engines: {node: '>=14.14'}
-
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -19243,7 +19239,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.4
+      tmp: 0.2.6
 
   externality@1.0.2:
     dependencies:
@@ -22933,7 +22929,7 @@ snapshots:
       properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
-      tmp: 0.2.5
+      tmp: 0.2.6
       undici: 7.24.4
     transitivePeerDependencies:
       - bare-abort-controller
@@ -22986,9 +22982,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tmp@0.2.4: {}
-
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,6 +74,7 @@ minimumReleaseAgeExclude:
   - hono
   - mppx
   - prool
+  - tmp
   - wagmi
   - viem
   - vite
@@ -128,7 +129,7 @@ overrides:
   srvx@<0.11.13: '>=0.11.13'
   svgo@=4.0.0: 4.0.1
   tar@<=7.5.10: 7.5.11
-  tmp@<=0.2.3: 0.2.4
+  tmp@<0.2.6: 0.2.6
   undici@<6.24.0: 6.24.0
   undici@>=7.0.0 <7.24.0: 7.24.0
   unhead@<2.1.13: 2.1.13


### PR DESCRIPTION
## Summary
- split version PR creation from npm publishing
- reduce default workflow permissions and scope publish permissions to release job
- disable dependency cache in privileged Changesets jobs

## Verification
- ruby YAML parse for .github/workflows/changesets.yml
- git diff --check -- .github/workflows/changesets.yml
- pnpm check (via pre-commit)