### PR TITLE
docs: update WalletConnect links

### DIFF
--- a/site/core/why.md
+++ b/site/core/why.md
@@ -32,7 +32,7 @@ Wagmi Core supports the most popular and commonly-used Ethereum features out of 
 
 If you need lower-level control, you can always drop down to [Viem](https://viem.sh), which Wagmi Core uses internally to perform blockchain operations. Wagmi Core also manages multi-chain support automatically so developers can focus on their applications instead of adding custom code.
 
-Finally, Wagmi Core has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [AppKit](https://walletconnect.com/appkit), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
+Finally, Wagmi Core has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [WalletConnect App SDK](https://docs.walletconnect.network/app-sdk/overview), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
 
 ## Stability
 

--- a/site/react/why.md
+++ b/site/react/why.md
@@ -32,7 +32,7 @@ Wagmi supports the most popular and commonly-used Ethereum features out of the b
 
 If you need lower-level control, you can always drop down to [Wagmi Core](/core/getting-started) or [Viem](https://viem.sh), which Wagmi uses internally to perform blockchain operations. Wagmi also manages multi-chain support automatically so developers can focus on their applications instead of adding custom code.
 
-Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [AppKit](https://walletconnect.com/appkit), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
+Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [WalletConnect App SDK](https://docs.walletconnect.network/app-sdk/overview), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
 
 ## Stability
 

--- a/site/shared/connectors/walletConnect.md
+++ b/site/shared/connectors/walletConnect.md
@@ -5,7 +5,7 @@ const connectorsPackageName = 'wagmi/connectors'
 
 # walletConnect
 
-Connector for [WalletConnect](https://walletconnect.com).
+Connector for [WalletConnect](https://walletconnect.network).
 
 ## Import
 

--- a/site/vue/guides/connect-wallet.md
+++ b/site/vue/guides/connect-wallet.md
@@ -8,7 +8,7 @@ Wagmi contains everything you need to get started with building a Connect Wallet
 
 You can use a pre-built Connect Wallet module from a third-party library such as:
 
-- [AppKit](https://walletconnect.com/appkit) - [Guide](https://docs.walletconnect.com/appkit/vue/core/installation)
+- [WalletConnect App SDK](https://docs.walletconnect.network/app-sdk/overview) - [Guide](https://docs.walletconnect.network/app-sdk/vue/installation)
 
 The above libraries are all built on top of Wagmi, handle all the edge cases around wallet connection, and provide a seamless Connect Wallet UX that you can use in your Dapp.
 

--- a/site/vue/why.md
+++ b/site/vue/why.md
@@ -32,7 +32,7 @@ Wagmi supports the most popular and commonly-used Ethereum features out of the b
 
 If you need lower-level control, you can always drop down to [Wagmi Core](/core/getting-started) or [Viem](https://viem.sh), which Wagmi uses internally to perform blockchain operations. Wagmi also manages multi-chain support automatically so developers can focus on their applications instead of adding custom code.
 
-Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [AppKit](https://walletconnect.com/appkit), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
+Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [RainbowKit](https://www.rainbowkit.com), [WalletConnect App SDK](https://docs.walletconnect.network/app-sdk/overview), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
 
 ## Stability
 


### PR DESCRIPTION
This PR updates **most** WalletConnect links pointing to walletconnect.com to their closest equivalent walletconnect.network links.

docs.walletconnect.com now hosts documentation for WalletConnect pay, making old links go to a 404 error page.