### PR TITLE
fix(tempo): zone mutation types

### DIFF
--- a/.changeset/smart-zones-type.md
+++ b/.changeset/smart-zones-type.md
@@ -1,0 +1,6 @@
+---
+"@wagmi/core": patch
+"wagmi": patch
+---
+
+Fixed Tempo Zone types for optional fields.

--- a/packages/core/src/tempo/actions/zone.test-d.ts
+++ b/packages/core/src/tempo/actions/zone.test-d.ts
@@ -1,0 +1,165 @@
+import { http } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { zone, http as zoneHttp } from 'viem/tempo/zones'
+import { expectTypeOf, test } from 'vitest'
+import { createConfig } from '../../createConfig.js'
+import * as zoneActions from './zone.js'
+
+const zoneChain = zone(7)
+const revealTo =
+  '0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+const token = '0x20c0000000000000000000000000000000000001'
+
+const config = createConfig({
+  chains: [tempoLocalnet, zoneChain],
+  transports: {
+    [tempoLocalnet.id]: http(),
+    [zoneChain.id]: zoneHttp(),
+  },
+})
+
+test('deposit parameters', () => {
+  zoneActions.deposit(config, {
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf<zoneActions.deposit.Parameters<typeof config>>().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    token: unknown
+    zoneId: number
+  }>()
+})
+
+test('depositSync parameters', () => {
+  zoneActions.depositSync(config, {
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf<
+    zoneActions.depositSync.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    token: unknown
+    zoneId: number
+  }>()
+})
+
+test('encryptedDeposit parameters', () => {
+  zoneActions.encryptedDeposit(config, {
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf<
+    zoneActions.encryptedDeposit.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    token: unknown
+    zoneId: number
+  }>()
+})
+
+test('encryptedDepositSync parameters', () => {
+  zoneActions.encryptedDepositSync(config, {
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf<
+    zoneActions.encryptedDepositSync.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    token: unknown
+    zoneId: number
+  }>()
+})
+
+test('requestWithdrawal parameters', () => {
+  zoneActions.requestWithdrawal(config, {
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    token,
+  })
+
+  expectTypeOf<
+    zoneActions.requestWithdrawal.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    token: unknown
+  }>()
+})
+
+test('requestWithdrawalSync parameters', () => {
+  zoneActions.requestWithdrawalSync(config, {
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    token,
+  })
+
+  expectTypeOf<
+    zoneActions.requestWithdrawalSync.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    token: unknown
+  }>()
+})
+
+test('requestVerifiableWithdrawal parameters', () => {
+  zoneActions.requestVerifiableWithdrawal(config, {
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    revealTo,
+    token,
+  })
+
+  expectTypeOf<
+    zoneActions.requestVerifiableWithdrawal.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    revealTo: unknown
+    token: unknown
+  }>()
+})
+
+test('requestVerifiableWithdrawalSync parameters', () => {
+  zoneActions.requestVerifiableWithdrawalSync(config, {
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    revealTo,
+    token,
+  })
+
+  expectTypeOf<
+    zoneActions.requestVerifiableWithdrawalSync.Parameters<typeof config>
+  >().toMatchTypeOf<{
+    account?: unknown
+    amount: bigint
+    chainId?: number | undefined
+    revealTo: unknown
+    token: unknown
+  }>()
+})

--- a/packages/core/src/tempo/actions/zone.ts
+++ b/packages/core/src/tempo/actions/zone.ts
@@ -24,6 +24,20 @@ import type { PartialBy, UnionLooseOmit } from '../../types/utils.js'
 import type { QueryOptions, QueryParameter } from './utils.js'
 import { filterQueryOptions } from './utils.js'
 
+type TransactionOverrideParameter =
+  | 'account'
+  | 'gas'
+  | 'maxFeePerGas'
+  | 'maxPriorityFeePerGas'
+  | 'nonce'
+
+type OptionalTransactionOverrides<parameters> = parameters extends object
+  ? PartialBy<
+      parameters,
+      Extract<TransactionOverrideParameter, keyof parameters>
+    >
+  : parameters
+
 /**
  * Gets information about the currently stored zone authorization token.
  *
@@ -572,7 +586,9 @@ export declare namespace deposit {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.deposit.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.zone.deposit.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -683,7 +699,9 @@ export declare namespace depositSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.depositSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.zone.depositSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -796,9 +814,11 @@ export declare namespace encryptedDeposit {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.encryptedDeposit.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.zone.encryptedDeposit.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -926,9 +946,11 @@ export declare namespace encryptedDepositSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.encryptedDepositSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.zone.encryptedDepositSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -988,9 +1010,11 @@ export declare namespace requestWithdrawal {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.requestWithdrawal.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.zone.requestWithdrawal.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1053,9 +1077,11 @@ export declare namespace requestWithdrawalSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.requestWithdrawalSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.zone.requestWithdrawalSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1117,9 +1143,11 @@ export declare namespace requestVerifiableWithdrawal {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.requestVerifiableWithdrawal.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.zone.requestVerifiableWithdrawal.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1187,9 +1215,11 @@ export declare namespace requestVerifiableWithdrawalSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.zone.requestVerifiableWithdrawalSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.zone.requestVerifiableWithdrawalSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >

--- a/packages/react/src/tempo/hooks/zone.test-d.ts
+++ b/packages/react/src/tempo/hooks/zone.test-d.ts
@@ -1,0 +1,199 @@
+import { createConfig, http } from '@wagmi/core'
+import { tempoLocalnet } from 'viem/chains'
+import { zone, http as zoneHttp } from 'viem/tempo/zones'
+import { expectTypeOf, test } from 'vitest'
+import {
+  useDeposit,
+  useDepositSync,
+  useEncryptedDeposit,
+  useEncryptedDepositSync,
+  useRequestVerifiableWithdrawal,
+  useRequestVerifiableWithdrawalSync,
+  useRequestWithdrawal,
+  useRequestWithdrawalSync,
+} from './zone.js'
+
+const zoneChain = zone(7)
+const revealTo =
+  '0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+const token = '0x20c0000000000000000000000000000000000001'
+
+const config = createConfig({
+  chains: [tempoLocalnet, zoneChain],
+  transports: {
+    [tempoLocalnet.id]: http(),
+    [zoneChain.id]: zoneHttp(),
+  },
+})
+
+test('deposit variables', () => {
+  const deposit = useDeposit({ config })
+
+  deposit.mutate({
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf(deposit.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        token: unknown
+        zoneId: number
+      }
+    | undefined
+  >()
+})
+
+test('depositSync variables', () => {
+  const deposit = useDepositSync({ config })
+
+  deposit.mutate({
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf(deposit.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        token: unknown
+        zoneId: number
+      }
+    | undefined
+  >()
+})
+
+test('encryptedDeposit variables', () => {
+  const deposit = useEncryptedDeposit({ config })
+
+  deposit.mutate({
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf(deposit.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        token: unknown
+        zoneId: number
+      }
+    | undefined
+  >()
+})
+
+test('encryptedDepositSync variables', () => {
+  const deposit = useEncryptedDepositSync({ config })
+
+  deposit.mutate({
+    amount: 1_000_000n,
+    chainId: tempoLocalnet.id,
+    token,
+    zoneId: 7,
+  })
+
+  expectTypeOf(deposit.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        token: unknown
+        zoneId: number
+      }
+    | undefined
+  >()
+})
+
+test('requestWithdrawal variables', () => {
+  const withdraw = useRequestWithdrawal({ config })
+
+  withdraw.mutate({
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    token,
+  })
+
+  expectTypeOf(withdraw.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        token: unknown
+      }
+    | undefined
+  >()
+})
+
+test('requestWithdrawalSync variables', () => {
+  const withdraw = useRequestWithdrawalSync({ config })
+
+  withdraw.mutate({
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    token,
+  })
+
+  expectTypeOf(withdraw.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        token: unknown
+      }
+    | undefined
+  >()
+})
+
+test('requestVerifiableWithdrawal variables', () => {
+  const withdraw = useRequestVerifiableWithdrawal({ config })
+
+  withdraw.mutate({
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    revealTo,
+    token,
+  })
+
+  expectTypeOf(withdraw.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        revealTo: unknown
+        token: unknown
+      }
+    | undefined
+  >()
+})
+
+test('requestVerifiableWithdrawalSync variables', () => {
+  const withdraw = useRequestVerifiableWithdrawalSync({ config })
+
+  withdraw.mutate({
+    amount: 1_000_000n,
+    chainId: zoneChain.id,
+    revealTo,
+    token,
+  })
+
+  expectTypeOf(withdraw.variables).toMatchTypeOf<
+    | {
+        account?: unknown
+        amount: bigint
+        chainId?: number | undefined
+        revealTo: unknown
+        token: unknown
+      }
+    | undefined
+  >()
+})


### PR DESCRIPTION
Makes Tempo Zone transaction override fields optional for wagmi actions and hooks so minimal deposit and withdrawal variables type-check.