### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/site/cli/api/commands.md
+++ b/site/cli/api/commands.md
@@ -27,6 +27,10 @@ yarn wagmi --help
 ```bash [bun]
 bun wagmi --help
 ```
+
+```bash [deno]
+deno wagmi --help
+```
 :::
 
 ### `-v`, `--version`
@@ -48,6 +52,10 @@ yarn wagmi --version
 
 ```bash [bun]
 bun wagmi --version
+```
+
+```bash [deno]
+deno wagmi --version
 ```
 :::
 

--- a/site/cli/create-wagmi.md
+++ b/site/cli/create-wagmi.md
@@ -19,6 +19,10 @@ yarn create wagmi
 ```bash [bun]
 bun create wagmi
 ```
+
+```bash [deno]
+deno create --npm wagmi
+```
 :::
 
 ## Options
@@ -39,6 +43,10 @@ yarn create wagmi --template next
 ```
 ```bash [bun]
 bun create wagmi --template next
+```
+
+```bash [deno]
+deno create --npm wagmi --template next
 ```
 :::
 

--- a/site/cli/getting-started.md
+++ b/site/cli/getting-started.md
@@ -24,6 +24,10 @@ yarn add -D @wagmi/cli
 ```bash [bun]
 bun add -D @wagmi/cli
 ```
+
+```bash [deno]
+deno add -D @wagmi/cli
+```
 :::
 
 ## Create Config File
@@ -45,6 +49,10 @@ yarn wagmi init
 
 ```bash [bun]
 bun wagmi init
+```
+
+```bash [deno]
+deno wagmi init
 ```
 :::
 
@@ -122,6 +130,10 @@ yarn wagmi generate
 
 ```bash [bun]
 bun wagmi generate
+```
+
+```bash [deno]
+deno wagmi generate
 ```
 :::
 

--- a/site/cli/guides/migrate-from-v1-to-v2.md
+++ b/site/cli/guides/migrate-from-v1-to-v2.md
@@ -24,6 +24,10 @@ yarn add @wagmi/cli
 ```bash-vue [bun]
 bun add @wagmi/cli
 ```
+
+```bash-vue [deno]
+deno add @wagmi/cli
+```
 :::
 
 ::: info Not ready to migrate yet?

--- a/site/cli/installation.md
+++ b/site/cli/installation.md
@@ -22,6 +22,10 @@ yarn add @wagmi/cli
 ```bash [bun]
 bun add @wagmi/cli
 ```
+
+```bash [deno]
+deno add @wagmi/cli
+```
 :::
 
 ## Using Unreleased Commits
@@ -43,6 +47,10 @@ yarn add @wagmi/cli@canary
 
 ```bash [bun]
 bun add @wagmi/cli@canary
+```
+
+```bash [deno]
+deno add @wagmi/cli@canary
 ```
 :::
 

--- a/site/core/getting-started.md
+++ b/site/core/getting-started.md
@@ -30,6 +30,10 @@ yarn add @wagmi/core @wagmi/connectors viem@{{viemVersion}}
 ```bash-vue [bun]
 bun add @wagmi/core @wagmi/connectors viem@{{viemVersion}}
 ```
+
+```bash-vue [deno]
+deno add @wagmi/core @wagmi/connectors viem@{{viemVersion}}
+```
 :::
 
 - [Wagmi Connectors](/core/api/connectors) is a collection of interfaces for linking accounts/wallets to Wagmi.

--- a/site/core/guides/migrate-from-v1-to-v2.md
+++ b/site/core/guides/migrate-from-v1-to-v2.md
@@ -32,6 +32,10 @@ yarn add @wagmi/core viem@{{viemVersion}} @wagmi/connectors
 ```bash-vue [bun]
 bun add @wagmi/core viem@{{viemVersion}} @wagmi/connectors
 ```
+
+```bash-vue [deno]
+deno add @wagmi/core viem@{{viemVersion}} @wagmi/connectors
+```
 :::
 
 ::: info Wagmi Core v2 should be the last major version that will have this many actionable breaking changes. 
@@ -272,6 +276,10 @@ yarn add @wagmi/connectors
 
 ```bash-vue [bun]
 bun add @wagmi/connectors
