### PR TITLE
feat(connectors): add native mossWallet connector for MOSS Wallet (MegaETH)

### DIFF
--- a/.changeset/moss-wallet-connector.md
+++ b/.changeset/moss-wallet-connector.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": minor
+---
+
+Added `mossWallet` connector for [MOSS Wallet](https://moss.megaeth.com), MegaETH's embedded SDK wallet.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -37,6 +37,7 @@
   "peerDependencies": {
     "@base-org/account": "^2.5.1",
     "@coinbase/wallet-sdk": "^4.3.6",
+    "@megaeth-labs/wallet-sdk": "^0.1.19",
     "@metamask/connect-evm": "^2.1.0",
     "@safe-global/safe-apps-provider": "~0.18.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",
@@ -52,6 +53,9 @@
       "optional": true
     },
     "@coinbase/wallet-sdk": {
+      "optional": true
+    },
+    "@megaeth-labs/wallet-sdk": {
       "optional": true
     },
     "@metamask/connect-evm": {
@@ -79,6 +83,7 @@
   "devDependencies": {
     "@base-org/account": "catalog:",
     "@coinbase/wallet-sdk": "catalog:",
+    "@megaeth-labs/wallet-sdk": "^0.1.19",
     "@metamask/connect-evm": "catalog:",
     "@safe-global/safe-apps-provider": "catalog:",
     "@safe-global/safe-apps-sdk": "catalog:",

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@base-org/account": "catalog:",
     "@coinbase/wallet-sdk": "catalog:",
-    "@megaeth-labs/wallet-sdk": "^0.1.19",
+    "@megaeth-labs/wallet-sdk": "^0.1.24",
     "@metamask/connect-evm": "catalog:",
     "@safe-global/safe-apps-provider": "catalog:",
     "@safe-global/safe-apps-sdk": "catalog:",

--- a/packages/connectors/src/exports/index.test.ts
+++ b/packages/connectors/src/exports/index.test.ts
@@ -11,6 +11,7 @@ test('exports', () => {
       "baseAccount",
       "coinbaseWallet",
       "metaMask",
+      "mossWallet",
       "porto",
       "safe",
       "version",

--- a/packages/connectors/src/exports/index.ts
+++ b/packages/connectors/src/exports/index.ts
@@ -12,6 +12,7 @@ export {
   coinbaseWallet,
 } from '../coinbaseWallet.js'
 export { type MetaMaskParameters, metaMask } from '../metaMask.js'
+export { type MossWalletParameters, mossWallet } from '../mossWallet.js'
 export { type PortoParameters, porto } from '../porto.js'
 export { type SafeParameters, safe } from '../safe.js'
 export { version } from '../version.js'

--- a/packages/connectors/src/mossWallet.test.ts
+++ b/packages/connectors/src/mossWallet.test.ts
@@ -1,0 +1,17 @@
+import { createConfig, http } from '@wagmi/core'
+import { megaeth } from 'viem/chains'
+import { expect, test } from 'vitest'
+
+import { mossWallet } from './mossWallet.js'
+
+test('setup', () => {
+  const config = createConfig({
+    chains: [megaeth],
+    connectors: [mossWallet()],
+    transports: { [megaeth.id]: http() },
+  })
+
+  const connector = config.connectors[0]
+  expect(connector?.name).toEqual('MOSS Wallet')
+  expect(connector?.rdns).toEqual('com.megaeth.account')
+})

--- a/packages/connectors/src/mossWallet.ts
+++ b/packages/connectors/src/mossWallet.ts
@@ -1,0 +1,1264 @@
+import type {
+  AuthenticateResponse,
+  BalancesRequest,
+  CallContractRequest,
+  GetFromContractRequest,
+  GetPermissionsResponse,
+  GrantPermissionsRequest,
+  GrantPermissionsResponse,
+  Network as MossWalletNetwork,
+  OwnedTokenResponse,
+  SendRequest,
+  SignDataRequest,
+  SignDataResponse,
+  SwapRequest,
+  TransactionResult,
+  TransferRequest,
+  Config as WalletSdkConfig,
+} from '@megaeth-labs/wallet-sdk'
+import {
+  ChainNotConfiguredError,
+  type Connector,
+  createConnector,
+  SwitchChainNotSupportedError,
+} from '@wagmi/core'
+import {
+  type Address,
+  type EIP1193EventMap,
+  type EIP1193Provider,
+  getAddress,
+  type Hex,
+  hexToString,
+  InternalRpcError,
+  InvalidParamsRpcError,
+  isAddress,
+  isHex,
+  MethodNotFoundRpcError,
+  numberToHex,
+  ProviderDisconnectedError,
+  type RpcTransactionRequest,
+  UserRejectedRequestError,
+} from 'viem'
+import { megaeth, megaethTestnet } from 'viem/chains'
+
+const mossWalletIcon =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAAAoDQEPAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoZXuEHAAANWElEQVRoBbVaaVBUVxY+3Q3ITgMGRFy6ZRNFhagkERfcZxJ0kqpsP2JApbJqXKYqmSWJbU1SlZo/QaOVpBJcZmJqamIGdSo6iZggEnFBaURFRGQxKrhgqygIdPec73bf16/bBhpNTlXz7rv33O3cc7+zPDT0K1BDZaXeGhL4tMamSddqNCN5yHTSkJ7s/HNRI2k0jTaiKj+7vdJms+03pqY2upofrKR5sG5EWLQ2NHSFzW7PtvOvp6eb2tvbqa3tBl25coVu3LBQR0cHr5nIz8+P9Ho9PfLIIzRkSCyFhYaJOp7bzL8CeojNDHgDWDjxwsluW2m32fX19fV0vNJMlWYz/XLhAt3lRfOGepVLSEgwbySGkpOSKGvKEzR2zFjS6rT8022xdXevHeipDGgDTbV1a2xkW9nZ2akvKyuj//2wl86fP9/rYn1pGDw4mubNm0vTp02nGD4h0mpNxqSktb70BY9PG2ioqTHwwEUs2vQztWdp+7fbWeJVXiUN6WtYbzAwJIuS1WZlLXGcCtq80YgRw+nF51+gzMmTeSpNIw8+05fT8D6aaoaGc7W5fDkL7ty5q9+8dSuVlJSQ1WpVcUBoWjIaDTR+/DhKGJXAej6EoqOjKSgoUPB1d/eQxWKhy5cv05kzZ6juXD1B9e7eves2job3mJk5mfLycil2SKyFQWCxMSVlhxuTx0ufG2iqq1tjtdlM5+sb6JMNG6j5QrNb98GDB9P06dNpKutyXFwcDRo0SNUOiXsfnhGIrl67RuUHD1Lxvh+phTfG6OQg7hYWHkb5S5fQtKlTIRzTyD5UyvsMPBQWzxOZzp07Rx999Hdqs9xQJvDz0/HCp9FLL71E+ogI58wP9rh9+zbt4038Z0eRQDG56eDgIMpd9DLNnTuHj5j4XqSs9TaD1w001NY+zcxFJ6qracMnG+haW5vSN47VIy83lyZOfFSojtLwkIVfLl6kgoJ1dL6hQRkpMDCQ/rhqJc81ESiVNzIxcavS6CzctwFxYXW6yuamC/q/ffABXW+77mS1U3r6BHpr2XKB6Z4D/RrvfM+ocFMhlewvVYYLCQ6m5W8tx+W28OXL8LzY92+gtrahq6vL8PY7f1bpvJ2mTZtGy998UxogOn78OLXdcKqVczo/nY6yWG/92XB5I9yKYxUVZLl5060ZIJA1ZYq4Qz09PfTN9m9p165ddK+rS/AF8t368MMPyGAwmEelpGSoO7vN1FRbyzhPhm8YJtUXNikxgZYszlMWjwGKduykU6dPq8cS7caEUTRy+Ai3evnS3d1FBevXEyStptDQUIFggQGDxBgvvvC8QK29xcWCrfPePdr6j3/SX955J72+rtaUkJRikv21sgDV4cWbGhsb6fvvf5DVDIdRtGrVaooI7/+yQnoHfz7ImK9gijIOCpVssQGdwk6wPXA9uRHH4yTU5768iNLGjpFVdOLECdpfdoB0ds2KSngDTlI2wDfSBHz/atvXjAZ3RHOAvz/l5y+lIbGxkr/fZ3n5ISea3M+KNoky6lZvrkcw6/4br79OcD0k7WS1utPerg8NDlwp68QGIH2+DLknqk/SMdZtScD4zEmT5atPz4uXLlHt2bP38cLRq2Ej5o16s84wiAtzFoiTQr/Lly7T93uLyY+0K4RPxnXyBLLZq6Ti4r0KMyQwf/485d3bxLIOEmQ3WryifOjQYdmkPOvZZ7p+XSKaw0NVGvsowA5ER0UJDox9gH0wm92mt4UGi1MQG9BotSvaGOtxApLGj4NbMEq+9vtMSk5WeMxVZmq/0668o3DkyBHFBQG+GwwGpZ3X1SvBDc/JeUppb2pqYgeygbR2+wxUasXlZSetglXnzh2H7qPhyd//Dg+fCMLPynpCOQWL5SYdP1ap9MXFrWD4lKqSlTWFAgcFKO3Ow1PePQtz58wh2AMQu/C0r3gfLn22iEms/rpsDAAnSxKcsJSUFPnq03PSxEkUGhYmeHHURyuOKv0c6uOw5jr2UB9/7DE16Ch8vRWCgoJc6+G1VlVVERxEa0jI01pNjy29m6Ops+wmSxqbNpb8GYEGQnp9BI1WbRqGTp6omYMd3DGQ0WigJA5m1GjUlwoxo6C0cWmySJZbt6ilpYV0HLqyEdROQPgHp0pSavLApC/7wVpL6ui8R9Unq+kGO4HlhwCfDsJJhYeFylfx7E+FwJSSnKT4XhxQ0SVGO7vNZvDjwMFw6+YtQqWkuLihsjig5zg+uUi+dDfY9wcBMXp6rBwHtAj9xx2YwdD8IBQdPZjjiyDlVC/xmBA+UMgAjJZBCiYJZ3/8QSg8PJzSM9KVrqeqT9NevnDy8gLVYoVRZEVWkS8qhEscEOC6+Fgz3zW9gNF77GtIJNOxQxbAztODEi6oDGxutd+mUydd0IwYwkFyNsebLyqExcNZlOTUGMcGgBqSIC13+cgW354ZGRk0fNgwhVle3kG8gPR0N0dS4fG5oNopVoxXnIBFfTRQJXanfR7TkxFSmsIhpiclJibS0Lghzmp3EQn5uVd5dmfY7Ob71KPUBzPUQzhiA9Bd6cPDk7zp4a8rvXwsTJo0ieAIqgnBOvx+B7lOHO8qwTrb739A57tY1SWFC5ujaeSMEplhrgNUlhEO2cMQws4MvsyRkZEUxX4M8j2TOCzsk9z3dB8rgifEBSCofAyDgcZub/SzWe1NERyYh4WFK4EGLOfDEIBg+bJlYgjcKZxqSEiIakh3fVFdQRWPe7G5uUlBSoBEbAy7+FptldautZthdRM56pJ0kp06tb7Jes8nJ6DYxCfRn95+m5HHkQOSPPBm8QN2uy/ewbGag/WFCxawxUdQ2I/4mQOJNEHMCvWJjY0hKyeJ/XT+gTv41m5OSUmmsrKfBU87O3Vn2acfM8YVETl6u/4iUnv91dcoO3sGQeIDJRg8RF2A1t3f7emzO2C+mjMkkiZwAg1pFySFtUaj0cK3qORRhjiJ32BEZqC30BDtUJHZs2cpiwd6XeTUCEx8j9WFFuCVdIt9mAucAMaCQFCvUUYjLVv2BiFJZnfXLNmNSktLORTtcLwzz/z589HbjAyFI6i3W/ezhcwel5ZGFccq0CjcgAU5OTR8uAvTlRG5oJY6Bxi0YeNGOnT4sKifN3cuvbxokZqdysvL6YvCQrGQkZwHfffdv4o0uxuTlxdkMIp27lJaYGNY6IDPAlQ6cC0gsIAhzjJjhrSUJKS0e89upWNfhdbWK1R64AD36RIL3Pfjj5xycSXDgBqIZxEnwMYgN3r0KATVPx1mR7C1tVVhnD17thASa8d+VIoN8I7gfa3LzMyk1NGpCnNpaRnHCbXKe28FqI/69DmfypjtbgytHmolIbG3MVGPDyX/+vc3AjbxHhMTQ1M5GOIdbJEJLmlZiD2lAn8/f0v+0qVOZCDq6Oygjws+ppbWFvTvleKHDqXsmTMdpp2N1TyOoIDTkqDrCxf+QUGcYcPixfcA2e7tiaTWF18Wuowqo08Oq3RUVDQF6nRrZR+14KihtsZkt2vWfPX1Nioq2il5RH7m/ffec0tsKY3OAoDw6tWrwqLDMGLRnoSYA6qFTHaAv8uz9OQDeHy1bRvtkLrPg+OLjsn0PjzStQmpqSbZx3UCXGNMSTVxgG9GKiMulv0WrIrpdE0NffrZZ32iEpYLiwvr623xGCeM8XvkiJH9Lh6JtV27/osugmArFi/Oo6DAwEb14tHotgHBbbU+w5bZsnr1KoqICBebwNeVn0pKaOOnnxKg8LcigMDmLVuosHCTEoIi+F+5cgUbzGQLR2AzPee+/5yZgzMVeWymNx8+fITWrVtPnV0uJyqBISw/Px8Deo71UO+wH4WbNrksLo8GD+G1V1+hWdnZUIZnvH2t8boBrKS+psbEqrAGOcn1n2zkz6aciXZyw+At4FwNXAEkZh+G4CYfYAhGSlOdtcZUS5YspqeefBKq66b36vl63QCY+CRMfBJrqqtP0eeff06XWuClyi7sEbLOI+k08dGJAuLUxk1Mgjsk2eWF4grYBagickXf7d5Dzc3NisqALYIzHC88/xzNmTULHzZ6XTzmUIYXE3r5I77WaDSbr7S26r8s/JK/C7hSJJIdTlsSByxpbMlHj04huNPh7OH6Of3/HkYVJLfwLQwf986crePcjpk3cVsOIZ5YTGJCIr3ySj4lJCbCNq0yJidvEY29/Ol3A+iH7B2fxE8sOUNFxTH+ALFdfAoC3PVG+DoPTxSE7wK4oJC8N0J9VFQkPffsszR75izyD/BnKdmekcbKWx9Z59MGJLNUKXwyLWFU+m7PHk7YulwGyTeQZ2hoCKclsyiHdT0+Pt7CC1/HCzf5OsaANoBBnaeBCXLhQuBfDI6wX1PH7jeyZfcYsSBoT1sAKcO24Z5E6iMpNTWVHns8k9LHT0DcIBbOyakCY0YGVMdnGvAG5MhiI0TZrForuC4daHLt+jXxMfvq1WsilS6TAzqdHxs4vbjo8fFD2b5EcLI2hNholhB7wnR34AuX63jgDcgB8MRmrLwZlno6W8YJXGVgcRv46SCNBhJG3GHmTEITn4ZZ19m5Y6DSlsOpn/8HoJdadFJ3DXkAAAAASUVORK5CYII='
+
+export type MossWalletParameters = Omit<WalletSdkConfig, 'network'> & {
+  network?: MossWalletNetwork
+}
+
+type SingleOrArray<T> = T | readonly [T]
+type OptionalSingleOrArray<T> = T | readonly [T?] | undefined
+type CallContractRequestBatch = readonly CallContractRequest[]
+type CallContractRequestParameter =
+  | CallContractRequest
+  | CallContractRequestBatch
+  | readonly [CallContractRequest | CallContractRequestBatch]
+
+type MossWalletRpcTransactionRequest = {
+  chainId?: Hex | number | undefined
+  data?: Hex | undefined
+  from?: Address | undefined
+  gas?: Hex | undefined
+  gasPrice?: Hex | undefined
+  maxFeePerGas?: Hex | undefined
+  maxPriorityFeePerGas?: Hex | undefined
+  nonce?: Hex | undefined
+  to?: Address | undefined
+  value?: Hex | undefined
+}
+
+type MossWalletSendTransactionParameters = readonly [
+  request: MossWalletRpcTransactionRequest,
+]
+
+type MossWalletPersonalSignParameters =
+  | readonly [message: string, address: Address]
+  | readonly [address: Address, message: string]
+
+type MossWalletTypedDataParameters = readonly [
+  address: Address,
+  typedData: string | SignDataRequest['data'],
+]
+
+type MossWalletManageAccountRequest = {
+  method: string
+  data?: unknown
+}
+
+interface MossWalletRequestMap {
+  eth_accounts: {
+    params: undefined
+    returnType: readonly Address[]
+  }
+  eth_chainId: {
+    params: undefined
+    returnType: Hex
+  }
+  eth_requestAccounts: {
+    params: undefined
+    returnType: readonly Address[]
+  }
+  eth_sendTransaction: {
+    params: MossWalletSendTransactionParameters
+    returnType: Hex
+  }
+  eth_signTypedData_v4: {
+    params: MossWalletTypedDataParameters
+    returnType: Hex
+  }
+  personal_sign: {
+    params: MossWalletPersonalSignParameters
+    returnType: Hex
+  }
+  wallet_balances: {
+    params: OptionalSingleOrArray<BalancesRequest>
+    returnType: OwnedTokenResponse[]
+  }
+  wallet_callContract: {
+    params: CallContractRequestParameter
+    returnType: TransactionResult
+  }
+  wallet_deposit: {
+    params: undefined
+    returnType: undefined
+  }
+  wallet_getFromContract: {
+    params: SingleOrArray<GetFromContractRequest>
+    returnType: unknown
+  }
+  wallet_getPermissions: {
+    params: string | readonly [address?: string] | undefined
+    returnType: GetPermissionsResponse | undefined
+  }
+  wallet_grantPermissions: {
+    params: SingleOrArray<GrantPermissionsRequest>
+    returnType: GrantPermissionsResponse
+  }
+  wallet_authenticate: {
+    params: undefined
+    returnType: AuthenticateResponse
+  }
+  wallet_manageAccount: {
+    params: SingleOrArray<MossWalletManageAccountRequest>
+    returnType: undefined
+  }
+  wallet_open: {
+    params: undefined
+    returnType: undefined
+  }
+  wallet_revokePermissions: {
+    params: undefined
+    returnType: undefined
+  }
+  wallet_signData: {
+    params: SingleOrArray<SignDataRequest>
+    returnType: SignDataResponse
+  }
+  wallet_send: {
+    params: SingleOrArray<SendRequest>
+    returnType: TransactionResult
+  }
+  wallet_swap: {
+    params: SingleOrArray<SwapRequest>
+    returnType: TransactionResult
+  }
+  wallet_transfer: {
+    params: SingleOrArray<TransferRequest>
+    returnType: TransactionResult
+  }
+}
+
+type MossWalletRequestMethod = keyof MossWalletRequestMap
+
+type MossWalletRequestParameters<
+  method extends MossWalletRequestMethod = MossWalletRequestMethod,
+> = MossWalletRequestMap[method]['params'] extends undefined
+  ? {
+      method: method
+      params?: undefined
+    }
+  : {
+      method: method
+      params: MossWalletRequestMap[method]['params']
+    }
+
+type MossWalletRequest = {
+  [method in MossWalletRequestMethod]: MossWalletRequestParameters<method>
+}[MossWalletRequestMethod]
+
+type MossWalletRequestReturnType<
+  method extends MossWalletRequestMethod = MossWalletRequestMethod,
+> = MossWalletRequestMap[method]['returnType']
+
+type Provider = Omit<EIP1193Provider, 'request'> & {
+  request<method extends MossWalletRequestMethod>(
+    parameters: MossWalletRequestParameters<method>,
+  ): Promise<MossWalletRequestReturnType<method>>
+
+  disconnect(): Promise<void>
+}
+
+// Mirrors the shape of the `mega` singleton exported by `@megaeth-labs/wallet-sdk`.
+// Imported lazily (see `loadMossWalletSdk` below) so the SDK stays an optional
+// peer dependency, like `porto`/`@coinbase/wallet-sdk` elsewhere in this package.
+type MossWalletSdk = {
+  events: { onStatusChange(listener: (status?: any) => void): void }
+  initialise(parameters: WalletSdkConfig): Promise<any>
+  status(): Promise<any>
+  connect(): Promise<any>
+  disconnect(): Promise<any>
+  callContract(request: unknown): Promise<TransactionResult>
+  signData(request: unknown): Promise<SignDataResponse>
+  signMessage(message: string): Promise<SignDataResponse>
+  balances(request: BalancesRequest): Promise<OwnedTokenResponse[]>
+  deposit(): Promise<void>
+  getFromContract(request: GetFromContractRequest): Promise<unknown>
+  getPermissions(address?: string): Promise<GetPermissionsResponse | undefined>
+  grantPermissions(
+    request: GrantPermissionsRequest,
+  ): Promise<GrantPermissionsResponse>
+  authenticate(): Promise<AuthenticateResponse>
+  manageAccount(request: MossWalletManageAccountRequest): Promise<void>
+  open(): Promise<void>
+  revokePermissions(): Promise<void>
+  send(request: SendRequest): Promise<TransactionResult>
+  swap(request: SwapRequest): Promise<TransactionResult>
+  transfer(request: TransferRequest): Promise<TransactionResult>
+}
+
+async function loadMossWalletSdk(): Promise<{ mega: MossWalletSdk }> {
+  return await (() => {
+    // safe webpack optional peer dependency dynamic import
+    try {
+      return import(
+        /* turbopackOptional: true */
+        '@megaeth-labs/wallet-sdk'
+      )
+    } catch {
+      throw new Error('dependency "@megaeth-labs/wallet-sdk" not found')
+    }
+  })()
+}
+
+const chainByNetwork = {
+  mainnet: megaeth,
+  testnet: megaethTestnet,
+}
+
+function getMossWalletChain(network: MossWalletNetwork = 'mainnet') {
+  return chainByNetwork[network]
+}
+
+function createDisconnectedError(message = 'MOSS Wallet is not connected.') {
+  return new ProviderDisconnectedError(new Error(message))
+}
+
+function createInternalError(message: string, cause?: unknown) {
+  if (cause instanceof Error && 'code' in cause) return cause
+  return new InternalRpcError(
+    cause instanceof Error ? cause : new Error(message),
+  )
+}
+
+function createInvalidParamsError(message: string) {
+  return new InvalidParamsRpcError(new Error(message))
+}
+
+function createMethodNotFoundError(method: string) {
+  return new MethodNotFoundRpcError(
+    new Error(`Unsupported method "${method}".`),
+    { method },
+  )
+}
+
+function createUserRejectedError(message: string) {
+  return new UserRejectedRequestError(new Error(message))
+}
+
+function normalizeProviderRequestError(
+  error: unknown,
+  fallbackMessage = 'MOSS Wallet request failed.',
+) {
+  if (error instanceof Error && 'code' in error) return error
+  return new InternalRpcError(
+    error instanceof Error ? error : new Error(fallbackMessage),
+  )
+}
+
+const unsupportedTransactionFields = [
+  'accessList',
+  'authorizationList',
+  'blobs',
+  'gas',
+  'gasPrice',
+  'maxFeePerBlobGas',
+  'maxFeePerGas',
+  'maxPriorityFeePerGas',
+  'nonce',
+  'type',
+] as const
+
+function normalizeAddressParam(
+  method: string,
+  field: string,
+  value: string,
+): Address {
+  try {
+    return getAddress(value as Address)
+  } catch {
+    throw createInvalidParamsError(
+      `"${method}" "${field}" must be a valid address.`,
+    )
+  }
+}
+
+function normalizeBigIntParam(
+  method: string,
+  field: string,
+  value: unknown,
+): bigint {
+  try {
+    return BigInt(value as string | number | bigint)
+  } catch {
+    throw createInvalidParamsError(
+      `"${method}" "${field}" must be a valid bigint-compatible value.`,
+    )
+  }
+}
+
+function getRequiredObjectParam<T>(
+  method: string,
+  params: T | readonly [T],
+): T {
+  if (Array.isArray(params)) {
+    if (params.length === 0 || params[0] === undefined) {
+      throw createInvalidParamsError(`"${method}" requires a request object.`)
+    }
+    return params[0] as T
+  }
+  if (!params || typeof params !== 'object') {
+    throw createInvalidParamsError(`"${method}" requires a request object.`)
+  }
+  return params as T
+}
+
+function getRequiredCallContractParam(
+  method: string,
+  params: CallContractRequestParameter,
+): CallContractRequest | CallContractRequest[] {
+  if (Array.isArray(params)) {
+    if (params.length === 0) {
+      throw createInvalidParamsError(`"${method}" requires a request object.`)
+    }
+    if (params.length === 1) {
+      const value = params[0]
+      if (!value || typeof value !== 'object') {
+        throw createInvalidParamsError(`"${method}" requires a request object.`)
+      }
+      return Array.isArray(value) ? [...value] : value
+    }
+    return [...params] as CallContractRequest[]
+  }
+  if (!params || typeof params !== 'object') {
+    throw createInvalidParamsError(`"${method}" requires a request object.`)
+  }
+  return params as CallContractRequest
+}
+
+function getOptionalObjectParam<T>(
+  method: string,
+  params: T | readonly [T?] | undefined,
+): T | undefined {
+  if (params === undefined) return undefined
+  if (Array.isArray(params)) {
+    if (params.length > 1) {
+      throw createInvalidParamsError(
+        `"${method}" accepts at most one request object.`,
+      )
+    }
+    return params[0] as T | undefined
+  }
+  if (typeof params !== 'object') {
+    throw createInvalidParamsError(`"${method}" requires a request object.`)
+  }
+  return params as T
+}
+
+function getOptionalStringParam(
+  method: string,
+  params: string | readonly [string?] | undefined,
+) {
+  if (params === undefined) return undefined
+  if (Array.isArray(params)) {
+    if (params.length > 1) {
+      throw createInvalidParamsError(
+        `"${method}" accepts at most one address parameter.`,
+      )
+    }
+    const value = params[0]
+    if (value === undefined) return undefined
+    if (typeof value !== 'string') {
+      throw createInvalidParamsError(`"${method}" expects an address string.`)
+    }
+    return value
+  }
+  if (typeof params !== 'string') {
+    throw createInvalidParamsError(`"${method}" expects an address string.`)
+  }
+  return params
+}
+
+function unwrapGrantPermissions(result: { status: 'approved' | 'cancelled' }) {
+  if (result.status === 'cancelled') {
+    throw createUserRejectedError('User rejected the permissions request.')
+  }
+  return result
+}
+
+function unwrapAuthenticateResult(result: AuthenticateResponse) {
+  if (result.status === 'cancelled') {
+    throw createUserRejectedError('User rejected the authentication request.')
+  }
+  if (result.status === 'error' || !result.jwt) {
+    throw createInternalError(
+      result.error ?? 'MOSS Wallet authentication failed.',
+    )
+  }
+  return result
+}
+
+function unwrapSignResult(
+  result: {
+    error?: string
+    signature?: string
+    status: 'cancelled' | 'error' | 'success'
+  },
+  cancelledMessage: string,
+  fallbackMessage: string,
+) {
+  if (result.status === 'cancelled') {
+    throw createUserRejectedError(cancelledMessage)
+  }
+  if (result.status === 'error' || !result.signature) {
+    throw createInternalError(result.error ?? fallbackMessage)
+  }
+  return result.signature as Hex
+}
+
+function unwrapTransactionResult(
+  result: TransactionResult,
+  cancelledMessage: string,
+) {
+  if (result.status === 'cancelled') {
+    throw createUserRejectedError(cancelledMessage)
+  }
+  if (result.status !== 'approved') {
+    throw createInternalError(result.error ?? 'MOSS Wallet transaction failed.')
+  }
+  return result
+}
+
+function normalizePersonalSignParameters(
+  account: Address,
+  params: readonly [string, string] | readonly [string, Address],
+) {
+  const [first, second] = params
+  if (typeof first !== 'string' || typeof second !== 'string') {
+    throw createInvalidParamsError(
+      '"personal_sign" requires a message and account.',
+    )
+  }
+
+  let message = first
+  let address = second
+
+  if (isAddress(first) && !isAddress(second)) {
+    address = first
+    message = second
+  }
+
+  const normalizedAddress = normalizeAddressParam(
+    'personal_sign',
+    'account',
+    address,
+  )
+
+  if (normalizedAddress !== account) {
+    throw createInvalidParamsError(
+      '"personal_sign" account does not match the connected account.',
+    )
+  }
+
+  if (isHex(message)) {
+    try {
+      message = hexToString(message)
+    } catch {
+      throw createInvalidParamsError(
+        '"personal_sign" only supports hex payloads that can be decoded to UTF-8 text.',
+      )
+    }
+  }
+
+  return { address: normalizedAddress, message }
+}
+
+function normalizeTypedDataParameters(
+  account: Address,
+  params: MossWalletTypedDataParameters,
+) {
+  const [address, typedData] = params
+  const normalizedAddress = normalizeAddressParam(
+    'eth_signTypedData_v4',
+    'account',
+    address,
+  )
+
+  if (normalizedAddress !== account) {
+    throw createInvalidParamsError(
+      '"eth_signTypedData_v4" account does not match the connected account.',
+    )
+  }
+
+  if (typeof typedData === 'string') {
+    try {
+      return JSON.parse(typedData)
+    } catch {
+      throw createInvalidParamsError(
+        '"eth_signTypedData_v4" expects a valid JSON string or typed data object.',
+      )
+    }
+  }
+
+  return typedData
+}
+
+function normalizeSendTransactionRequest(
+  account: Address,
+  chainId: number,
+  params: MossWalletSendTransactionParameters,
+) {
+  const [request] = params
+
+  if (!request || typeof request !== 'object') {
+    throw createInvalidParamsError(
+      '"eth_sendTransaction" requires a transaction object.',
+    )
+  }
+
+  const transaction = request as MossWalletRpcTransactionRequest &
+    Record<string, RpcTransactionRequest[keyof RpcTransactionRequest]>
+
+  for (const field of unsupportedTransactionFields) {
+    if (transaction[field] !== undefined) {
+      throw createInvalidParamsError(
+        `"eth_sendTransaction" does not support the "${field}" field for MOSS Wallet.`,
+      )
+    }
+  }
+
+  if (!transaction.to) {
+    throw createInvalidParamsError(
+      '"eth_sendTransaction" requires a "to" address.',
+    )
+  }
+
+  if (transaction.from) {
+    const normalizedFrom = normalizeAddressParam(
+      'eth_sendTransaction',
+      'from',
+      transaction.from,
+    )
+    if (normalizedFrom !== account) {
+      throw createInvalidParamsError(
+        '"eth_sendTransaction" "from" must match the connected MOSS Wallet account.',
+      )
+    }
+  }
+
+  if (transaction.chainId !== undefined) {
+    const transactionChainId = Number(transaction.chainId)
+    if (
+      !Number.isFinite(transactionChainId) ||
+      transactionChainId !== chainId
+    ) {
+      throw createInvalidParamsError(
+        '"eth_sendTransaction" chainId must match the configured MOSS Wallet network.',
+      )
+    }
+  }
+
+  if (transaction.data !== undefined && !isHex(transaction.data)) {
+    throw createInvalidParamsError(
+      '"eth_sendTransaction" "data" must be a hex string.',
+    )
+  }
+
+  const normalizedTo = normalizeAddressParam(
+    'eth_sendTransaction',
+    'to',
+    transaction.to,
+  )
+  const normalizedValue =
+    transaction.value === undefined
+      ? 0n
+      : normalizeBigIntParam('eth_sendTransaction', 'value', transaction.value)
+
+  return {
+    data: transaction.data,
+    address: normalizedTo,
+    value: normalizedValue,
+  }
+}
+
+type ListenerMap = {
+  [event in keyof EIP1193EventMap]: Set<EIP1193EventMap[event]>
+}
+
+function createListenerMap(): ListenerMap {
+  return {
+    accountsChanged: new Set(),
+    chainChanged: new Set(),
+    connect: new Set(),
+    disconnect: new Set(),
+    message: new Set(),
+  }
+}
+
+class MossWalletProviderImplementation implements Provider {
+  readonly #listeners = createListenerMap()
+  readonly #mega: MossWalletSdk
+  #account: Address | undefined
+  #initializationPromise: Promise<void> | undefined
+  #initialized = false
+  #isConnected = false
+
+  readonly chain
+  readonly chainId
+  readonly chainIdHex
+
+  constructor(
+    mega: MossWalletSdk,
+    readonly parameters: WalletSdkConfig,
+  ) {
+    this.#mega = mega
+    this.chain = getMossWalletChain(parameters.network as MossWalletNetwork)
+    this.chainId = this.chain.id
+    this.chainIdHex = numberToHex(this.chainId)
+
+    mega.events.onStatusChange((status) => {
+      this.applyStatus(status)
+    })
+  }
+
+  get account() {
+    return this.#account
+  }
+
+  async disconnect() {
+    await this.ensureInitialized()
+    const status = await this.#mega.disconnect()
+    this.applyStatus(status)
+  }
+
+  async ensureInitialized() {
+    if (this.#initialized) return
+
+    this.#initializationPromise ??= (async () => {
+      const initialStatus =
+        (await this.#mega.initialise(this.parameters)) ??
+        (await this.#mega.status())
+      this.applyStatus(initialStatus)
+      this.#initialized = true
+    })().finally(() => {
+      this.#initializationPromise = undefined
+    })
+
+    await this.#initializationPromise
+  }
+
+  on<event extends keyof ListenerMap>(
+    event: event,
+    listener: EIP1193EventMap[event],
+  ) {
+    this.#listeners[event].add(listener)
+  }
+
+  applyStatus(status?: { status?: string; address?: string }) {
+    const nextAccount =
+      status?.status === 'connected' && status.address
+        ? getAddress(status.address)
+        : undefined
+    const previousAccount = this.#account
+    const wasConnected = this.#isConnected
+
+    this.#account = nextAccount
+    this.#isConnected = Boolean(nextAccount)
+
+    const previousAccounts = previousAccount ? [previousAccount] : []
+    const nextAccounts = nextAccount ? [nextAccount] : []
+
+    const accountsChanged =
+      previousAccounts.length !== nextAccounts.length ||
+      previousAccounts.some((account, index) => account !== nextAccounts[index])
+
+    if (accountsChanged) {
+      this.emit('accountsChanged', nextAccounts)
+    }
+
+    if (!wasConnected && this.#isConnected) {
+      this.emit('connect', { chainId: this.chainIdHex })
+    }
+
+    if (wasConnected && !this.#isConnected) {
+      this.emit(
+        'disconnect',
+        new ProviderDisconnectedError(new Error('MOSS Wallet disconnected.')),
+      )
+    }
+  }
+
+  removeListener<event extends keyof ListenerMap>(
+    event: event,
+    listener: EIP1193EventMap[event],
+  ) {
+    this.#listeners[event].delete(listener)
+  }
+
+  async request<method extends MossWalletRequestMethod>(
+    parameters: MossWalletRequestParameters<method>,
+  ): Promise<MossWalletRequestReturnType<method>> {
+    try {
+      return (await this.#handleRequest(
+        parameters as MossWalletRequest,
+      )) as MossWalletRequestReturnType<method>
+    } catch (error) {
+      throw normalizeProviderRequestError(error)
+    }
+  }
+
+  async #handleRequest(request: MossWalletRequest) {
+    await this.ensureInitialized()
+    const mega = this.#mega
+
+    switch (request.method) {
+      case 'eth_accounts': {
+        const account = this.account
+        return account ? [account] : []
+      }
+
+      case 'eth_chainId':
+        return this.chainIdHex
+
+      case 'eth_requestAccounts': {
+        const status = await mega.connect()
+        this.applyStatus(status)
+
+        if (status.status === 'cancelled') {
+          throw createUserRejectedError('User rejected the connection request.')
+        }
+        if (status.status !== 'connected' || !status.address) {
+          throw createInternalError(
+            'MOSS Wallet did not return a connected account.',
+          )
+        }
+        return [getAddress(status.address)]
+      }
+
+      case 'eth_sendTransaction': {
+        const account = this.#expectConnectedAccount()
+        const normalizedRequest = normalizeSendTransactionRequest(
+          account,
+          this.chainId,
+          request.params,
+        )
+        const result = await mega.callContract(normalizedRequest)
+        const approvedResult = unwrapTransactionResult(
+          result,
+          'User rejected the transaction request.',
+        )
+        if (!approvedResult.receipt?.hash) {
+          throw createInternalError(
+            'MOSS Wallet approved the transaction without a receipt hash.',
+          )
+        }
+        return approvedResult.receipt.hash
+      }
+
+      case 'eth_signTypedData_v4': {
+        const account = this.#expectConnectedAccount()
+        const typedData = normalizeTypedDataParameters(account, request.params)
+        return unwrapSignResult(
+          await mega.signData({ data: typedData }),
+          'User rejected the typed data signature request.',
+          'MOSS Wallet did not return a typed data signature.',
+        )
+      }
+
+      case 'personal_sign': {
+        const account = this.#expectConnectedAccount()
+        const { message } = normalizePersonalSignParameters(
+          account,
+          request.params,
+        )
+        return unwrapSignResult(
+          await mega.signMessage(message),
+          'User rejected the message signature request.',
+          'MOSS Wallet did not return a message signature.',
+        )
+      }
+
+      case 'wallet_balances': {
+        const balancesRequest =
+          getOptionalObjectParam<BalancesRequest>(
+            request.method,
+            request.params,
+          ) ?? {}
+        return await mega.balances(balancesRequest)
+      }
+
+      case 'wallet_callContract': {
+        const callContractRequest = getRequiredCallContractParam(
+          request.method,
+          request.params,
+        )
+        const result = await mega.callContract(callContractRequest)
+        return unwrapTransactionResult(
+          result,
+          'User rejected the contract call request.',
+        )
+      }
+
+      case 'wallet_deposit':
+        await mega.deposit()
+        return
+
+      case 'wallet_getFromContract': {
+        const getFromContractRequest =
+          getRequiredObjectParam<GetFromContractRequest>(
+            request.method,
+            request.params,
+          )
+        return await mega.getFromContract(getFromContractRequest)
+      }
+
+      case 'wallet_getPermissions': {
+        const address = getOptionalStringParam(request.method, request.params)
+        return await mega.getPermissions(address)
+      }
+
+      case 'wallet_grantPermissions': {
+        const grantPermissionsRequest =
+          getRequiredObjectParam<GrantPermissionsRequest>(
+            request.method,
+            request.params,
+          )
+        const result = await mega.grantPermissions(grantPermissionsRequest)
+        return unwrapGrantPermissions(result)
+      }
+
+      case 'wallet_authenticate': {
+        const result = await mega.authenticate()
+        return unwrapAuthenticateResult(result)
+      }
+
+      case 'wallet_manageAccount': {
+        const manageAccountRequest =
+          getRequiredObjectParam<MossWalletManageAccountRequest>(
+            request.method,
+            request.params,
+          )
+        await mega.manageAccount(manageAccountRequest)
+        return
+      }
+
+      case 'wallet_open':
+        await mega.open()
+        return
+
+      case 'wallet_revokePermissions':
+        await mega.revokePermissions()
+        return
+
+      case 'wallet_signData': {
+        const signDataRequest = getRequiredObjectParam<SignDataRequest>(
+          request.method,
+          request.params,
+        )
+        const result = await mega.signData(signDataRequest)
+        unwrapSignResult(
+          result,
+          'User rejected the typed data signature request.',
+          'MOSS Wallet did not return a typed data signature.',
+        )
+        return result
+      }
+
+      case 'wallet_send': {
+        const sendRequest = getRequiredObjectParam<SendRequest>(
+          request.method,
+          request.params,
+        )
+        const result = await mega.send(sendRequest)
+        return unwrapTransactionResult(
+          result,
+          'User rejected the send request.',
+        )
+      }
+
+      case 'wallet_swap': {
+        const swapRequest = getRequiredObjectParam<SwapRequest>(
+          request.method,
+          request.params,
+        )
+        const result = await mega.swap(swapRequest)
+        return unwrapTransactionResult(
+          result,
+          'User rejected the swap request.',
+        )
+      }
+
+      case 'wallet_transfer': {
+        const transferRequest = getRequiredObjectParam<TransferRequest>(
+          request.method,
+          request.params,
+        )
+        const result = await mega.transfer(transferRequest)
+        return unwrapTransactionResult(
+          result,
+          'User rejected the transfer request.',
+        )
+      }
+    }
+
+    throw createMethodNotFoundError((request as { method: string }).method)
+  }
+
+  #expectConnectedAccount() {
+    const account = this.account
+    if (!account) throw createDisconnectedError()
+    return account
+  }
+
+  private emit<event extends keyof ListenerMap>(
+    event: event,
+    payload: ListenerMap[event] extends Set<(value: infer item) => void>
+      ? item
+      : never,
+  ) {
+    for (const listener of [...this.#listeners[event]]) {
+      listener(payload as never)
+    }
+  }
+}
+
+let activeProvider: MossWalletProviderImplementation | undefined
+let activeProviderKey: string | undefined
+
+function serializeParameters(parameters: WalletSdkConfig) {
+  return JSON.stringify({
+    debug: parameters.debug ?? false,
+    devMode: parameters.devMode ?? false,
+    logging: parameters.logging ?? null,
+    network: parameters.network,
+    sponsorMode: parameters.sponsorMode ?? null,
+    sponsorToken: parameters.sponsorToken ?? null,
+    sponsorUrl: parameters.sponsorUrl ?? null,
+  })
+}
+
+mossWallet.type = 'injected' as const
+
+/**
+ * Connector for [MOSS Wallet](https://moss.megaeth.com), MegaETH's embedded
+ * SDK wallet. Wraps `@megaeth-labs/wallet-sdk` (an optional peer dependency,
+ * loaded lazily — only resolved if a dapp actually configures this
+ * connector).
+ *
+ * The SDK initializes a single embedded session per page load, so only one
+ * `mossWallet(...)` configuration is supported per `Config`.
+ */
+type Properties = {
+  balances(request?: BalancesRequest): Promise<OwnedTokenResponse[]>
+  callContract(
+    request: CallContractRequest | CallContractRequestBatch,
+  ): Promise<TransactionResult>
+  deposit(): Promise<undefined>
+  getFromContract(request: GetFromContractRequest): Promise<unknown>
+  getPermissions(address?: string): Promise<GetPermissionsResponse | undefined>
+  grantPermissions(
+    request: GrantPermissionsRequest,
+  ): Promise<GrantPermissionsResponse>
+  authenticate(): Promise<AuthenticateResponse>
+  manageAccount(request: MossWalletManageAccountRequest): Promise<undefined>
+  open(): Promise<undefined>
+  revokePermissions(): Promise<undefined>
+  send(request: SendRequest): Promise<TransactionResult>
+  signData(request: SignDataRequest): Promise<SignDataResponse>
+  swap(request: SwapRequest): Promise<TransactionResult>
+  transfer(request: TransferRequest): Promise<TransactionResult>
+}
+
+export function mossWallet(parameters: MossWalletParameters = {}) {
+  const normalizedParameters: WalletSdkConfig = {
+    ...parameters,
+    network: parameters.network ?? 'mainnet',
+  } as WalletSdkConfig
+  const chain = getMossWalletChain(
+    normalizedParameters.network as MossWalletNetwork,
+  )
+
+  let providerPromise: Promise<MossWalletProviderImplementation> | undefined
+
+  const getProvider = () => {
+    providerPromise ??= (async () => {
+      const providerKey = serializeParameters(normalizedParameters)
+
+      if (activeProvider) {
+        if (activeProviderKey !== providerKey) {
+          throw new Error(
+            'MOSS Wallet SDK can only be initialized once per page load. Use a single connector configuration.',
+          )
+        }
+        return activeProvider
+      }
+
+      const { mega } = await loadMossWalletSdk()
+      activeProvider = new MossWalletProviderImplementation(
+        mega,
+        normalizedParameters,
+      )
+      activeProviderKey = providerKey
+
+      return activeProvider
+    })()
+
+    return providerPromise
+  }
+
+  let accountsChanged: Connector['onAccountsChanged'] | undefined
+  let connect: Connector['onConnect'] | undefined
+  let disconnect: Connector['onDisconnect'] | undefined
+
+  return createConnector<Provider, Properties>((config) => ({
+    id: 'mossWallet',
+    name: 'MOSS Wallet',
+    type: mossWallet.type,
+    rdns: 'com.megaeth.account',
+    icon: mossWalletIcon,
+
+    async setup() {
+      if (!config.chains.some((item) => item.id === chain.id)) {
+        throw new ChainNotConfiguredError()
+      }
+
+      const provider = await this.getProvider()
+
+      if (!accountsChanged) {
+        accountsChanged = this.onAccountsChanged.bind(this)
+        provider.on('accountsChanged', accountsChanged)
+      }
+      if (!connect) {
+        const onConnect = this.onConnect?.bind(this)
+        if (!onConnect) return
+        connect = onConnect
+        provider.on('connect', onConnect)
+      }
+      if (!disconnect) {
+        disconnect = this.onDisconnect.bind(this)
+        provider.on('disconnect', disconnect)
+      }
+    },
+
+    async connect<withCapabilities extends boolean = false>({
+      chainId,
+      withCapabilities,
+    }: {
+      chainId?: number | undefined
+      isReconnecting?: boolean | undefined
+      withCapabilities?: withCapabilities | boolean | undefined
+    } = {}) {
+      const configuredChain = config.chains.find((item) => item.id === chain.id)
+      if (!configuredChain) throw new ChainNotConfiguredError()
+
+      const provider = await this.getProvider()
+
+      if (chainId && chainId !== configuredChain.id) {
+        await this.switchChain?.({ chainId })
+      }
+
+      const accounts = await provider.request({ method: 'eth_requestAccounts' })
+
+      return {
+        accounts: (withCapabilities
+          ? accounts.map((address) => ({
+              address: getAddress(address),
+              capabilities: {},
+            }))
+          : accounts.map((address) => getAddress(address))) as never,
+        chainId: configuredChain.id,
+      }
+    },
+
+    async disconnect() {
+      const provider = await this.getProvider()
+      await provider.disconnect()
+    },
+
+    balances(request?: BalancesRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({
+          method: 'wallet_balances',
+          params: request === undefined ? undefined : [request],
+        }),
+      )
+    },
+
+    callContract(request: CallContractRequest | CallContractRequestBatch) {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_callContract', params: [request] }),
+      )
+    },
+
+    deposit() {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_deposit' }),
+      )
+    },
+
+    getFromContract(request: GetFromContractRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({
+          method: 'wallet_getFromContract',
+          params: [request],
+        }),
+      )
+    },
+
+    getPermissions(address?: string) {
+      return this.getProvider().then((provider) =>
+        provider.request({
+          method: 'wallet_getPermissions',
+          params: address === undefined ? undefined : [address],
+        }),
+      )
+    },
+
+    grantPermissions(request: GrantPermissionsRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({
+          method: 'wallet_grantPermissions',
+          params: [request],
+        }),
+      )
+    },
+
+    authenticate() {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_authenticate' }),
+      )
+    },
+
+    manageAccount(request: MossWalletManageAccountRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_manageAccount', params: [request] }),
+      )
+    },
+
+    open() {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_open' }),
+      )
+    },
+
+    revokePermissions() {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_revokePermissions' }),
+      )
+    },
+
+    send(request: SendRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_send', params: [request] }),
+      )
+    },
+
+    signData(request: SignDataRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_signData', params: [request] }),
+      )
+    },
+
+    swap(request: SwapRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_swap', params: [request] }),
+      )
+    },
+
+    transfer(request: TransferRequest) {
+      return this.getProvider().then((provider) =>
+        provider.request({ method: 'wallet_transfer', params: [request] }),
+      )
+    },
+
+    async getAccounts() {
+      const provider = await this.getProvider()
+      const accounts = await provider.request({ method: 'eth_accounts' })
+      return accounts.map((account) => getAddress(account))
+    },
+
+    async getChainId() {
+      const provider = await this.getProvider()
+      const chainId = await provider.request({ method: 'eth_chainId' })
+      return Number(chainId)
+    },
+
+    async getProvider() {
+      return getProvider()
+    },
+
+    async isAuthorized() {
+      try {
+        return (await this.getAccounts()).length > 0
+      } catch {
+        return false
+      }
+    },
+
+    async switchChain({ chainId }) {
+      const configuredChain = config.chains.find((item) => item.id === chain.id)
+      if (!configuredChain) throw new ChainNotConfiguredError()
+
+      if (chainId === configuredChain.id) {
+        return configuredChain
+      }
+
+      throw new SwitchChainNotSupportedError({ connector: this as never })
+    },
+
+    onAccountsChanged(accounts) {
+      config.emitter.emit('change', {
+        accounts: accounts.map((account) => getAddress(account)),
+      })
+    },
+
+    onChainChanged(chainId) {
+      config.emitter.emit('change', { chainId: Number(chainId) })
+    },
+
+    async onConnect(connectInfo) {
+      const accounts = await this.getAccounts()
+      if (accounts.length === 0) return
+
+      config.emitter.emit('connect', {
+        accounts,
+        chainId: Number(connectInfo.chainId),
+      })
+    },
+
+    onDisconnect() {
+      config.emitter.emit('disconnect')
+    },
+  }))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,7 +198,7 @@ importers:
         version: 5.69.0(@types/node@24.6.2)(typescript@5.9.3)
       node:
         specifier: runtime:^24.5.1
