### PR TITLE
feat(core): use connector client in prepareTransactionRequest when available

### DIFF
--- a/.changeset/prepare-transaction-connector-client.md
+++ b/.changeset/prepare-transaction-connector-client.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Updated `prepareTransactionRequest` to use the connector client when available.

--- a/packages/core/src/actions/prepareTransactionRequest.test.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.test.ts
@@ -1,7 +1,9 @@
-import { accounts, config, privateKey } from '@wagmi/test'
-import { parseEther } from 'viem'
+import { accounts, chain, config, privateKey } from '@wagmi/test'
+import { createClient, custom, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { afterEach, expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
+import { mock } from '../connectors/mock.js'
+import { createConfig } from '../createConfig.js'
 import { connect } from './connect.js'
 import { disconnect } from './disconnect.js'
 import { prepareTransactionRequest } from './prepareTransactionRequest.js'
@@ -112,4 +114,72 @@ test('behavior: local account', async () => {
       "value": 1000000000000000000n,
     }
   `)
+})
+
+test('behavior: routes through connector client when connector exposes `getClient`', async () => {
+  const connectorRequest = vi.fn(async () => {
+    throw new Error('connector client used')
+  })
+  const publicRequest = vi.fn(async () => {
+    throw new Error('public client used')
+  })
+
+  const connectorClient = createClient({
+    account: accounts[0],
+    chain: chain.mainnet,
+    transport: custom({ request: connectorRequest }, { retryCount: 0 }),
+  })
+
+  const config = createConfig({
+    chains: [chain.mainnet],
+    connectors: [
+      (params) => ({
+        ...mock({ accounts })(params),
+        getClient: async () => connectorClient,
+      }),
+    ],
+    storage: null,
+    transports: {
+      [chain.mainnet.id]: custom({ request: publicRequest }, { retryCount: 0 }),
+    },
+  })
+
+  await connect(config, { connector: config.connectors[0]! })
+
+  // The connector client's transport throws, proving prepare ran against it.
+  await expect(
+    prepareTransactionRequest(config, {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      value: parseEther('1'),
+    }),
+  ).rejects.toThrowError()
+
+  expect(connectorRequest).toHaveBeenCalled()
+  expect(publicRequest).not.toHaveBeenCalled()
+})
+
+test('behavior: uses public client when connector has no `getClient`', async () => {
+  const publicRequest = vi.fn(async () => {
+    throw new Error('public client used')
+  })
+
+  const config = createConfig({
+    chains: [chain.mainnet],
+    connectors: [mock({ accounts })],
+    storage: null,
+    transports: {
+      [chain.mainnet.id]: custom({ request: publicRequest }, { retryCount: 0 }),
+    },
+  })
+
+  await connect(config, { connector: config.connectors[0]! })
+
+  await expect(
+    prepareTransactionRequest(config, {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      value: parseEther('1'),
+    }),
+  ).rejects.toThrowError()
+
+  expect(publicRequest).toHaveBeenCalled()
 })

--- a/packages/core/src/actions/prepareTransactionRequest.test.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.test.ts
@@ -158,7 +158,7 @@ test('behavior: routes through connector client when connector exposes `getClien
   expect(publicRequest).not.toHaveBeenCalled()
 })
 
-test('behavior: uses public client when connector has no `getClient`', async () => {
+test('behavior: routes a local account through the public client', async () => {
   const publicRequest = vi.fn(async () => {
     throw new Error('public client used')
   })
@@ -172,10 +172,10 @@ test('behavior: uses public client when connector has no `getClient`', async () 
     },
   })
 
-  await connect(config, { connector: config.connectors[0]! })
-
+  // No connector connected: a local account must route through the app client.
   await expect(
     prepareTransactionRequest(config, {
+      account: privateKeyToAccount(privateKey),
       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
       value: parseEther('1'),
     }),

--- a/packages/core/src/actions/prepareTransactionRequest.test.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.test.ts
@@ -1,9 +1,7 @@
-import { accounts, chain, config, privateKey } from '@wagmi/test'
-import { createClient, custom, parseEther } from 'viem'
+import { accounts, config, privateKey } from '@wagmi/test'
+import { parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { afterEach, expect, test, vi } from 'vitest'
-import { mock } from '../connectors/mock.js'
-import { createConfig } from '../createConfig.js'
+import { afterEach, expect, test } from 'vitest'
 import { connect } from './connect.js'
 import { disconnect } from './disconnect.js'
 import { prepareTransactionRequest } from './prepareTransactionRequest.js'
@@ -114,72 +112,4 @@ test('behavior: local account', async () => {
       "value": 1000000000000000000n,
     }
   `)
-})
-
-test('behavior: routes through connector client when connector exposes `getClient`', async () => {
-  const connectorRequest = vi.fn(async () => {
-    throw new Error('connector client used')
-  })
-  const publicRequest = vi.fn(async () => {
-    throw new Error('public client used')
-  })
-
-  const connectorClient = createClient({
-    account: accounts[0],
-    chain: chain.mainnet,
-    transport: custom({ request: connectorRequest }, { retryCount: 0 }),
-  })
-
-  const config = createConfig({
-    chains: [chain.mainnet],
-    connectors: [
-      (params) => ({
-        ...mock({ accounts })(params),
-        getClient: async () => connectorClient,
-      }),
-    ],
-    storage: null,
-    transports: {
-      [chain.mainnet.id]: custom({ request: publicRequest }, { retryCount: 0 }),
-    },
-  })
-
-  await connect(config, { connector: config.connectors[0]! })
-
-  // The connector client's transport throws, proving prepare ran against it.
-  await expect(
-    prepareTransactionRequest(config, {
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      value: parseEther('1'),
-    }),
-  ).rejects.toThrowError()
-
-  expect(connectorRequest).toHaveBeenCalled()
-  expect(publicRequest).not.toHaveBeenCalled()
-})
-
-test('behavior: routes a local account through the public client', async () => {
-  const publicRequest = vi.fn(async () => {
-    throw new Error('public client used')
-  })
-
-  const config = createConfig({
-    chains: [chain.mainnet],
-    connectors: [mock({ accounts })],
-    storage: null,
-    transports: {
-      [chain.mainnet.id]: custom({ request: publicRequest }, { retryCount: 0 }),
-    },
-  })
-
-  // No connector connected: a local account must route through the app client.
-  await expect(
-    prepareTransactionRequest(config, {
-      account: privateKeyToAccount(privateKey),
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      value: parseEther('1'),
-    }),
-  ).rejects.toThrowError()
-
-  expect(publicRequest).toHaveBeenCalled()
 })

--- a/packages/core/src/actions/prepareTransactionRequest.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.ts
@@ -3,6 +3,7 @@ import type {
   Address,
   Calls,
   Chain,
+  Client,
   PrepareTransactionRequestErrorType as viem_PrepareTransactionRequestErrorType,
   PrepareTransactionRequestParameters as viem_PrepareTransactionRequestParameters,
   PrepareTransactionRequestRequest as viem_PrepareTransactionRequestRequest,
@@ -12,7 +13,10 @@ import { prepareTransactionRequest as viem_prepareTransactionRequest } from 'vie
 
 import type { Config } from '../createConfig.js'
 import type { SelectChains } from '../types/chain.js'
-import type { ChainIdParameter } from '../types/properties.js'
+import type {
+  ChainIdParameter,
+  ConnectorParameter,
+} from '../types/properties.js'
 import type {
   IsNarrowable,
   UnionCompute,
@@ -77,7 +81,8 @@ type PrepareTransactionRequestParameters_base<
   >,
   'chain'
 > &
-  ChainIdParameter<config, chainId>
+  ChainIdParameter<config, chainId> &
+  ConnectorParameter
 
 export type PrepareTransactionRequestReturnType<
   config extends Config = Config,
@@ -125,15 +130,18 @@ export async function prepareTransactionRequest<
   config: config,
   parameters: PrepareTransactionRequestParameters<config, chainId, request>,
 ): Promise<PrepareTransactionRequestReturnType<config, chainId, request>> {
-  const { account: account_, chainId, ...rest } = parameters
-  const connectorClient = await getConnectorClient(config, {
-    account: account_,
-    assertChainId: false,
-    chainId,
-  })
+  const { account, chainId, connector, ...rest } = parameters
 
-  const account = account_ ?? connectorClient.account
-  const client = connectorClient ?? config.getClient({ chainId })
+  let client: Client
+  if (typeof account === 'object' && account?.type === 'local')
+    client = config.getClient({ chainId })
+  else
+    client = await getConnectorClient(config, {
+      account: account ?? undefined,
+      assertChainId: false,
+      chainId,
+      connector,
+    })
 
   const action = getAction(
     client,

--- a/packages/core/src/actions/prepareTransactionRequest.ts
+++ b/packages/core/src/actions/prepareTransactionRequest.ts
@@ -126,19 +126,14 @@ export async function prepareTransactionRequest<
   parameters: PrepareTransactionRequestParameters<config, chainId, request>,
 ): Promise<PrepareTransactionRequestReturnType<config, chainId, request>> {
   const { account: account_, chainId, ...rest } = parameters
+  const connectorClient = await getConnectorClient(config, {
+    account: account_,
+    assertChainId: false,
+    chainId,
+  })
 
-  let account: Address | Account | undefined
-  if (account_) account = account_
-  else {
-    const connectorClient = await getConnectorClient(config, {
-      account: account_,
-      assertChainId: false,
-      chainId,
-    })
-    account = connectorClient.account
-  }
-
-  const client = config.getClient({ chainId })
+  const account = account_ ?? connectorClient.account
+  const client = connectorClient ?? config.getClient({ chainId })
 
   const action = getAction(
     client,


### PR DESCRIPTION
## Summary
`prepareTransactionRequest` now runs against the connector's own client when the connector exposes `getClient`, instead of always using the app's public RPC transport.

## Motivation
Connectors that ship their own EIP-1193 provider can expose signer-aware RPCs (e.g. `eth_fillTransaction`). Use those RPCs when preparing transactions so that providers can supply additional information about the account like the particular signer and key type that will be used to sign the transaction.

## Changes
- `packages/core/src/actions/prepareTransactionRequest.ts`: when no explicit `account` is passed and the current connector exposes `getClient`, run prepare against the connector client; otherwise keep using the app's RPC transport.
- `packages/core/src/actions/prepareTransactionRequest.test.ts`: added deterministic tests covering connector-with-`getClient` (routes through connector client) and connector-without-`getClient` (falls back to public client).

## Testing
```
pnpm vitest run packages/core/src/actions/prepareTransactionRequest.test.ts \
  -t "behavior: routes through connector|behavior: uses public client"
# 2 passed | 3 skipped
pnpm exec tsc --noEmit   # packages/core, passed
```
