### PR TITLE
Fix accounts peer dependency range

### DIFF
--- a/.changeset/tidy-berries-cheer.md
+++ b/.changeset/tidy-berries-cheer.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/connectors": patch
+"@wagmi/core": patch
+---
+
+Updated the optional `accounts` peer dependency range to allow `accounts@0.14`.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -42,7 +42,7 @@
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@wagmi/core": "workspace:*",
     "@walletconnect/ethereum-provider": "^2.21.1",
-    "accounts": "~0.10",
+    "accounts": ">=0.12 <0.15",
     "porto": "~0.2.35",
     "typescript": ">=5.9.3",
     "viem": "2.x"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@tanstack/query-core": ">=5.0.0",
-    "accounts": "~0.12",
+    "accounts": ">=0.12 <0.15",
     "typescript": ">=5.9.3",
     "viem": "2.x"
   },


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->

Fixes #5145.

This updates the optional `accounts` peer dependency range for `@wagmi/core` and `@wagmi/connectors` to allow `accounts@0.14`.

Projects that install `accounts@^0.14` alongside wagmi currently hit npm peer resolution errors because `@wagmi/core` only accepts `~0.12` and `@wagmi/connectors` only accepts `~0.10`.