-        version: runtime:24.16.0
+        version: runtime:24.18.0
       playwright:
         specifier: 1.56.1
         version: 1.56.1
@@ -332,6 +332,9 @@ importers:
       '@coinbase/wallet-sdk':
         specifier: 'catalog:'
         version: 4.3.6(@types/react@19.2.3)(bufferutil@4.0.8)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@megaeth-labs/wallet-sdk':
+        specifier: ^0.1.19
+        version: 0.1.19
       '@metamask/connect-evm':
         specifier: 'catalog:'
         version: 2.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -2632,6 +2635,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@megaeth-labs/wallet-sdk@0.1.19':
+    resolution: {integrity: sha512-yhJgT4d1v/x+r1Dk/4Gy3uPC9klLr68AkHaK+FLmTZA/9f5o6OUiN06jbm1XEvTWuyvP3XcMsrwijgKIRG241Q==}
+
   '@metamask/analytics@0.6.0':
     resolution: {integrity: sha512-L250lV3PANTcKqhZkmRV1Obkyddm6JDQvDBuUVAi+7TmPdOVdpavWNXyEh7ErscjwG0z2wiF9Ne0ihK/nCdX0w==}
     engines: {node: '>=20.19.0'}
@@ -4132,7 +4138,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -8775,94 +8781,94 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
-  node@runtime:24.16.0:
+  node@runtime:24.18.0:
     resolution:
       type: variations
       variants:
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-MN/Y5EMiwnEoE/JeFjwlPK1TvkPgmJB7i1NIvxdKSWg=
+            integrity: sha256-ZGOiNzn2sjAOvsXM1gJ14TjjhY/Br8bo+bxOT2pLdvo=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-ORidq07rFXBsQkrwrAijBEyeSPfbEqfXf2t6r8fdXfY=
+            integrity: sha256-4al+FMmcgD6WxzOUAyguoFpJnDL42D3v6e9exm+XntE=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-KYtMezy4B2XIcD5CuQMkpOzjtmNJR7iedpw8mAq1UYU=
+            integrity: sha256-39Db0+chUDQ033tyBecZ9hs6OjGyvPlym4uR/qJA8IA=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-WJ9bbdT8/uTf2nMBOQPJZquqir2T28nUNlRORytPDnQ=
+            integrity: sha256-a0SEwhkCdBdd+aqPKOLXWKgZyxwf5qtIHi+VtGOrhQg=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-JStYIFNNwDBKKFQcmkRDfPpyAufyAiXSjUk5MsWOl6o=
+            integrity: sha256-/hM4ly95KDxrwh5h2/RXa76MBa3tKZnUHIZDrTAmUUI=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-Vnrwl1s0BVFrmx3cZEKaI+yMWi+mzwE5EmGkzHdOPt0=
+            integrity: sha256-Nx68E5RfwWlJPnUvLdr6+rbs2My0Ubz/RuCfacXdjHo=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
         - resolution:
             archive: tarball
             bin: bin/node