+```
+
+```bash-vue [deno]
+deno add @wagmi/connectors
 ```
 :::
 

--- a/site/core/guides/migrate-from-v2-to-v3.md
+++ b/site/core/guides/migrate-from-v2-to-v3.md
@@ -35,6 +35,10 @@ yarn add @wagmi/core@3
 ```bash [bun]
 bun add @wagmi/core@3
 ```
+
+```bash [deno]
+deno add @wagmi/core@3
+```
 :::
 
 ::: info Not ready to migrate yet?

--- a/site/core/installation.md
+++ b/site/core/installation.md
@@ -32,6 +32,10 @@ yarn add @wagmi/core viem@{{viemVersion}}
 ```bash-vue [bun]
 bun add @wagmi/core viem@{{viemVersion}}
 ```
+
+```bash-vue [deno]
+deno add @wagmi/core viem@{{viemVersion}}
+```
 :::
 
 - [Viem](https://viem.sh) is a TypeScript interface for Ethereum that performs blockchain operations.

--- a/site/react/getting-started.md
+++ b/site/react/getting-started.md
@@ -62,6 +62,10 @@ yarn add wagmi viem@{{viemVersion}} @tanstack/react-query
 ```bash-vue [bun]
 bun add wagmi viem@{{viemVersion}} @tanstack/react-query
 ```
+
+```bash-vue [deno]
+deno add wagmi viem@{{viemVersion}} @tanstack/react-query
+```
 :::
 
 - [Viem](https://viem.sh) is a TypeScript interface for Ethereum that performs blockchain operations.

--- a/site/react/getting-started.md
+++ b/site/react/getting-started.md
@@ -30,6 +30,10 @@ yarn create wagmi
 ```bash [bun]
 bun create wagmi
 ```
+
+```bash [deno]
+deno create --npm wagmi
+```
 :::
 
 Once the command runs, you'll see some prompts to complete.

--- a/site/react/guides/migrate-from-v1-to-v2.md
+++ b/site/react/guides/migrate-from-v1-to-v2.md
@@ -33,6 +33,10 @@ yarn add wagmi viem@{{viemVersion}} @tanstack/react-query
 ```bash-vue [bun]
 bun add wagmi viem@{{viemVersion}} @tanstack/react-query
 ```
+
+```bash-vue [deno]
+deno add wagmi viem@{{viemVersion}} @tanstack/react-query
+```
 :::
 
 ::: info Wagmi v2 should be the last major version that will have this many actionable breaking changes. 

--- a/site/react/guides/migrate-from-v2-to-v3.md
+++ b/site/react/guides/migrate-from-v2-to-v3.md
@@ -35,6 +35,10 @@ yarn add wagmi@3
 ```bash [bun]
 bun add wagmi@3
 ```
+
+```bash [deno]
+deno add wagmi@3
+```
 :::
 
 ::: info Not ready to migrate yet?

--- a/site/react/guides/tanstack-query.md
+++ b/site/react/guides/tanstack-query.md
@@ -51,6 +51,10 @@ yarn add @tanstack/query-sync-storage-persister @tanstack/react-query-persist-cl
 ```bash [bun]
 bun i @tanstack/query-sync-storage-persister @tanstack/react-query-persist-client
 ```
+
+```bash [deno]
+deno i @tanstack/query-sync-storage-persister @tanstack/react-query-persist-client
+```
 :::
 
 #### Usage
@@ -116,6 +120,10 @@ yarn add @tanstack/query-async-storage-persister @tanstack/react-query-persist-c
 
 ```bash [bun]
 bun i @tanstack/query-async-storage-persister @tanstack/react-query-persist-client
+```
+
+```bash [deno]
+deno i @tanstack/query-async-storage-persister @tanstack/react-query-persist-client
 ```
 :::
 
@@ -380,6 +388,10 @@ yarn add @tanstack/react-query-devtools
 
 ```bash [bun]
 bun i @tanstack/react-query-devtools
