### PR TITLE
Clean generated connector package metadata

### DIFF
--- a/scripts/generateConnectorExports.ts
+++ b/scripts/generateConnectorExports.ts
@@ -28,6 +28,15 @@ if (process.argv.includes('--clean')) {
     for (const pkg of frameworkPackages)
       await removeFile(`packages/${pkg}/src/exports/${connector}.ts`)
   }
+  await cleanPackageJson('packages/connectors/package.json', {
+    exportPrefix: '.',
+    typesPrefix: '',
+  })
+  for (const pkg of frameworkPackages)
+    await cleanPackageJson(`packages/${pkg}/package.json`, {
+      exportPrefix: './connectors',
+      typesPrefix: 'connectors/',
+    })
   console.log(`Done. Cleaned ${count} ${count === 1 ? 'file' : 'files'}.`)
   process.exit(0)
 }
@@ -126,6 +135,39 @@ async function updatePackageJson(
   }
   if (!insertedTypesVersions) nextPackageJson.typesVersions = typesVersions
   packageJson = nextPackageJson
+
+  await writeFile(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, undefined, 2)}\n`,
+  )
+}
+
+async function cleanPackageJson(
+  packageJsonPath: string,
+  options: {
+    exportPrefix: '.' | './connectors'
+    typesPrefix: '' | 'connectors/'
+  },
+) {
+  const packageJson = JSON.parse(
+    await fs.readFile(packageJsonPath, 'utf-8'),
+  ) as PackageJson
+  const originalPackageJson = JSON.stringify(packageJson)
+
+  for (const connector of connectors) {
+    delete packageJson.exports?.[`${options.exportPrefix}/${connector}`]
+
+    const typesVersions = packageJson.typesVersions
+    const typesVersion = typesVersions?.['*']
+    if (!typesVersion) continue
+
+    delete typesVersion[`${options.typesPrefix}${connector}`]
+    if (Object.keys(typesVersion).length === 0) delete typesVersions['*']
+    if (Object.keys(typesVersions).length === 0)
+      delete packageJson.typesVersions
+  }
+
+  if (JSON.stringify(packageJson) === originalPackageJson) return
 
   await writeFile(
     packageJsonPath,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->


Updates the connector export generator so `--clean` removes the generated connector subpath entries from package.json exports and typesVersions, in addition to deleting the generated source export files. This keeps the workspace clean after running the generate/clean cycle used by the build script.