-            integrity: sha256-L69qOH6bYriI4hxU8BJJ+ydTf/7PGELyn0yRnQpZoP8=
+            integrity: sha256-eDEwmElj23upy9AQierywu+wVcfBaTyUMXS5Z7MFDLg=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
         - resolution:
             archive: zip
             bin: node.exe
-            integrity: sha256-FINGEdTGs8BgVOcAdzK5BHTBbgsy85XgW1Wlce9xxtI=
-            prefix: node-v24.16.0-win-arm64
+            integrity: sha256-8nRmmtuTsf0Pv48h/QeGCencyEMz1PJxjS3eP5oWGgE=
+            prefix: node-v24.18.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
         - resolution:
             archive: zip
             bin: node.exe
-            integrity: sha256-7aypvVjsjpIDfaxOh31S9rj0MLgcGLV+JktOL7ERzVY=
-            prefix: node-v24.16.0-win-x64
+            integrity: sha256-CuaEBrQtdyVmHal5sUA+yZJtogXGdwgn8zqsnY8m6CE=
+            prefix: node-v24.18.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-x64.zip
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-win-x64.zip
           targets:
             - cpu: x64
               os: win32
-    version: 24.16.0
+    version: 24.18.0
     hasBin: true
 
   nopt@7.2.1:
