### PR TITLE
fix: include register-tests packages so changesets resolves them

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 packages:
   - packages/*
-  - '!packages/register-tests'
   - packages/cli/src/plugins/__fixtures__/hardhat
   - packages/register-tests/*
   - playgrounds/*


### PR DESCRIPTION
## Problem
The Changesets "Create version pull request" job fails:

```
Found issues in your config:
- ignore: Invalid path: The package or glob "*-register" does not match any package in the project.
🦋 Exited with code 1
```

## Cause
`pnpm-workspace.yaml` excluded `packages/register-tests` and then re-included its children:

```yaml
- packages/*
- '!packages/register-tests'
- packages/register-tests/*
```

pnpm honors the re-inclusion, but the `@manypkg/get-packages` resolver used by changesets drops the negated directory's children entirely. As a result `react-register` / `solid-register` / `vue-register` are invisible to changesets, so the `*-register` entry in `.changeset/config.json` `ignore` matches nothing and config validation throws.

## Fix
Remove the `'!packages/register-tests'` negation. `packages/register-tests` has no direct `package.json`, so `packages/*` skips it harmlessly while `packages/register-tests/*` still picks up the three register packages. `pnpm install` is unaffected and the lockfile is unchanged.

Verified locally: `changeset version` now passes config validation (only fails afterward on the missing local `GITHUB_TOKEN`, which CI provides).