+```
+
+```bash [deno]
+deno i @tanstack/react-query-devtools
 ```
 :::
 

--- a/site/react/installation.md
+++ b/site/react/installation.md
@@ -32,6 +32,10 @@ yarn add wagmi viem@{{viemVersion}} @tanstack/react-query
 ```bash-vue [bun]
 bun add wagmi viem@{{viemVersion}} @tanstack/react-query
 ```
+
+```bash-vue [deno]
+deno add wagmi viem@{{viemVersion}} @tanstack/react-query
+```
 :::
 
 - [Viem](https://viem.sh) is a TypeScript interface for Ethereum that performs blockchain operations.

--- a/site/shared/connectors/baseAccount.md
+++ b/site/shared/connectors/baseAccount.md
@@ -34,6 +34,10 @@ yarn add @base-org/account@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add @base-org/account@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add @base-org/account@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/shared/connectors/coinbaseWallet.md
+++ b/site/shared/connectors/coinbaseWallet.md
@@ -34,6 +34,10 @@ yarn add @coinbase/wallet-sdk@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add @coinbase/wallet-sdk@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add @coinbase/wallet-sdk@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/shared/connectors/metaMask.md
+++ b/site/shared/connectors/metaMask.md
@@ -34,6 +34,10 @@ yarn add @metamask/connect-evm@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add @metamask/connect-evm@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add @metamask/connect-evm@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/shared/connectors/porto.md
+++ b/site/shared/connectors/porto.md
@@ -34,6 +34,10 @@ yarn add porto@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add porto@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add porto@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/shared/connectors/safe.md
+++ b/site/shared/connectors/safe.md
@@ -35,6 +35,10 @@ yarn add @safe-global/safe-apps-provider@{{connectorDependencyVersions?.[0]}} @s
 ```bash-vue [bun]
 bun add @safe-global/safe-apps-provider@{{connectorDependencyVersions?.[0]}} @safe-global/safe-apps-sdk@{{connectorDependencyVersions?.[1]}}
 ```
+
+```bash-vue [deno]
+deno add @safe-global/safe-apps-provider@{{connectorDependencyVersions?.[0]}} @safe-global/safe-apps-sdk@{{connectorDependencyVersions?.[1]}}
+```
 :::
 
 ## Usage

--- a/site/shared/connectors/tempoWallet.md
+++ b/site/shared/connectors/tempoWallet.md
@@ -34,6 +34,10 @@ yarn add accounts@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add accounts@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add accounts@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/shared/connectors/walletConnect.md
+++ b/site/shared/connectors/walletConnect.md
@@ -34,6 +34,10 @@ yarn add @walletconnect/ethereum-provider@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add @walletconnect/ethereum-provider@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add @walletconnect/ethereum-provider@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/shared/installation.md
+++ b/site/shared/installation.md
@@ -37,6 +37,10 @@ yarn add {{packageName}}@canary
 ```bash-vue [bun]
 bun add {{packageName}}@canary
 ```
+
+```bash-vue [deno]
+deno add {{packageName}}@canary
+```
 :::
 
 Or clone the [Wagmi repo](https://github.com/wevm/wagmi) to your local machine, build, and link it yourself.

--- a/site/shared/migrate-from-v2-to-v3.md
+++ b/site/shared/migrate-from-v2-to-v3.md
@@ -42,6 +42,10 @@ yarn add @base-org/account@{{packageJson?.peerDependencies?.['@base-org/account'
 ```bash-vue [bun]
 bun add @base-org/account@{{packageJson?.peerDependencies?.['@base-org/account']}}
 ```
+
+```bash-vue [deno]
+deno add @base-org/account@{{packageJson?.peerDependencies?.['@base-org/account']}}
+```
 :::
 
 ### coinbaseWallet
@@ -65,6 +69,10 @@ yarn add @coinbase/wallet-sdk@{{packageJson?.peerDependencies?.['@coinbase/walle
 
 ```bash-vue [bun]
 bun add @coinbase/wallet-sdk@{{packageJson?.peerDependencies?.['@coinbase/wallet-sdk']}}
+```
+
+```bash-vue [deno]
+deno add @coinbase/wallet-sdk@{{packageJson?.peerDependencies?.['@coinbase/wallet-sdk']}}
 ```
 :::
 
@@ -90,6 +98,10 @@ yarn add @metamask/connect-evm@{{packageJson?.peerDependencies?.['@metamask/conn
 ```bash-vue [bun]
 bun add @metamask/connect-evm@{{packageJson?.peerDependencies?.['@metamask/connect-evm']}}
 ```
+
+```bash-vue [deno]
+deno add @metamask/connect-evm@{{packageJson?.peerDependencies?.['@metamask/connect-evm']}}
+```
 :::
 
 ### porto
@@ -113,6 +125,10 @@ yarn add porto@{{packageJson?.peerDependencies?.['porto']}}
 
 ```bash-vue [bun]
 bun add porto@{{packageJson?.peerDependencies?.['porto']}}
+```
+
+```bash-vue [deno]
+deno add porto@{{packageJson?.peerDependencies?.['porto']}}
 ```
 :::
 
@@ -139,6 +155,10 @@ yarn add @safe-global/safe-apps-provider@{{packageJson?.peerDependencies?.['@saf
 ```bash-vue [bun]
 bun add @safe-global/safe-apps-provider@{{packageJson?.peerDependencies?.['@safe-global/safe-apps-provider']}} @safe-global/safe-apps-sdk@{{packageJson?.peerDependencies?.['@safe-global/safe-apps-sdk']}} 
 ```
+
+```bash-vue [deno]
+deno add @safe-global/safe-apps-provider@{{packageJson?.peerDependencies?.['@safe-global/safe-apps-provider']}} @safe-global/safe-apps-sdk@{{packageJson?.peerDependencies?.['@safe-global/safe-apps-sdk']}} 
+```
 :::
 
 ### walletConnect
@@ -162,6 +182,10 @@ yarn add @walletconnect/ethereum-provider@{{packageJson?.peerDependencies?.['@wa
 
 ```bash-vue [bun]
 bun add @walletconnect/ethereum-provider@{{packageJson?.peerDependencies?.['@walletconnect/ethereum-provider']}}