@@ -9202,6 +9208,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  penpal@7.0.6:
+    resolution: {integrity: sha512-iZ70OhtiZ959V57j7vSKBuv1UEXwCEu7C+TK7YxAkrB1JahB4pElHs1S1ThzMuGYNQ+SbExOXmvqrEeGwX/A8g==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -13342,6 +13351,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@megaeth-labs/wallet-sdk@0.1.19':
+    dependencies:
+      penpal: 7.0.6
 
   '@metamask/analytics@0.6.0':
     dependencies:
@@ -21045,7 +21058,7 @@ snapshots:
 
   node-releases@2.0.36: {}
 
-  node@runtime:24.16.0: {}
+  node@runtime:24.18.0: {}
 
   nopt@7.2.1:
     dependencies:
@@ -21845,6 +21858,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  penpal@7.0.6: {}
 
   perfect-debounce@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6(@types/react@19.2.3)(bufferutil@4.0.8)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@megaeth-labs/wallet-sdk':
-        specifier: ^0.1.19
-        version: 0.1.19
+        specifier: ^0.1.24
+        version: 0.1.24
       '@metamask/connect-evm':
         specifier: 'catalog:'
         version: 2.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -2635,8 +2635,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@megaeth-labs/wallet-sdk@0.1.19':
-    resolution: {integrity: sha512-yhJgT4d1v/x+r1Dk/4Gy3uPC9klLr68AkHaK+FLmTZA/9f5o6OUiN06jbm1XEvTWuyvP3XcMsrwijgKIRG241Q==}
+  '@megaeth-labs/wallet-sdk@0.1.24':
+    resolution: {integrity: sha512-qalT2IafQZF/W0hhGEp2WeA2wiaKhbWqbEdr5oyV9OL1fnwvfweTi2MWEUm9Ebg4TKRiCeua5zDCXXLYfQNpxg==}
 
   '@metamask/analytics@0.6.0':
     resolution: {integrity: sha512-L250lV3PANTcKqhZkmRV1Obkyddm6JDQvDBuUVAi+7TmPdOVdpavWNXyEh7ErscjwG0z2wiF9Ne0ihK/nCdX0w==}
@@ -13352,7 +13352,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@megaeth-labs/wallet-sdk@0.1.19':
+  '@megaeth-labs/wallet-sdk@0.1.24':
     dependencies:
       penpal: 7.0.6
 


### PR DESCRIPTION
## Summary
Adds `mossWallet` to `@wagmi/connectors` for [MOSS Wallet](https://moss.megaeth.com), MegaETH's embedded SDK wallet — modeled directly on `porto.ts`/`coinbaseWallet.ts`.

- Lazily imports `@megaeth-labs/wallet-sdk` as an optional peer dependency (same `try/catch` + `turbopackOptional` pattern as `porto`/`@coinbase/wallet-sdk`), so this connector adds zero required dependencies for apps that don't use it.
- Non-standard `wallet_*` capabilities (balances, swap, transfer, etc.) are exposed as connector `Properties`, the same pattern `porto` uses for `getPortoInstance()`.
- Standard EIP-1193 methods (`connect`, `disconnect`, `getAccounts`, `switchChain`, etc.) dispatch through the provider's typed `request()`.

## Test plan
- [x] `pnpm --filter @wagmi/connectors check:types`
- [x] `pnpm --filter @wagmi/connectors run build`
- [x] `pnpm vitest run --project connectors` (13/13 passing, including new `mossWallet.test.ts`)
- [x] `biome check` clean
