### PR TITLE
ci: stabilize Playwright browser cache

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -143,10 +143,13 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Pull Tempo Docker image


### PR DESCRIPTION
## Summary
- key Playwright browser cache off package.json instead of the full lockfile
- add a Playwright cache restore prefix so dependency-only lockfile changes can reuse existing browser downloads
- cap Playwright install at 5 minutes so a browser install hang fails fast instead of consuming the whole test shard

Prompted by: @tmm