+```
+
+```bash-vue [deno]
+deno add @walletconnect/ethereum-provider@{{packageJson?.peerDependencies?.['@walletconnect/ethereum-provider']}}
 ```
 :::
 

--- a/site/solid/getting-started.md
+++ b/site/solid/getting-started.md
@@ -30,6 +30,10 @@ yarn add @wagmi/solid viem@{{viemVersion}} @tanstack/solid-query
 ```bash-vue [bun]
 bun add @wagmi/solid viem@{{viemVersion}} @tanstack/solid-query
 ```
+
+```bash-vue [deno]
+deno add @wagmi/solid viem@{{viemVersion}} @tanstack/solid-query
+```
 :::
 
 - [Viem](https://viem.sh) is a TypeScript interface for Ethereum that performs blockchain operations.

--- a/site/solid/installation.md
+++ b/site/solid/installation.md
@@ -31,6 +31,10 @@ yarn add @wagmi/solid viem@{{viemVersion}} @tanstack/solid-query
 ```bash-vue [bun]
 bun add @wagmi/solid viem@{{viemVersion}} @tanstack/solid-query
 ```
+
+```bash-vue [deno]
+deno add @wagmi/solid viem@{{viemVersion}} @tanstack/solid-query
+```
 :::
 
 - [Viem](https://viem.sh) is a TypeScript interface for Ethereum that performs blockchain operations.

--- a/site/tempo/connectors/dangerous_secp256k1.md
+++ b/site/tempo/connectors/dangerous_secp256k1.md
@@ -33,6 +33,10 @@ yarn add accounts@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add accounts@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add accounts@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/tempo/connectors/webAuthn.md
+++ b/site/tempo/connectors/webAuthn.md
@@ -29,6 +29,10 @@ yarn add accounts@{{connectorDependencyVersion}}
 ```bash-vue [bun]
 bun add accounts@{{connectorDependencyVersion}}
 ```
+
+```bash-vue [deno]
+deno add accounts@{{connectorDependencyVersion}}
+```
 :::
 
 ## Usage

--- a/site/tempo/getting-started.md
+++ b/site/tempo/getting-started.md
@@ -31,6 +31,10 @@ yarn add viem@{{viemVersion}} accounts@{{accountsVersion}}
 ```bash-vue [bun]
 bun add viem@{{viemVersion}} accounts@{{accountsVersion}}
 ```
+
+```bash-vue [deno]
+deno add viem@{{viemVersion}} accounts@{{accountsVersion}}
+```
 :::
 
 To dive a layer deeper, check out the [Viem Tempo docs](https://viem.sh/tempo).

--- a/site/vue/getting-started.md
+++ b/site/vue/getting-started.md
@@ -30,6 +30,10 @@ yarn create wagmi
 ```bash [bun]
 bun create wagmi
 ```
+
+```bash [deno]
+deno create --npm wagmi
+```
 :::
 
 Once the command runs, you'll see some prompts to complete.
@@ -61,6 +65,10 @@ yarn add @wagmi/vue viem@{{viemVersion}} @tanstack/vue-query
 
 ```bash-vue [bun]
 bun add @wagmi/vue viem@{{viemVersion}} @tanstack/vue-query
+```
+
+```bash-vue [deno]
+deno add @wagmi/vue viem@{{viemVersion}} @tanstack/vue-query
 ```
 :::
 

--- a/site/vue/guides/tanstack-query.md
+++ b/site/vue/guides/tanstack-query.md
@@ -246,6 +246,10 @@ yarn add @tanstack/vue-query-devtools
 ```bash [bun]
 bun i @tanstack/vue-query-devtools
 ```
+
+```bash [deno]
+deno i @tanstack/vue-query-devtools
+```
 :::
 
 #### Usage

--- a/site/vue/installation.md
+++ b/site/vue/installation.md
@@ -32,6 +32,10 @@ yarn add @wagmi/vue viem@{{viemVersion}} @tanstack/vue-query
 ```bash-vue [bun]
 bun add @wagmi/vue viem@{{viemVersion}} @tanstack/vue-query
 ```
+
+```bash-vue [deno]
+deno add @wagmi/vue viem@{{viemVersion}} @tanstack/vue-query
+```
 :::
 
 - [Viem](https://viem.sh) is a TypeScript interface for Ethereum that performs blockchain operations.


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The manual-installation `code-group` lists pnpm / npm / yarn / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity:

```sh
deno add wagmi viem @tanstack/react-query
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
