### PR TITLE
fix(tempo): transaction override types

### DIFF
--- a/.changeset/quiet-lions-jump.md
+++ b/.changeset/quiet-lions-jump.md
@@ -3,4 +3,4 @@
 'wagmi': patch
 ---
 
-Fixed Tempo action and hook types so transaction override parameters are optional.
+Fixed Tempo types so transaction override parameters are optional.

--- a/.changeset/quiet-lions-jump.md
+++ b/.changeset/quiet-lions-jump.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fixed Tempo action and hook types so transaction override parameters are optional.

--- a/packages/core/src/tempo/actions/amm.test-d.ts
+++ b/packages/core/src/tempo/actions/amm.test-d.ts
@@ -1,0 +1,37 @@
+import { createConfig, http } from '@wagmi/core'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { test } from 'vitest'
+import * as amm from './amm.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const tokenA = '0x20c0000000000000000000000000000000000001'
+const tokenB = '0x20c0000000000000000000000000000000000002'
+const to = '0xd2135CfB216b74109775236E36d4b433F1DF507B'
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('mintSync accepts optional transaction overrides', () => {
+  const chainId = tempo.id
+
+  amm.mintSync(config, {
+    chainId,
+    feePayer: true,
+    to,
+    userTokenAddress: tokenA,
+    validatorTokenAddress: tokenB,
+    validatorTokenAmount: 1_000_000n,
+  })
+
+  // @ts-expect-error required action parameters stay required
+  amm.mintSync(config, {
+    chainId,
+    feePayer: true,
+    to,
+    validatorTokenAddress: tokenB,
+    validatorTokenAmount: 1_000_000n,
+  })
+})

--- a/packages/core/src/tempo/actions/amm.ts
+++ b/packages/core/src/tempo/actions/amm.ts
@@ -7,7 +7,11 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 import { filterQueryOptions } from './utils.js'
 
 /**
@@ -257,7 +261,9 @@ export declare namespace rebalanceSwap {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.amm.rebalanceSwap.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.amm.rebalanceSwap.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -314,9 +320,11 @@ export declare namespace rebalanceSwapSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.amm.rebalanceSwapSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.amm.rebalanceSwapSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -374,7 +382,9 @@ export declare namespace mint {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.amm.mint.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.amm.mint.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -431,7 +441,9 @@ export declare namespace mintSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.amm.mintSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.amm.mintSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -488,7 +500,9 @@ export declare namespace burn {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.amm.burn.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.amm.burn.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -545,7 +559,9 @@ export declare namespace burnSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.amm.burnSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.amm.burnSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 

--- a/packages/core/src/tempo/actions/dex.test-d.ts
+++ b/packages/core/src/tempo/actions/dex.test-d.ts
@@ -1,0 +1,36 @@
+import { createConfig, http } from '@wagmi/core'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { test } from 'vitest'
+import * as dex from './dex.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const tokenA = '0x20c0000000000000000000000000000000000001'
+const tokenB = '0x20c0000000000000000000000000000000000002'
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('buySync accepts optional transaction overrides', () => {
+  const chainId = tempo.id
+
+  dex.buySync(config, {
+    amountOut: 1_000_000n,
+    chainId,
+    feePayer: true,
+    maxAmountIn: 1_000_000n,
+    tokenIn: tokenA,
+    tokenOut: tokenB,
+  })
+
+  // @ts-expect-error required action parameters stay required
+  dex.buySync(config, {
+    chainId,
+    feePayer: true,
+    maxAmountIn: 1_000_000n,
+    tokenIn: tokenA,
+    tokenOut: tokenB,
+  })
+})

--- a/packages/core/src/tempo/actions/dex.ts
+++ b/packages/core/src/tempo/actions/dex.ts
@@ -7,7 +7,11 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { PartialBy, UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 
 /**
  * Buys a specific amount of tokens.
@@ -57,7 +61,9 @@ export declare namespace buy {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.buy.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.buy.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -117,7 +123,9 @@ export declare namespace buySync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.buySync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.buySync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -171,7 +179,9 @@ export declare namespace cancel {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.cancel.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.cancel.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -228,7 +238,9 @@ export declare namespace cancelSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.cancelSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.cancelSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -285,7 +297,9 @@ export declare namespace cancelStale {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.cancelStale.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.cancelStale.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -342,7 +356,12 @@ export declare namespace cancelStaleSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.cancelStaleSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.cancelStaleSync.Parameters<
+          config['chains'][number],
+          Account
+        >
+      >,
       'chain'
     >
 
@@ -396,7 +415,9 @@ export declare namespace createPair {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.createPair.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.createPair.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -453,7 +474,9 @@ export declare namespace createPairSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.createPairSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.createPairSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1086,7 +1109,9 @@ export declare namespace place {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.place.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.place.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1144,7 +1169,9 @@ export declare namespace placeFlip {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.placeFlip.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.placeFlip.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1205,7 +1232,9 @@ export declare namespace placeFlipSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.placeFlipSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.placeFlipSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1265,7 +1294,9 @@ export declare namespace placeSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.placeSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.placeSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1322,7 +1353,9 @@ export declare namespace sell {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.sell.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.sell.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1382,7 +1415,9 @@ export declare namespace sellSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.sellSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.sellSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1617,7 +1652,9 @@ export declare namespace withdraw {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.withdraw.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.withdraw.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1675,7 +1712,9 @@ export declare namespace withdrawSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.dex.withdrawSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.dex.withdrawSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 

--- a/packages/core/src/tempo/actions/fee.test-d.ts
+++ b/packages/core/src/tempo/actions/fee.test-d.ts
@@ -1,0 +1,29 @@
+import { createConfig, http } from '@wagmi/core'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { test } from 'vitest'
+import * as fee from './fee.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const token = '0x20c0000000000000000000000000000000000001'
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('setUserTokenSync accepts optional transaction overrides', () => {
+  const chainId = tempo.id
+
+  fee.setUserTokenSync(config, {
+    chainId,
+    feePayer: true,
+    token,
+  })
+
+  // @ts-expect-error required action parameters stay required
+  fee.setUserTokenSync(config, {
+    chainId,
+    feePayer: true,
+  })
+})

--- a/packages/core/src/tempo/actions/fee.ts
+++ b/packages/core/src/tempo/actions/fee.ts
@@ -7,7 +7,11 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { PartialBy, UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 import { filterQueryOptions } from './utils.js'
 
 /**
@@ -148,7 +152,9 @@ export declare namespace setUserToken {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.fee.setUserToken.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.fee.setUserToken.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -205,9 +211,11 @@ export declare namespace setUserTokenSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.fee.setUserTokenSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.fee.setUserTokenSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >

--- a/packages/core/src/tempo/actions/policy.test-d.ts
+++ b/packages/core/src/tempo/actions/policy.test-d.ts
@@ -1,0 +1,28 @@
+import { createConfig, http } from '@wagmi/core'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { test } from 'vitest'
+import * as policy from './policy.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('createSync accepts optional transaction overrides', () => {
+  const chainId = tempo.id
+
+  policy.createSync(config, {
+    chainId,
+    feePayer: true,
+    type: 'whitelist',
+  })
+
+  // @ts-expect-error required action parameters stay required
+  policy.createSync(config, {
+    chainId,
+    feePayer: true,
+  })
+})

--- a/packages/core/src/tempo/actions/policy.ts
+++ b/packages/core/src/tempo/actions/policy.ts
@@ -7,7 +7,11 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 
 /**
  * Creates a new policy.
@@ -54,7 +58,9 @@ export declare namespace create {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.create.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.policy.create.Parameters<config['chains'][number], Account>
+      >,
       'chain' | 'admin'
     >
 
@@ -111,7 +117,9 @@ export declare namespace createSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.createSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.policy.createSync.Parameters<config['chains'][number], Account>
+      >,
       'chain' | 'admin'
     >
 
@@ -166,7 +174,9 @@ export declare namespace setAdmin {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.setAdmin.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.policy.setAdmin.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -224,7 +234,12 @@ export declare namespace setAdminSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.setAdminSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.policy.setAdminSync.Parameters<
+          config['chains'][number],
+          Account
+        >
+      >,
       'chain'
     >
 
@@ -280,9 +295,11 @@ export declare namespace modifyWhitelist {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.modifyWhitelist.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.policy.modifyWhitelist.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -342,9 +359,11 @@ export declare namespace modifyWhitelistSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.modifyWhitelistSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.policy.modifyWhitelistSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -401,9 +420,11 @@ export declare namespace modifyBlacklist {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.modifyBlacklist.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.policy.modifyBlacklist.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -463,9 +484,11 @@ export declare namespace modifyBlacklistSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.policy.modifyBlacklistSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.policy.modifyBlacklistSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >

--- a/packages/core/src/tempo/actions/reward.test-d.ts
+++ b/packages/core/src/tempo/actions/reward.test-d.ts
@@ -1,0 +1,29 @@
+import { createConfig, http } from '@wagmi/core'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { test } from 'vitest'
+import * as reward from './reward.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const token = '0x20c0000000000000000000000000000000000001'
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('claimSync accepts optional transaction overrides', () => {
+  const chainId = tempo.id
+
+  reward.claimSync(config, {
+    chainId,
+    feePayer: true,
+    token,
+  })
+
+  // @ts-expect-error required action parameters stay required
+  reward.claimSync(config, {
+    chainId,
+    feePayer: true,
+  })
+})

--- a/packages/core/src/tempo/actions/reward.ts
+++ b/packages/core/src/tempo/actions/reward.ts
@@ -7,7 +7,11 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 
 /**
  * Claims accumulated rewards for a recipient.
@@ -55,7 +59,9 @@ export declare namespace claim {
     ChainIdParameter<config> &
       ConnectorParameter &
       UnionLooseOmit<
-        Actions.reward.claim.Parameters<config['chains'][number], Account>,
+        OptionalTransactionOverrides<
+          Actions.reward.claim.Parameters<config['chains'][number], Account>
+        >,
         'chain'
       >
 
@@ -110,7 +116,9 @@ export declare namespace claimSync {
     ChainIdParameter<config> &
       ConnectorParameter &
       UnionLooseOmit<
-        Actions.reward.claimSync.Parameters<config['chains'][number], Account>,
+        OptionalTransactionOverrides<
+          Actions.reward.claimSync.Parameters<config['chains'][number], Account>
+        >,
         'chain'
       >
 
@@ -351,9 +359,11 @@ export declare namespace setRecipient {
     ChainIdParameter<config> &
       ConnectorParameter &
       UnionLooseOmit<
-        Actions.reward.setRecipient.Parameters<
-          config['chains'][number],
-          Account
+        OptionalTransactionOverrides<
+          Actions.reward.setRecipient.Parameters<
+            config['chains'][number],
+            Account
+          >
         >,
         'chain'
       >
@@ -410,9 +420,11 @@ export declare namespace setRecipientSync {
     ChainIdParameter<config> &
       ConnectorParameter &
       UnionLooseOmit<
-        Actions.reward.setRecipientSync.Parameters<
-          config['chains'][number],
-          Account
+        OptionalTransactionOverrides<
+          Actions.reward.setRecipientSync.Parameters<
+            config['chains'][number],
+            Account
+          >
         >,
         'chain'
       >
@@ -470,7 +482,12 @@ export declare namespace distribute {
     ChainIdParameter<config> &
       ConnectorParameter &
       UnionLooseOmit<
-        Actions.reward.distribute.Parameters<config['chains'][number], Account>,
+        OptionalTransactionOverrides<
+          Actions.reward.distribute.Parameters<
+            config['chains'][number],
+            Account
+          >
+        >,
         'chain'
       >
 
@@ -527,9 +544,11 @@ export declare namespace distributeSync {
     ChainIdParameter<config> &
       ConnectorParameter &
       UnionLooseOmit<
-        Actions.reward.distributeSync.Parameters<
-          config['chains'][number],
-          Account
+        OptionalTransactionOverrides<
+          Actions.reward.distributeSync.Parameters<
+            config['chains'][number],
+            Account
+          >
         >,
         'chain'
       >

--- a/packages/core/src/tempo/actions/token.test-d.ts
+++ b/packages/core/src/tempo/actions/token.test-d.ts
@@ -1,0 +1,34 @@
+import { createConfig, http } from '@wagmi/core'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { test } from 'vitest'
+import * as token from './token.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const tokenAddress = '0x20c0000000000000000000000000000000000001'
+const to = '0xd2135CfB216b74109775236E36d4b433F1DF507B'
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('transferSync accepts optional transaction overrides', () => {
+  const chainId = tempo.id
+
+  token.transferSync(config, {
+    amount: 1_000_000n,
+    chainId,
+    feePayer: true,
+    to,
+    token: tokenAddress,
+  })
+
+  // @ts-expect-error required action parameters stay required
+  token.transferSync(config, {
+    chainId,
+    feePayer: true,
+    to,
+    token: tokenAddress,
+  })
+})

--- a/packages/core/src/tempo/actions/token.ts
+++ b/packages/core/src/tempo/actions/token.ts
@@ -7,7 +7,11 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 
 /**
  * Approves a spender to transfer TIP20 tokens on behalf of the caller.
@@ -53,7 +57,9 @@ export declare namespace approve {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.approve.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.approve.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -109,7 +115,9 @@ export declare namespace approveSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.approveSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.approveSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -162,7 +170,9 @@ export declare namespace burn {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.burn.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.burn.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -216,7 +226,9 @@ export declare namespace burnBlocked {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.burnBlocked.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.burnBlocked.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -273,9 +285,11 @@ export declare namespace burnBlockedSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.burnBlockedSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.burnBlockedSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -332,7 +346,9 @@ export declare namespace burnSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.burnSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.burnSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -385,9 +401,11 @@ export declare namespace changeTransferPolicy {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.changeTransferPolicy.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.changeTransferPolicy.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -444,9 +462,11 @@ export declare namespace changeTransferPolicySync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.changeTransferPolicySync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.changeTransferPolicySync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -501,7 +521,9 @@ export declare namespace create {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.create.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.create.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -558,7 +580,9 @@ export declare namespace createSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.createSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.createSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -610,9 +634,11 @@ export declare namespace updateQuoteToken {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.updateQuoteToken.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.updateQuoteToken.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -668,9 +694,11 @@ export declare namespace updateQuoteTokenSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.updateQuoteTokenSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.updateQuoteTokenSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1097,7 +1125,9 @@ export declare namespace grantRoles {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.grantRoles.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.grantRoles.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1154,9 +1184,11 @@ export declare namespace grantRolesSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.grantRolesSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.grantRolesSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1307,7 +1339,9 @@ export declare namespace mint {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.mint.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.mint.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1364,7 +1398,9 @@ export declare namespace mintSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.mintSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.mintSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1416,7 +1452,9 @@ export declare namespace pause {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.pause.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.pause.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1471,7 +1509,9 @@ export declare namespace pauseSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.pauseSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.pauseSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1524,7 +1564,12 @@ export declare namespace renounceRoles {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.renounceRoles.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.renounceRoles.Parameters<
+          config['chains'][number],
+          Account
+        >
+      >,
       'chain'
     >
 
@@ -1580,9 +1625,11 @@ export declare namespace renounceRolesSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.renounceRolesSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.renounceRolesSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1637,7 +1684,9 @@ export declare namespace revokeRoles {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.revokeRoles.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.revokeRoles.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1694,9 +1743,11 @@ export declare namespace revokeRolesSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.revokeRolesSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.revokeRolesSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1751,7 +1802,9 @@ export declare namespace setRoleAdmin {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.setRoleAdmin.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.setRoleAdmin.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1808,9 +1861,11 @@ export declare namespace setRoleAdminSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.setRoleAdminSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.setRoleAdminSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1864,7 +1919,9 @@ export declare namespace setSupplyCap {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.setSupplyCap.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.setSupplyCap.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -1920,9 +1977,11 @@ export declare namespace setSupplyCapSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.setSupplyCapSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.setSupplyCapSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -1976,7 +2035,9 @@ export declare namespace transfer {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.transfer.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.transfer.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -2032,7 +2093,9 @@ export declare namespace transferSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.transferSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.transferSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -2084,7 +2147,9 @@ export declare namespace unpause {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.unpause.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.unpause.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -2139,7 +2204,9 @@ export declare namespace unpauseSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.unpauseSync.Parameters<config['chains'][number], Account>,
+      OptionalTransactionOverrides<
+        Actions.token.unpauseSync.Parameters<config['chains'][number], Account>
+      >,
       'chain'
     >
 
@@ -2192,9 +2259,11 @@ export declare namespace prepareUpdateQuoteToken {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.prepareUpdateQuoteToken.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.prepareUpdateQuoteToken.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >
@@ -2251,9 +2320,11 @@ export declare namespace prepareUpdateQuoteTokenSync {
   export type Parameters<config extends Config> = ChainIdParameter<config> &
     ConnectorParameter &
     UnionLooseOmit<
-      Actions.token.prepareUpdateQuoteTokenSync.Parameters<
-        config['chains'][number],
-        Account
+      OptionalTransactionOverrides<
+        Actions.token.prepareUpdateQuoteTokenSync.Parameters<
+          config['chains'][number],
+          Account
+        >
       >,
       'chain'
     >

--- a/packages/core/src/tempo/actions/utils.test-d.ts
+++ b/packages/core/src/tempo/actions/utils.test-d.ts
@@ -1,0 +1,51 @@
+import { expectTypeOf, test } from 'vitest'
+import type { OptionalTransactionOverrides } from './utils.js'
+
+test('OptionalTransactionOverrides', () => {
+  type Parameters = OptionalTransactionOverrides<{
+    account: `0x${string}`
+    amount: bigint
+    gas: bigint
+    maxFeePerGas: bigint
+    maxPriorityFeePerGas: bigint
+    nonce: number
+    to: `0x${string}`
+  }>
+
+  expectTypeOf<Parameters>().toExtend<{
+    account?: `0x${string}` | undefined
+    amount: bigint
+    gas?: bigint | undefined
+    maxFeePerGas?: bigint | undefined
+    maxPriorityFeePerGas?: bigint | undefined
+    nonce?: number | undefined
+    to: `0x${string}`
+  }>()
+
+  void ({
+    account: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    amount: 1_000_000n,
+    gas: 21_000n,
+    maxFeePerGas: 1_000_000n,
+    maxPriorityFeePerGas: 1_000_000n,
+    nonce: 1,
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  } satisfies Parameters)
+
+  void ({
+    amount: 1_000_000n,
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  } satisfies Parameters)
+
+  void ({
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    // @ts-expect-error required non-override parameters stay required
+  } satisfies Parameters)
+
+  void ({
+    amount: 1_000_000n,
+    // @ts-expect-error excess parameters stay rejected
+    extra: true,
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  } satisfies Parameters)
+})

--- a/packages/core/src/tempo/actions/utils.ts
+++ b/packages/core/src/tempo/actions/utils.ts
@@ -1,5 +1,22 @@
 import type * as Query from '@tanstack/query-core'
-import type { RequiredBy, UnionLooseOmit } from '../../types/utils.js'
+import type {
+  PartialBy,
+  RequiredBy,
+  UnionLooseOmit,
+} from '../../types/utils.js'
+
+export type OptionalTransactionOverrides<parameters> = parameters extends object
+  ? PartialBy<
+      parameters,
+      Extract<TransactionOverrideParameter, keyof parameters>
+    >
+  : parameters
+type TransactionOverrideParameter =
+  | 'account'
+  | 'gas'
+  | 'maxFeePerGas'
+  | 'maxPriorityFeePerGas'
+  | 'nonce'
 
 export type QueryParameter<
   queryFnData = unknown,

--- a/packages/core/src/tempo/actions/zone.test-d.ts
+++ b/packages/core/src/tempo/actions/zone.test-d.ts
@@ -26,7 +26,7 @@ test('deposit parameters', () => {
     zoneId: 7,
   })
 
-  expectTypeOf<zoneActions.deposit.Parameters<typeof config>>().toMatchTypeOf<{
+  expectTypeOf<zoneActions.deposit.Parameters<typeof config>>().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -43,9 +43,7 @@ test('depositSync parameters', () => {
     zoneId: 7,
   })
 
-  expectTypeOf<
-    zoneActions.depositSync.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  expectTypeOf<zoneActions.depositSync.Parameters<typeof config>>().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -64,7 +62,7 @@ test('encryptedDeposit parameters', () => {
 
   expectTypeOf<
     zoneActions.encryptedDeposit.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  >().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -83,7 +81,7 @@ test('encryptedDepositSync parameters', () => {
 
   expectTypeOf<
     zoneActions.encryptedDepositSync.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  >().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -101,7 +99,7 @@ test('requestWithdrawal parameters', () => {
 
   expectTypeOf<
     zoneActions.requestWithdrawal.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  >().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -118,7 +116,7 @@ test('requestWithdrawalSync parameters', () => {
 
   expectTypeOf<
     zoneActions.requestWithdrawalSync.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  >().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -136,7 +134,7 @@ test('requestVerifiableWithdrawal parameters', () => {
 
   expectTypeOf<
     zoneActions.requestVerifiableWithdrawal.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  >().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined
@@ -155,7 +153,7 @@ test('requestVerifiableWithdrawalSync parameters', () => {
 
   expectTypeOf<
     zoneActions.requestVerifiableWithdrawalSync.Parameters<typeof config>
-  >().toMatchTypeOf<{
+  >().toExtend<{
     account?: unknown
     amount: bigint
     chainId?: number | undefined

--- a/packages/core/src/tempo/actions/zone.ts
+++ b/packages/core/src/tempo/actions/zone.ts
@@ -21,22 +21,12 @@ import type {
   ConnectorParameter,
 } from '../../types/properties.js'
 import type { PartialBy, UnionLooseOmit } from '../../types/utils.js'
-import type { QueryOptions, QueryParameter } from './utils.js'
+import type {
+  OptionalTransactionOverrides,
+  QueryOptions,
+  QueryParameter,
+} from './utils.js'
 import { filterQueryOptions } from './utils.js'
-
-type TransactionOverrideParameter =
-  | 'account'
-  | 'gas'
-  | 'maxFeePerGas'
-  | 'maxPriorityFeePerGas'
-  | 'nonce'
-
-type OptionalTransactionOverrides<parameters> = parameters extends object
-  ? PartialBy<
-      parameters,
-      Extract<TransactionOverrideParameter, keyof parameters>
-    >
-  : parameters
 
 /**
  * Gets information about the currently stored zone authorization token.

--- a/packages/react/src/tempo/hooks/amm.test-d.ts
+++ b/packages/react/src/tempo/hooks/amm.test-d.ts
@@ -1,0 +1,562 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as amm from './amm.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('usePool', () => {
+  const result = amm.usePool({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.amm.getPool.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useLiquidityBalance', () => {
+  const result = amm.useLiquidityBalance({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.amm.getLiquidityBalance.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useRebalanceSwap', () => {
+  const variables = {} as Actions.amm.rebalanceSwap.Parameters<typeof config>
+
+  const rebalanceSwap = amm.useRebalanceSwap({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwap.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.rebalanceSwap.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.amm.rebalanceSwap.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.amm.rebalanceSwap.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.amm.rebalanceSwap.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(rebalanceSwap.data).toEqualTypeOf<
+    Actions.amm.rebalanceSwap.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    rebalanceSwap.error,
+  ).toEqualTypeOf<Actions.amm.rebalanceSwap.ErrorType | null>()
+  expectTypeOf(rebalanceSwap.variables).toEqualTypeOf<
+    Actions.amm.rebalanceSwap.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(rebalanceSwap.context).toEqualTypeOf<Context | undefined>()
+
+  rebalanceSwap.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.rebalanceSwap.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.rebalanceSwap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.amm.rebalanceSwap.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.rebalanceSwap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.amm.rebalanceSwap.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.amm.rebalanceSwap.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.rebalanceSwap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.amm.rebalanceSwapSync.Parameters<
+    typeof config
+  >
+
+  const rebalanceSwapSync = amm.useRebalanceSwapSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.amm.rebalanceSwapSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(rebalanceSwapSync.data).toEqualTypeOf<
+    Actions.amm.rebalanceSwapSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    rebalanceSwapSync.error,
+  ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ErrorType | null>()
+  expectTypeOf(rebalanceSwapSync.variables).toEqualTypeOf<
+    Actions.amm.rebalanceSwapSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(rebalanceSwapSync.context).toEqualTypeOf<Context | undefined>()
+
+  rebalanceSwapSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.amm.rebalanceSwapSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.amm.rebalanceSwapSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.rebalanceSwapSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useMint', () => {
+  const variables = {} as Actions.amm.mint.Parameters<typeof config>
+
+  const mint = amm.useMint({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mint.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.mint.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mint.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.amm.mint.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mint.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.amm.mint.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.mint.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mint.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(mint.data).toEqualTypeOf<
+    Actions.amm.mint.ReturnValue | undefined
+  >()
+  expectTypeOf(mint.error).toEqualTypeOf<Actions.amm.mint.ErrorType | null>()
+  expectTypeOf(mint.variables).toEqualTypeOf<
+    Actions.amm.mint.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(mint.context).toEqualTypeOf<Context | undefined>()
+
+  mint.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.mint.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.mint.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.amm.mint.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.mint.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.amm.mint.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.mint.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.mint.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.amm.mintSync.Parameters<typeof config>
+
+  const mintSync = amm.useMintSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mintSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.mintSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mintSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.amm.mintSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mintSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.amm.mintSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.amm.mintSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.mintSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(mintSync.data).toEqualTypeOf<
+    Actions.amm.mintSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    mintSync.error,
+  ).toEqualTypeOf<Actions.amm.mintSync.ErrorType | null>()
+  expectTypeOf(mintSync.variables).toEqualTypeOf<
+    Actions.amm.mintSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(mintSync.context).toEqualTypeOf<Context | undefined>()
+
+  mintSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.mintSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.mintSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.amm.mintSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.mintSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.amm.mintSync.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.mintSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.mintSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useBurn', () => {
+  const variables = {} as Actions.amm.burn.Parameters<typeof config>
+
+  const burn = amm.useBurn({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burn.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.burn.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burn.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.amm.burn.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burn.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.amm.burn.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.burn.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burn.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(burn.data).toEqualTypeOf<
+    Actions.amm.burn.ReturnValue | undefined
+  >()
+  expectTypeOf(burn.error).toEqualTypeOf<Actions.amm.burn.ErrorType | null>()
+  expectTypeOf(burn.variables).toEqualTypeOf<
+    Actions.amm.burn.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(burn.context).toEqualTypeOf<Context | undefined>()
+
+  burn.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.burn.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.burn.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.amm.burn.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.burn.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.amm.burn.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.burn.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.burn.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.amm.burnSync.Parameters<typeof config>
+
+  const burnSync = amm.useBurnSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burnSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.amm.burnSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burnSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.amm.burnSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burnSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.amm.burnSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.amm.burnSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.amm.burnSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(burnSync.data).toEqualTypeOf<
+    Actions.amm.burnSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    burnSync.error,
+  ).toEqualTypeOf<Actions.amm.burnSync.ErrorType | null>()
+  expectTypeOf(burnSync.variables).toEqualTypeOf<
+    Actions.amm.burnSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(burnSync.context).toEqualTypeOf<Context | undefined>()
+
+  burnSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.burnSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.burnSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.amm.burnSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.burnSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.amm.burnSync.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.amm.burnSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.amm.burnSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWatchRebalanceSwap', () => {
+  amm.useWatchRebalanceSwap({
+    config,
+    enabled: true,
+    onRebalanceSwap(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchMint', () => {
+  amm.useWatchMint({
+    config,
+    enabled: true,
+    onMint(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchBurn', () => {
+  amm.useWatchBurn({
+    config,
+    enabled: true,
+    onBurn(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/dex.test-d.ts
+++ b/packages/react/src/tempo/hooks/dex.test-d.ts
@@ -1,0 +1,1431 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as dex from './dex.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useBalance', () => {
+  const result = dex.useBalance({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.getBalance.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useBuyQuote', () => {
+  const result = dex.useBuyQuote({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.getBuyQuote.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useOrder', () => {
+  const result = dex.useOrder({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.getOrder.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useOrderbook', () => {
+  const result = dex.useOrderbook({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.getOrderbook.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useTickLevel', () => {
+  const result = dex.useTickLevel({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.getTickLevel.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useSellQuote', () => {
+  const result = dex.useSellQuote({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.getSellQuote.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useBuy', () => {
+  const variables = {} as Actions.dex.buy.Parameters<typeof config>
+
+  const buy = dex.useBuy({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buy.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.buy.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buy.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.buy.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buy.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.buy.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.buy.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buy.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(buy.data).toEqualTypeOf<
+    Actions.dex.buy.ReturnValue | undefined
+  >()
+  expectTypeOf(buy.error).toEqualTypeOf<Actions.dex.buy.ErrorType | null>()
+  expectTypeOf(buy.variables).toEqualTypeOf<
+    Actions.dex.buy.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(buy.context).toEqualTypeOf<Context | undefined>()
+
+  buy.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.buy.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.buy.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.buy.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.buy.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.buy.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.buy.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.buy.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.buySync.Parameters<typeof config>
+
+  const buySync = dex.useBuySync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buySync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.buySync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buySync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.buySync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buySync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.buySync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.buySync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.buySync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(buySync.data).toEqualTypeOf<
+    Actions.dex.buySync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    buySync.error,
+  ).toEqualTypeOf<Actions.dex.buySync.ErrorType | null>()
+  expectTypeOf(buySync.variables).toEqualTypeOf<
+    Actions.dex.buySync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(buySync.context).toEqualTypeOf<Context | undefined>()
+
+  buySync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.buySync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.buySync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.buySync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.buySync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.buySync.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.buySync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.buySync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useCancel', () => {
+  const variables = {} as Actions.dex.cancel.Parameters<typeof config>
+
+  const cancel = dex.useCancel({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancel.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.cancel.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancel.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.cancel.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancel.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.cancel.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.cancel.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancel.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(cancel.data).toEqualTypeOf<
+    Actions.dex.cancel.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    cancel.error,
+  ).toEqualTypeOf<Actions.dex.cancel.ErrorType | null>()
+  expectTypeOf(cancel.variables).toEqualTypeOf<
+    Actions.dex.cancel.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(cancel.context).toEqualTypeOf<Context | undefined>()
+
+  cancel.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.cancel.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancel.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.cancel.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancel.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.cancel.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.cancel.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancel.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.cancelSync.Parameters<typeof config>
+
+  const cancelSync = dex.useCancelSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.cancelSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.cancelSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.cancelSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.cancelSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(cancelSync.data).toEqualTypeOf<
+    Actions.dex.cancelSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    cancelSync.error,
+  ).toEqualTypeOf<Actions.dex.cancelSync.ErrorType | null>()
+  expectTypeOf(cancelSync.variables).toEqualTypeOf<
+    Actions.dex.cancelSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(cancelSync.context).toEqualTypeOf<Context | undefined>()
+
+  cancelSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.cancelSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.cancelSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.cancelSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.cancelSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useCancelStale', () => {
+  const variables = {} as Actions.dex.cancelStale.Parameters<typeof config>
+
+  const cancelStale = dex.useCancelStale({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStale.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.cancelStale.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStale.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.cancelStale.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStale.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.cancelStale.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.cancelStale.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStale.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(cancelStale.data).toEqualTypeOf<
+    Actions.dex.cancelStale.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    cancelStale.error,
+  ).toEqualTypeOf<Actions.dex.cancelStale.ErrorType | null>()
+  expectTypeOf(cancelStale.variables).toEqualTypeOf<
+    Actions.dex.cancelStale.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(cancelStale.context).toEqualTypeOf<Context | undefined>()
+
+  cancelStale.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.cancelStale.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelStale.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.cancelStale.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelStale.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.cancelStale.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.cancelStale.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelStale.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.cancelStaleSync.Parameters<
+    typeof config
+  >
+
+  const cancelStaleSync = dex.useCancelStaleSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStaleSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.cancelStaleSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStaleSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.dex.cancelStaleSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStaleSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.cancelStaleSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.cancelStaleSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.cancelStaleSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(cancelStaleSync.data).toEqualTypeOf<
+    Actions.dex.cancelStaleSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    cancelStaleSync.error,
+  ).toEqualTypeOf<Actions.dex.cancelStaleSync.ErrorType | null>()
+  expectTypeOf(cancelStaleSync.variables).toEqualTypeOf<
+    Actions.dex.cancelStaleSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(cancelStaleSync.context).toEqualTypeOf<Context | undefined>()
+
+  cancelStaleSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.cancelStaleSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelStaleSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.dex.cancelStaleSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelStaleSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.cancelStaleSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.cancelStaleSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.cancelStaleSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useCreatePair', () => {
+  const variables = {} as Actions.dex.createPair.Parameters<typeof config>
+
+  const createPair = dex.useCreatePair({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPair.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.createPair.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPair.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.createPair.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPair.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.createPair.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.createPair.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPair.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(createPair.data).toEqualTypeOf<
+    Actions.dex.createPair.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    createPair.error,
+  ).toEqualTypeOf<Actions.dex.createPair.ErrorType | null>()
+  expectTypeOf(createPair.variables).toEqualTypeOf<
+    Actions.dex.createPair.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(createPair.context).toEqualTypeOf<Context | undefined>()
+
+  createPair.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.createPair.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.createPair.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.createPair.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.createPair.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.createPair.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.createPair.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.createPair.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.createPairSync.Parameters<
+    typeof config
+  >
+
+  const createPairSync = dex.useCreatePairSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPairSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.createPairSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPairSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.dex.createPairSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPairSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.createPairSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.createPairSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.createPairSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(createPairSync.data).toEqualTypeOf<
+    Actions.dex.createPairSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    createPairSync.error,
+  ).toEqualTypeOf<Actions.dex.createPairSync.ErrorType | null>()
+  expectTypeOf(createPairSync.variables).toEqualTypeOf<
+    Actions.dex.createPairSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(createPairSync.context).toEqualTypeOf<Context | undefined>()
+
+  createPairSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.createPairSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.createPairSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.createPairSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.createPairSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.createPairSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.createPairSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.createPairSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('usePlace', () => {
+  const variables = {} as Actions.dex.place.Parameters<typeof config>
+
+  const place = dex.usePlace({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.place.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.place.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.place.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.place.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.place.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.place.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.place.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.place.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(place.data).toEqualTypeOf<
+    Actions.dex.place.ReturnValue | undefined
+  >()
+  expectTypeOf(place.error).toEqualTypeOf<Actions.dex.place.ErrorType | null>()
+  expectTypeOf(place.variables).toEqualTypeOf<
+    Actions.dex.place.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(place.context).toEqualTypeOf<Context | undefined>()
+
+  place.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.place.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.place.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.place.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.place.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.place.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.place.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.place.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.placeSync.Parameters<typeof config>
+
+  const placeSync = dex.usePlaceSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.placeSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.placeSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.placeSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.placeSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(placeSync.data).toEqualTypeOf<
+    Actions.dex.placeSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    placeSync.error,
+  ).toEqualTypeOf<Actions.dex.placeSync.ErrorType | null>()
+  expectTypeOf(placeSync.variables).toEqualTypeOf<
+    Actions.dex.placeSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(placeSync.context).toEqualTypeOf<Context | undefined>()
+
+  placeSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.placeSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.placeSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.placeSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.placeSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('usePlaceFlip', () => {
+  const variables = {} as Actions.dex.placeFlip.Parameters<typeof config>
+
+  const placeFlip = dex.usePlaceFlip({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlip.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.placeFlip.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlip.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.placeFlip.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlip.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.placeFlip.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.placeFlip.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlip.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(placeFlip.data).toEqualTypeOf<
+    Actions.dex.placeFlip.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    placeFlip.error,
+  ).toEqualTypeOf<Actions.dex.placeFlip.ErrorType | null>()
+  expectTypeOf(placeFlip.variables).toEqualTypeOf<
+    Actions.dex.placeFlip.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(placeFlip.context).toEqualTypeOf<Context | undefined>()
+
+  placeFlip.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.placeFlip.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeFlip.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.placeFlip.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeFlip.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.placeFlip.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.placeFlip.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeFlip.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.placeFlipSync.Parameters<
+    typeof config
+  >
+
+  const placeFlipSync = dex.usePlaceFlipSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlipSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.placeFlipSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlipSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.dex.placeFlipSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlipSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.placeFlipSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.placeFlipSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.placeFlipSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(placeFlipSync.data).toEqualTypeOf<
+    Actions.dex.placeFlipSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    placeFlipSync.error,
+  ).toEqualTypeOf<Actions.dex.placeFlipSync.ErrorType | null>()
+  expectTypeOf(placeFlipSync.variables).toEqualTypeOf<
+    Actions.dex.placeFlipSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(placeFlipSync.context).toEqualTypeOf<Context | undefined>()
+
+  placeFlipSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.placeFlipSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeFlipSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.placeFlipSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeFlipSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.placeFlipSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.placeFlipSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.placeFlipSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useSell', () => {
+  const variables = {} as Actions.dex.sell.Parameters<typeof config>
+
+  const sell = dex.useSell({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sell.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.sell.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sell.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.sell.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sell.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.sell.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.sell.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sell.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(sell.data).toEqualTypeOf<
+    Actions.dex.sell.ReturnValue | undefined
+  >()
+  expectTypeOf(sell.error).toEqualTypeOf<Actions.dex.sell.ErrorType | null>()
+  expectTypeOf(sell.variables).toEqualTypeOf<
+    Actions.dex.sell.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(sell.context).toEqualTypeOf<Context | undefined>()
+
+  sell.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.sell.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.sell.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.sell.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.sell.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.sell.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.sell.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.sell.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.sellSync.Parameters<typeof config>
+
+  const sellSync = dex.useSellSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sellSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.sellSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sellSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.sellSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sellSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.sellSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.sellSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.sellSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(sellSync.data).toEqualTypeOf<
+    Actions.dex.sellSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    sellSync.error,
+  ).toEqualTypeOf<Actions.dex.sellSync.ErrorType | null>()
+  expectTypeOf(sellSync.variables).toEqualTypeOf<
+    Actions.dex.sellSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(sellSync.context).toEqualTypeOf<Context | undefined>()
+
+  sellSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.sellSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.sellSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.sellSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.sellSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.sellSync.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.sellSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.sellSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWithdraw', () => {
+  const variables = {} as Actions.dex.withdraw.Parameters<typeof config>
+
+  const withdraw = dex.useWithdraw({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdraw.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.withdraw.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdraw.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.withdraw.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdraw.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.withdraw.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.withdraw.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdraw.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(withdraw.data).toEqualTypeOf<
+    Actions.dex.withdraw.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    withdraw.error,
+  ).toEqualTypeOf<Actions.dex.withdraw.ErrorType | null>()
+  expectTypeOf(withdraw.variables).toEqualTypeOf<
+    Actions.dex.withdraw.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(withdraw.context).toEqualTypeOf<Context | undefined>()
+
+  withdraw.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.withdraw.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.withdraw.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.withdraw.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.withdraw.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.withdraw.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.withdraw.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.withdraw.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.dex.withdrawSync.Parameters<typeof config>
+
+  const withdrawSync = dex.useWithdrawSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdrawSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.dex.withdrawSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdrawSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.dex.withdrawSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdrawSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.dex.withdrawSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.dex.withdrawSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.dex.withdrawSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(withdrawSync.data).toEqualTypeOf<
+    Actions.dex.withdrawSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    withdrawSync.error,
+  ).toEqualTypeOf<Actions.dex.withdrawSync.ErrorType | null>()
+  expectTypeOf(withdrawSync.variables).toEqualTypeOf<
+    Actions.dex.withdrawSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(withdrawSync.context).toEqualTypeOf<Context | undefined>()
+
+  withdrawSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.dex.withdrawSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.withdrawSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.dex.withdrawSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.withdrawSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.dex.withdrawSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.dex.withdrawSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.dex.withdrawSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWatchFlipOrderPlaced', () => {
+  dex.useWatchFlipOrderPlaced({
+    config,
+    enabled: true,
+    onFlipOrderPlaced(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchOrderCancelled', () => {
+  dex.useWatchOrderCancelled({
+    config,
+    enabled: true,
+    onOrderCancelled(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchOrderFilled', () => {
+  dex.useWatchOrderFilled({
+    config,
+    enabled: true,
+    onOrderFilled(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchOrderPlaced', () => {
+  dex.useWatchOrderPlaced({
+    config,
+    enabled: true,
+    onOrderPlaced(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/faucet.test-d.ts
+++ b/packages/react/src/tempo/hooks/faucet.test-d.ts
@@ -1,0 +1,174 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as faucet from './faucet.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useFund', () => {
+  const variables = {} as Actions.faucet.fund.Parameters<typeof config>
+
+  const fund = faucet.useFund({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fund.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.faucet.fund.ErrorType>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fund.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.faucet.fund.ReturnValue>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fund.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.faucet.fund.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.faucet.fund.ErrorType | null>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fund.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(fund.data).toEqualTypeOf<
+    Actions.faucet.fund.ReturnValue | undefined
+  >()
+  expectTypeOf(fund.error).toEqualTypeOf<Actions.faucet.fund.ErrorType | null>()
+  expectTypeOf(fund.variables).toEqualTypeOf<
+    Actions.faucet.fund.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(fund.context).toEqualTypeOf<Context | undefined>()
+
+  fund.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.faucet.fund.ErrorType>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.faucet.fund.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.faucet.fund.ReturnValue>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.faucet.fund.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.faucet.fund.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.faucet.fund.ErrorType | null>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.faucet.fund.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.faucet.fundSync.Parameters<typeof config>
+
+  const fundSync = faucet.useFundSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fundSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.faucet.fundSync.ErrorType>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fundSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.faucet.fundSync.ReturnValue>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fundSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.faucet.fundSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.faucet.fundSync.ErrorType | null>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.faucet.fundSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(fundSync.data).toEqualTypeOf<
+    Actions.faucet.fundSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    fundSync.error,
+  ).toEqualTypeOf<Actions.faucet.fundSync.ErrorType | null>()
+  expectTypeOf(fundSync.variables).toEqualTypeOf<
+    Actions.faucet.fundSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(fundSync.context).toEqualTypeOf<Context | undefined>()
+
+  fundSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.faucet.fundSync.ErrorType>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.faucet.fundSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.faucet.fundSync.ReturnValue>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.faucet.fundSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.faucet.fundSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.faucet.fundSync.ErrorType | null>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.faucet.fundSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/fee.test-d.ts
+++ b/packages/react/src/tempo/hooks/fee.test-d.ts
@@ -1,0 +1,214 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as fee from './fee.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useUserToken', () => {
+  const result = fee.useUserToken({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.fee.getUserToken.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useSetUserToken', () => {
+  const variables = {} as Actions.fee.setUserToken.Parameters<typeof config>
+
+  const setUserToken = fee.useSetUserToken({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserToken.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.fee.setUserToken.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.fee.setUserToken.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.fee.setUserToken.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.fee.setUserToken.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setUserToken.data).toEqualTypeOf<
+    Actions.fee.setUserToken.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setUserToken.error,
+  ).toEqualTypeOf<Actions.fee.setUserToken.ErrorType | null>()
+  expectTypeOf(setUserToken.variables).toEqualTypeOf<
+    Actions.fee.setUserToken.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setUserToken.context).toEqualTypeOf<Context | undefined>()
+
+  setUserToken.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.fee.setUserToken.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.fee.setUserToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.fee.setUserToken.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.fee.setUserToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.fee.setUserToken.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.fee.setUserToken.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.fee.setUserToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.fee.setUserTokenSync.Parameters<
+    typeof config
+  >
+
+  const setUserTokenSync = fee.useSetUserTokenSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserTokenSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.fee.setUserTokenSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.fee.setUserTokenSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.fee.setUserTokenSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.fee.setUserTokenSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.fee.setUserTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setUserTokenSync.data).toEqualTypeOf<
+    Actions.fee.setUserTokenSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setUserTokenSync.error,
+  ).toEqualTypeOf<Actions.fee.setUserTokenSync.ErrorType | null>()
+  expectTypeOf(setUserTokenSync.variables).toEqualTypeOf<
+    Actions.fee.setUserTokenSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setUserTokenSync.context).toEqualTypeOf<Context | undefined>()
+
+  setUserTokenSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.fee.setUserTokenSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.fee.setUserTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.fee.setUserTokenSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.fee.setUserTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.fee.setUserTokenSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.fee.setUserTokenSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.fee.setUserTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWatchSetUserToken', () => {
+  fee.useWatchSetUserToken({
+    config,
+    enabled: true,
+    onUserTokenSet(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/nonce.test-d.ts
+++ b/packages/react/src/tempo/hooks/nonce.test-d.ts
@@ -1,0 +1,28 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as nonce from './nonce.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+test('useNonce', () => {
+  const result = nonce.useNonce({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.nonce.getNonce.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})

--- a/packages/react/src/tempo/hooks/policy.test-d.ts
+++ b/packages/react/src/tempo/hooks/policy.test-d.ts
@@ -1,0 +1,791 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as policy from './policy.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useData', () => {
+  const result = policy.useData({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.policy.getData.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useIsAuthorized', () => {
+  const result = policy.useIsAuthorized({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.isAuthorized.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useCreate', () => {
+  const variables = {} as Actions.policy.create.Parameters<typeof config>
+
+  const create = policy.useCreate({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.create.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.policy.create.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.create.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.policy.create.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.create.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.create.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.create.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.create.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(create.data).toEqualTypeOf<
+    Actions.policy.create.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    create.error,
+  ).toEqualTypeOf<Actions.policy.create.ErrorType | null>()
+  expectTypeOf(create.variables).toEqualTypeOf<
+    Actions.policy.create.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(create.context).toEqualTypeOf<Context | undefined>()
+
+  create.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.policy.create.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.create.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.policy.create.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.create.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.create.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.create.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.create.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.policy.createSync.Parameters<
+    typeof config
+  >
+
+  const createSync = policy.useCreateSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.createSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.policy.createSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.createSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.createSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.createSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.createSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.createSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.createSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(createSync.data).toEqualTypeOf<
+    Actions.policy.createSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    createSync.error,
+  ).toEqualTypeOf<Actions.policy.createSync.ErrorType | null>()
+  expectTypeOf(createSync.variables).toEqualTypeOf<
+    Actions.policy.createSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(createSync.context).toEqualTypeOf<Context | undefined>()
+
+  createSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.policy.createSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.createSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.policy.createSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.createSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.createSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.createSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.createSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useSetAdmin', () => {
+  const variables = {} as Actions.policy.setAdmin.Parameters<typeof config>
+
+  const setAdmin = policy.useSetAdmin({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdmin.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.policy.setAdmin.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdmin.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.policy.setAdmin.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdmin.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.setAdmin.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.setAdmin.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdmin.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setAdmin.data).toEqualTypeOf<
+    Actions.policy.setAdmin.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setAdmin.error,
+  ).toEqualTypeOf<Actions.policy.setAdmin.ErrorType | null>()
+  expectTypeOf(setAdmin.variables).toEqualTypeOf<
+    Actions.policy.setAdmin.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setAdmin.context).toEqualTypeOf<Context | undefined>()
+
+  setAdmin.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.policy.setAdmin.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.setAdmin.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.policy.setAdmin.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.setAdmin.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.setAdmin.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.setAdmin.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.setAdmin.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.policy.setAdminSync.Parameters<
+    typeof config
+  >
+
+  const setAdminSync = policy.useSetAdminSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdminSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.setAdminSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdminSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.setAdminSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdminSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.setAdminSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.setAdminSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.setAdminSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setAdminSync.data).toEqualTypeOf<
+    Actions.policy.setAdminSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setAdminSync.error,
+  ).toEqualTypeOf<Actions.policy.setAdminSync.ErrorType | null>()
+  expectTypeOf(setAdminSync.variables).toEqualTypeOf<
+    Actions.policy.setAdminSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setAdminSync.context).toEqualTypeOf<Context | undefined>()
+
+  setAdminSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.policy.setAdminSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.setAdminSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.policy.setAdminSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.setAdminSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.setAdminSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.setAdminSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.setAdminSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useModifyWhitelist', () => {
+  const variables = {} as Actions.policy.modifyWhitelist.Parameters<
+    typeof config
+  >
+
+  const modifyWhitelist = policy.useModifyWhitelist({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelist.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyWhitelist.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelist.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.modifyWhitelist.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelist.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.modifyWhitelist.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyWhitelist.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelist.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(modifyWhitelist.data).toEqualTypeOf<
+    Actions.policy.modifyWhitelist.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    modifyWhitelist.error,
+  ).toEqualTypeOf<Actions.policy.modifyWhitelist.ErrorType | null>()
+  expectTypeOf(modifyWhitelist.variables).toEqualTypeOf<
+    Actions.policy.modifyWhitelist.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(modifyWhitelist.context).toEqualTypeOf<Context | undefined>()
+
+  modifyWhitelist.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyWhitelist.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyWhitelist.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.policy.modifyWhitelist.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyWhitelist.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.modifyWhitelist.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyWhitelist.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyWhitelist.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.policy.modifyWhitelistSync.Parameters<
+    typeof config
+  >
+
+  const modifyWhitelistSync = policy.useModifyWhitelistSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.modifyWhitelistSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(modifyWhitelistSync.data).toEqualTypeOf<
+    Actions.policy.modifyWhitelistSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    modifyWhitelistSync.error,
+  ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ErrorType | null>()
+  expectTypeOf(modifyWhitelistSync.variables).toEqualTypeOf<
+    Actions.policy.modifyWhitelistSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(modifyWhitelistSync.context).toEqualTypeOf<Context | undefined>()
+
+  modifyWhitelistSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.modifyWhitelistSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyWhitelistSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyWhitelistSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useModifyBlacklist', () => {
+  const variables = {} as Actions.policy.modifyBlacklist.Parameters<
+    typeof config
+  >
+
+  const modifyBlacklist = policy.useModifyBlacklist({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklist.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyBlacklist.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklist.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.modifyBlacklist.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklist.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.modifyBlacklist.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyBlacklist.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklist.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(modifyBlacklist.data).toEqualTypeOf<
+    Actions.policy.modifyBlacklist.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    modifyBlacklist.error,
+  ).toEqualTypeOf<Actions.policy.modifyBlacklist.ErrorType | null>()
+  expectTypeOf(modifyBlacklist.variables).toEqualTypeOf<
+    Actions.policy.modifyBlacklist.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(modifyBlacklist.context).toEqualTypeOf<Context | undefined>()
+
+  modifyBlacklist.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyBlacklist.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyBlacklist.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.policy.modifyBlacklist.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyBlacklist.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.modifyBlacklist.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyBlacklist.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyBlacklist.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.policy.modifyBlacklistSync.Parameters<
+    typeof config
+  >
+
+  const modifyBlacklistSync = policy.useModifyBlacklistSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.policy.modifyBlacklistSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(modifyBlacklistSync.data).toEqualTypeOf<
+    Actions.policy.modifyBlacklistSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    modifyBlacklistSync.error,
+  ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ErrorType | null>()
+  expectTypeOf(modifyBlacklistSync.variables).toEqualTypeOf<
+    Actions.policy.modifyBlacklistSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(modifyBlacklistSync.context).toEqualTypeOf<Context | undefined>()
+
+  modifyBlacklistSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.policy.modifyBlacklistSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.policy.modifyBlacklistSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.policy.modifyBlacklistSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWatchCreate', () => {
+  policy.useWatchCreate({
+    config,
+    enabled: true,
+    onPolicyCreated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchAdminUpdated', () => {
+  policy.useWatchAdminUpdated({
+    config,
+    enabled: true,
+    onAdminUpdated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchWhitelistUpdated', () => {
+  policy.useWatchWhitelistUpdated({
+    config,
+    enabled: true,
+    onWhitelistUpdated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchBlacklistUpdated', () => {
+  policy.useWatchBlacklistUpdated({
+    config,
+    enabled: true,
+    onBlacklistUpdated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/reward.test-d.ts
+++ b/packages/react/src/tempo/hooks/reward.test-d.ts
@@ -1,0 +1,583 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as reward from './reward.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useGetGlobalRewardPerToken', () => {
+  const result = reward.useGetGlobalRewardPerToken({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.reward.getGlobalRewardPerToken.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useUserRewardInfo', () => {
+  const result = reward.useUserRewardInfo({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.reward.getUserRewardInfo.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useClaim', () => {
+  const variables = {} as Actions.reward.claim.Parameters<typeof config>
+
+  const claim = reward.useClaim({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claim.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.reward.claim.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claim.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.reward.claim.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claim.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.reward.claim.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.claim.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claim.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(claim.data).toEqualTypeOf<
+    Actions.reward.claim.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    claim.error,
+  ).toEqualTypeOf<Actions.reward.claim.ErrorType | null>()
+  expectTypeOf(claim.variables).toEqualTypeOf<
+    Actions.reward.claim.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(claim.context).toEqualTypeOf<Context | undefined>()
+
+  claim.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.reward.claim.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.claim.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.reward.claim.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.claim.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.reward.claim.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.reward.claim.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.claim.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.reward.claimSync.Parameters<typeof config>
+
+  const claimSync = reward.useClaimSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claimSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.reward.claimSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claimSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.reward.claimSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claimSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.reward.claimSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.claimSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.claimSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(claimSync.data).toEqualTypeOf<
+    Actions.reward.claimSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    claimSync.error,
+  ).toEqualTypeOf<Actions.reward.claimSync.ErrorType | null>()
+  expectTypeOf(claimSync.variables).toEqualTypeOf<
+    Actions.reward.claimSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(claimSync.context).toEqualTypeOf<Context | undefined>()
+
+  claimSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.reward.claimSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.claimSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.reward.claimSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.claimSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.reward.claimSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.claimSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.claimSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useSetRecipient', () => {
+  const variables = {} as Actions.reward.setRecipient.Parameters<typeof config>
+
+  const setRecipient = reward.useSetRecipient({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipient.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.setRecipient.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipient.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.reward.setRecipient.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipient.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.reward.setRecipient.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.setRecipient.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipient.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setRecipient.data).toEqualTypeOf<
+    Actions.reward.setRecipient.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setRecipient.error,
+  ).toEqualTypeOf<Actions.reward.setRecipient.ErrorType | null>()
+  expectTypeOf(setRecipient.variables).toEqualTypeOf<
+    Actions.reward.setRecipient.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setRecipient.context).toEqualTypeOf<Context | undefined>()
+
+  setRecipient.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.reward.setRecipient.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.setRecipient.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.reward.setRecipient.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.setRecipient.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.reward.setRecipient.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.setRecipient.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.setRecipient.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.reward.setRecipientSync.Parameters<
+    typeof config
+  >
+
+  const setRecipientSync = reward.useSetRecipientSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipientSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.setRecipientSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipientSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.reward.setRecipientSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipientSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.reward.setRecipientSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.setRecipientSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.setRecipientSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setRecipientSync.data).toEqualTypeOf<
+    Actions.reward.setRecipientSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setRecipientSync.error,
+  ).toEqualTypeOf<Actions.reward.setRecipientSync.ErrorType | null>()
+  expectTypeOf(setRecipientSync.variables).toEqualTypeOf<
+    Actions.reward.setRecipientSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setRecipientSync.context).toEqualTypeOf<Context | undefined>()
+
+  setRecipientSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.setRecipientSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.setRecipientSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.reward.setRecipientSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.setRecipientSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.reward.setRecipientSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.setRecipientSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.setRecipientSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useDistribute', () => {
+  const variables = {} as Actions.reward.distribute.Parameters<typeof config>
+
+  const distribute = reward.useDistribute({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distribute.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.reward.distribute.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distribute.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.reward.distribute.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distribute.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.reward.distribute.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.distribute.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distribute.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(distribute.data).toEqualTypeOf<
+    Actions.reward.distribute.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    distribute.error,
+  ).toEqualTypeOf<Actions.reward.distribute.ErrorType | null>()
+  expectTypeOf(distribute.variables).toEqualTypeOf<
+    Actions.reward.distribute.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(distribute.context).toEqualTypeOf<Context | undefined>()
+
+  distribute.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.reward.distribute.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.distribute.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.reward.distribute.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.distribute.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.reward.distribute.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.distribute.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.distribute.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.reward.distributeSync.Parameters<
+    typeof config
+  >
+
+  const distributeSync = reward.useDistributeSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distributeSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.distributeSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distributeSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.reward.distributeSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distributeSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.reward.distributeSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.reward.distributeSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.reward.distributeSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(distributeSync.data).toEqualTypeOf<
+    Actions.reward.distributeSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    distributeSync.error,
+  ).toEqualTypeOf<Actions.reward.distributeSync.ErrorType | null>()
+  expectTypeOf(distributeSync.variables).toEqualTypeOf<
+    Actions.reward.distributeSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(distributeSync.context).toEqualTypeOf<Context | undefined>()
+
+  distributeSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.distributeSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.distributeSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.reward.distributeSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.distributeSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.reward.distributeSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.reward.distributeSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.reward.distributeSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWatchRewardDistributed', () => {
+  reward.useWatchRewardDistributed({
+    config,
+    enabled: true,
+    onRewardDistributed(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchRewardRecipientSet', () => {
+  reward.useWatchRewardRecipientSet({
+    config,
+    enabled: true,
+    onRewardRecipientSet(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/token.test-d.ts
+++ b/packages/react/src/tempo/hooks/token.test-d.ts
@@ -1,0 +1,2919 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as token from './token.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+const selected = 'selected' as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useGetAllowance', () => {
+  const result = token.useGetAllowance({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.getAllowance.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useGetBalance', () => {
+  const result = token.useGetBalance({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.getBalance.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useGetMetadata', () => {
+  const result = token.useGetMetadata({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.getMetadata.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useGetRoleAdmin', () => {
+  const result = token.useGetRoleAdmin({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.getRoleAdmin.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useHasRole', () => {
+  const result = token.useHasRole({
+    config,
+    query: {
+      select(data) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.hasRole.ReturnValue>()
+        return selected
+      },
+    },
+  })
+
+  expectTypeOf(result.data).toEqualTypeOf<typeof selected | undefined>()
+})
+
+test('useApprove', () => {
+  const variables = {} as Actions.token.approve.Parameters<typeof config>
+
+  const approve = token.useApprove({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.approve.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.approve.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.approve.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.approve.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.approve.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.approve.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.approve.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.approve.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(approve.data).toEqualTypeOf<
+    Actions.token.approve.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    approve.error,
+  ).toEqualTypeOf<Actions.token.approve.ErrorType | null>()
+  expectTypeOf(approve.variables).toEqualTypeOf<
+    Actions.token.approve.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(approve.context).toEqualTypeOf<Context | undefined>()
+
+  approve.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.approve.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.approve.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.approve.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.approve.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.approve.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.approve.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.approve.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.approveSync.Parameters<
+    typeof config
+  >
+
+  const approveSync = token.useApproveSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.approveSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.approveSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.approveSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.approveSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.approveSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.approveSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.approveSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.approveSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(approveSync.data).toEqualTypeOf<
+    Actions.token.approveSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    approveSync.error,
+  ).toEqualTypeOf<Actions.token.approveSync.ErrorType | null>()
+  expectTypeOf(approveSync.variables).toEqualTypeOf<
+    Actions.token.approveSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(approveSync.context).toEqualTypeOf<Context | undefined>()
+
+  approveSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.approveSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.approveSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.approveSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.approveSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.approveSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.approveSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.approveSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useBurn', () => {
+  const variables = {} as Actions.token.burn.Parameters<typeof config>
+
+  const burn = token.useBurn({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.burn.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.burn.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burn.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.burn.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burn.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.burn.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.token.burn.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burn.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(burn.data).toEqualTypeOf<
+    Actions.token.burn.ReturnValue | undefined
+  >()
+  expectTypeOf(burn.error).toEqualTypeOf<Actions.token.burn.ErrorType | null>()
+  expectTypeOf(burn.variables).toEqualTypeOf<
+    Actions.token.burn.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(burn.context).toEqualTypeOf<Context | undefined>()
+
+  burn.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.burn.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burn.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.burn.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burn.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.burn.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.token.burn.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burn.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.burnSync.Parameters<typeof config>
+
+  const burnSync = token.useBurnSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.burnSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.burnSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.burnSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.burnSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(burnSync.data).toEqualTypeOf<
+    Actions.token.burnSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    burnSync.error,
+  ).toEqualTypeOf<Actions.token.burnSync.ErrorType | null>()
+  expectTypeOf(burnSync.variables).toEqualTypeOf<
+    Actions.token.burnSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(burnSync.context).toEqualTypeOf<Context | undefined>()
+
+  burnSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.burnSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.burnSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.burnSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.burnSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useBurnBlocked', () => {
+  const variables = {} as Actions.token.burnBlocked.Parameters<typeof config>
+
+  const burnBlocked = token.useBurnBlocked({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlocked.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.burnBlocked.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlocked.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.burnBlocked.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlocked.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.burnBlocked.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.burnBlocked.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlocked.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(burnBlocked.data).toEqualTypeOf<
+    Actions.token.burnBlocked.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    burnBlocked.error,
+  ).toEqualTypeOf<Actions.token.burnBlocked.ErrorType | null>()
+  expectTypeOf(burnBlocked.variables).toEqualTypeOf<
+    Actions.token.burnBlocked.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(burnBlocked.context).toEqualTypeOf<Context | undefined>()
+
+  burnBlocked.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.burnBlocked.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnBlocked.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.burnBlocked.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnBlocked.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.burnBlocked.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.burnBlocked.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnBlocked.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.burnBlockedSync.Parameters<
+    typeof config
+  >
+
+  const burnBlockedSync = token.useBurnBlockedSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlockedSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.burnBlockedSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlockedSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.burnBlockedSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlockedSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.burnBlockedSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.burnBlockedSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.burnBlockedSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(burnBlockedSync.data).toEqualTypeOf<
+    Actions.token.burnBlockedSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    burnBlockedSync.error,
+  ).toEqualTypeOf<Actions.token.burnBlockedSync.ErrorType | null>()
+  expectTypeOf(burnBlockedSync.variables).toEqualTypeOf<
+    Actions.token.burnBlockedSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(burnBlockedSync.context).toEqualTypeOf<Context | undefined>()
+
+  burnBlockedSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.burnBlockedSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnBlockedSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.burnBlockedSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnBlockedSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.burnBlockedSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.burnBlockedSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.burnBlockedSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useChangeTransferPolicy', () => {
+  const variables = {} as Actions.token.changeTransferPolicy.Parameters<
+    typeof config
+  >
+
+  const changeTransferPolicy = token.useChangeTransferPolicy({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicy.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.changeTransferPolicy.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicy.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.changeTransferPolicy.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicy.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.changeTransferPolicy.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.changeTransferPolicy.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicy.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(changeTransferPolicy.data).toEqualTypeOf<
+    Actions.token.changeTransferPolicy.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    changeTransferPolicy.error,
+  ).toEqualTypeOf<Actions.token.changeTransferPolicy.ErrorType | null>()
+  expectTypeOf(changeTransferPolicy.variables).toEqualTypeOf<
+    Actions.token.changeTransferPolicy.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(changeTransferPolicy.context).toEqualTypeOf<
+    Context | undefined
+  >()
+
+  changeTransferPolicy.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.changeTransferPolicy.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.changeTransferPolicy.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.changeTransferPolicy.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.changeTransferPolicy.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.changeTransferPolicy.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.changeTransferPolicy.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.changeTransferPolicy.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.changeTransferPolicySync.Parameters<
+    typeof config
+  >
+
+  const changeTransferPolicySync = token.useChangeTransferPolicySync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicySync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicySync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicySync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.changeTransferPolicySync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.changeTransferPolicySync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(changeTransferPolicySync.data).toEqualTypeOf<
+    Actions.token.changeTransferPolicySync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    changeTransferPolicySync.error,
+  ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ErrorType | null>()
+  expectTypeOf(changeTransferPolicySync.variables).toEqualTypeOf<
+    Actions.token.changeTransferPolicySync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(changeTransferPolicySync.context).toEqualTypeOf<
+    Context | undefined
+  >()
+
+  changeTransferPolicySync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.changeTransferPolicySync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.changeTransferPolicySync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.changeTransferPolicySync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.changeTransferPolicySync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.changeTransferPolicySync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useCreate', () => {
+  const variables = {} as Actions.token.create.Parameters<typeof config>
+
+  const create = token.useCreate({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.create.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.create.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.create.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.create.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.create.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.create.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.create.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.create.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(create.data).toEqualTypeOf<
+    Actions.token.create.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    create.error,
+  ).toEqualTypeOf<Actions.token.create.ErrorType | null>()
+  expectTypeOf(create.variables).toEqualTypeOf<
+    Actions.token.create.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(create.context).toEqualTypeOf<Context | undefined>()
+
+  create.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.create.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.create.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.create.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.create.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.create.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.token.create.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.create.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.createSync.Parameters<typeof config>
+
+  const createSync = token.useCreateSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.createSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.createSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.createSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.createSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.createSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.createSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.createSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.createSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(createSync.data).toEqualTypeOf<
+    Actions.token.createSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    createSync.error,
+  ).toEqualTypeOf<Actions.token.createSync.ErrorType | null>()
+  expectTypeOf(createSync.variables).toEqualTypeOf<
+    Actions.token.createSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(createSync.context).toEqualTypeOf<Context | undefined>()
+
+  createSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.createSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.createSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.createSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.createSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.createSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.createSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.createSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useUpdateQuoteToken', () => {
+  const variables = {} as Actions.token.updateQuoteToken.Parameters<
+    typeof config
+  >
+
+  const updateQuoteToken = token.useUpdateQuoteToken({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteToken.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.updateQuoteToken.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.updateQuoteToken.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.updateQuoteToken.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.updateQuoteToken.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(updateQuoteToken.data).toEqualTypeOf<
+    Actions.token.updateQuoteToken.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    updateQuoteToken.error,
+  ).toEqualTypeOf<Actions.token.updateQuoteToken.ErrorType | null>()
+  expectTypeOf(updateQuoteToken.variables).toEqualTypeOf<
+    Actions.token.updateQuoteToken.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(updateQuoteToken.context).toEqualTypeOf<Context | undefined>()
+
+  updateQuoteToken.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.updateQuoteToken.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.updateQuoteToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.updateQuoteToken.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.updateQuoteToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.updateQuoteToken.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.updateQuoteToken.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.updateQuoteToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.updateQuoteTokenSync.Parameters<
+    typeof config
+  >
+
+  const updateQuoteTokenSync = token.useUpdateQuoteTokenSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.updateQuoteTokenSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(updateQuoteTokenSync.data).toEqualTypeOf<
+    Actions.token.updateQuoteTokenSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    updateQuoteTokenSync.error,
+  ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ErrorType | null>()
+  expectTypeOf(updateQuoteTokenSync.variables).toEqualTypeOf<
+    Actions.token.updateQuoteTokenSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(updateQuoteTokenSync.context).toEqualTypeOf<
+    Context | undefined
+  >()
+
+  updateQuoteTokenSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.updateQuoteTokenSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.updateQuoteTokenSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.updateQuoteTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useGrantRoles', () => {
+  const variables = {} as Actions.token.grantRoles.Parameters<typeof config>
+
+  const grantRoles = token.useGrantRoles({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRoles.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.grantRoles.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.grantRoles.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.grantRoles.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.grantRoles.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(grantRoles.data).toEqualTypeOf<
+    Actions.token.grantRoles.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    grantRoles.error,
+  ).toEqualTypeOf<Actions.token.grantRoles.ErrorType | null>()
+  expectTypeOf(grantRoles.variables).toEqualTypeOf<
+    Actions.token.grantRoles.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(grantRoles.context).toEqualTypeOf<Context | undefined>()
+
+  grantRoles.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.grantRoles.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.grantRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.grantRoles.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.grantRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.grantRoles.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.grantRoles.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.grantRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.grantRolesSync.Parameters<
+    typeof config
+  >
+
+  const grantRolesSync = token.useGrantRolesSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRolesSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.grantRolesSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.grantRolesSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.grantRolesSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.grantRolesSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.grantRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(grantRolesSync.data).toEqualTypeOf<
+    Actions.token.grantRolesSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    grantRolesSync.error,
+  ).toEqualTypeOf<Actions.token.grantRolesSync.ErrorType | null>()
+  expectTypeOf(grantRolesSync.variables).toEqualTypeOf<
+    Actions.token.grantRolesSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(grantRolesSync.context).toEqualTypeOf<Context | undefined>()
+
+  grantRolesSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.grantRolesSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.grantRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.grantRolesSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.grantRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.grantRolesSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.grantRolesSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.grantRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useMint', () => {
+  const variables = {} as Actions.token.mint.Parameters<typeof config>
+
+  const mint = token.useMint({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.mint.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.mint.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.mint.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.mint.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.mint.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.mint.ReturnValue | undefined
+        >()
+        expectTypeOf(error).toEqualTypeOf<Actions.token.mint.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.mint.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(mint.data).toEqualTypeOf<
+    Actions.token.mint.ReturnValue | undefined
+  >()
+  expectTypeOf(mint.error).toEqualTypeOf<Actions.token.mint.ErrorType | null>()
+  expectTypeOf(mint.variables).toEqualTypeOf<
+    Actions.token.mint.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(mint.context).toEqualTypeOf<Context | undefined>()
+
+  mint.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.mint.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.mint.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.mint.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.mint.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.mint.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.token.mint.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.mint.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.mintSync.Parameters<typeof config>
+
+  const mintSync = token.useMintSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.mintSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.mintSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.mintSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.mintSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.mintSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.mintSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.mintSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.mintSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(mintSync.data).toEqualTypeOf<
+    Actions.token.mintSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    mintSync.error,
+  ).toEqualTypeOf<Actions.token.mintSync.ErrorType | null>()
+  expectTypeOf(mintSync.variables).toEqualTypeOf<
+    Actions.token.mintSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(mintSync.context).toEqualTypeOf<Context | undefined>()
+
+  mintSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.mintSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.mintSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.mintSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.mintSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.mintSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.mintSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.mintSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('usePause', () => {
+  const variables = {} as Actions.token.pause.Parameters<typeof config>
+
+  const pause = token.usePause({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.pause.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.pause.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.pause.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.pause.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.pause.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.pause.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.pause.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.pause.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(pause.data).toEqualTypeOf<
+    Actions.token.pause.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    pause.error,
+  ).toEqualTypeOf<Actions.token.pause.ErrorType | null>()
+  expectTypeOf(pause.variables).toEqualTypeOf<
+    Actions.token.pause.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(pause.context).toEqualTypeOf<Context | undefined>()
+
+  pause.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.pause.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.pause.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.pause.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.pause.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.pause.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.token.pause.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.pause.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.pauseSync.Parameters<typeof config>
+
+  const pauseSync = token.usePauseSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.pauseSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.pauseSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.pauseSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.pauseSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.pauseSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.pauseSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.pauseSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.pauseSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(pauseSync.data).toEqualTypeOf<
+    Actions.token.pauseSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    pauseSync.error,
+  ).toEqualTypeOf<Actions.token.pauseSync.ErrorType | null>()
+  expectTypeOf(pauseSync.variables).toEqualTypeOf<
+    Actions.token.pauseSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(pauseSync.context).toEqualTypeOf<Context | undefined>()
+
+  pauseSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.pauseSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.pauseSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.pauseSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.pauseSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.pauseSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.pauseSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.pauseSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useRenounceRoles', () => {
+  const variables = {} as Actions.token.renounceRoles.Parameters<typeof config>
+
+  const renounceRoles = token.useRenounceRoles({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRoles.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.renounceRoles.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.renounceRoles.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.renounceRoles.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.renounceRoles.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(renounceRoles.data).toEqualTypeOf<
+    Actions.token.renounceRoles.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    renounceRoles.error,
+  ).toEqualTypeOf<Actions.token.renounceRoles.ErrorType | null>()
+  expectTypeOf(renounceRoles.variables).toEqualTypeOf<
+    Actions.token.renounceRoles.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(renounceRoles.context).toEqualTypeOf<Context | undefined>()
+
+  renounceRoles.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.renounceRoles.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.renounceRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.renounceRoles.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.renounceRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.renounceRoles.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.renounceRoles.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.renounceRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.renounceRolesSync.Parameters<
+    typeof config
+  >
+
+  const renounceRolesSync = token.useRenounceRolesSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRolesSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.renounceRolesSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.renounceRolesSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.renounceRolesSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.renounceRolesSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.renounceRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(renounceRolesSync.data).toEqualTypeOf<
+    Actions.token.renounceRolesSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    renounceRolesSync.error,
+  ).toEqualTypeOf<Actions.token.renounceRolesSync.ErrorType | null>()
+  expectTypeOf(renounceRolesSync.variables).toEqualTypeOf<
+    Actions.token.renounceRolesSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(renounceRolesSync.context).toEqualTypeOf<Context | undefined>()
+
+  renounceRolesSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.renounceRolesSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.renounceRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.renounceRolesSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.renounceRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.renounceRolesSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.renounceRolesSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.renounceRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useRevokeRoles', () => {
+  const variables = {} as Actions.token.revokeRoles.Parameters<typeof config>
+
+  const revokeRoles = token.useRevokeRoles({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRoles.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.revokeRoles.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.revokeRoles.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.revokeRoles.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.revokeRoles.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRoles.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(revokeRoles.data).toEqualTypeOf<
+    Actions.token.revokeRoles.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    revokeRoles.error,
+  ).toEqualTypeOf<Actions.token.revokeRoles.ErrorType | null>()
+  expectTypeOf(revokeRoles.variables).toEqualTypeOf<
+    Actions.token.revokeRoles.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(revokeRoles.context).toEqualTypeOf<Context | undefined>()
+
+  revokeRoles.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.revokeRoles.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.revokeRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.revokeRoles.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.revokeRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.revokeRoles.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.revokeRoles.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.revokeRoles.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.revokeRolesSync.Parameters<
+    typeof config
+  >
+
+  const revokeRolesSync = token.useRevokeRolesSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRolesSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.revokeRolesSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.revokeRolesSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.revokeRolesSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.revokeRolesSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.revokeRolesSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(revokeRolesSync.data).toEqualTypeOf<
+    Actions.token.revokeRolesSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    revokeRolesSync.error,
+  ).toEqualTypeOf<Actions.token.revokeRolesSync.ErrorType | null>()
+  expectTypeOf(revokeRolesSync.variables).toEqualTypeOf<
+    Actions.token.revokeRolesSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(revokeRolesSync.context).toEqualTypeOf<Context | undefined>()
+
+  revokeRolesSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.revokeRolesSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.revokeRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.revokeRolesSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.revokeRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.revokeRolesSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.revokeRolesSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.revokeRolesSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useSetRoleAdmin', () => {
+  const variables = {} as Actions.token.setRoleAdmin.Parameters<typeof config>
+
+  const setRoleAdmin = token.useSetRoleAdmin({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdmin.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setRoleAdmin.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdmin.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.setRoleAdmin.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdmin.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.setRoleAdmin.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setRoleAdmin.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdmin.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setRoleAdmin.data).toEqualTypeOf<
+    Actions.token.setRoleAdmin.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setRoleAdmin.error,
+  ).toEqualTypeOf<Actions.token.setRoleAdmin.ErrorType | null>()
+  expectTypeOf(setRoleAdmin.variables).toEqualTypeOf<
+    Actions.token.setRoleAdmin.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setRoleAdmin.context).toEqualTypeOf<Context | undefined>()
+
+  setRoleAdmin.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.setRoleAdmin.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setRoleAdmin.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.setRoleAdmin.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setRoleAdmin.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.setRoleAdmin.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.setRoleAdmin.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setRoleAdmin.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.setRoleAdminSync.Parameters<
+    typeof config
+  >
+
+  const setRoleAdminSync = token.useSetRoleAdminSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdminSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setRoleAdminSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdminSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.setRoleAdminSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdminSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.setRoleAdminSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setRoleAdminSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setRoleAdminSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setRoleAdminSync.data).toEqualTypeOf<
+    Actions.token.setRoleAdminSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setRoleAdminSync.error,
+  ).toEqualTypeOf<Actions.token.setRoleAdminSync.ErrorType | null>()
+  expectTypeOf(setRoleAdminSync.variables).toEqualTypeOf<
+    Actions.token.setRoleAdminSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setRoleAdminSync.context).toEqualTypeOf<Context | undefined>()
+
+  setRoleAdminSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.setRoleAdminSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setRoleAdminSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.setRoleAdminSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setRoleAdminSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.setRoleAdminSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.setRoleAdminSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setRoleAdminSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useSetSupplyCap', () => {
+  const variables = {} as Actions.token.setSupplyCap.Parameters<typeof config>
+
+  const setSupplyCap = token.useSetSupplyCap({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCap.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setSupplyCap.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.setSupplyCap.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.setSupplyCap.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setSupplyCap.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setSupplyCap.data).toEqualTypeOf<
+    Actions.token.setSupplyCap.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setSupplyCap.error,
+  ).toEqualTypeOf<Actions.token.setSupplyCap.ErrorType | null>()
+  expectTypeOf(setSupplyCap.variables).toEqualTypeOf<
+    Actions.token.setSupplyCap.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setSupplyCap.context).toEqualTypeOf<Context | undefined>()
+
+  setSupplyCap.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.setSupplyCap.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setSupplyCap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.setSupplyCap.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setSupplyCap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.setSupplyCap.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.setSupplyCap.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setSupplyCap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.setSupplyCapSync.Parameters<
+    typeof config
+  >
+
+  const setSupplyCapSync = token.useSetSupplyCapSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCapSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setSupplyCapSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCapSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.setSupplyCapSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCapSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.setSupplyCapSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.setSupplyCapSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.setSupplyCapSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(setSupplyCapSync.data).toEqualTypeOf<
+    Actions.token.setSupplyCapSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    setSupplyCapSync.error,
+  ).toEqualTypeOf<Actions.token.setSupplyCapSync.ErrorType | null>()
+  expectTypeOf(setSupplyCapSync.variables).toEqualTypeOf<
+    Actions.token.setSupplyCapSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(setSupplyCapSync.context).toEqualTypeOf<Context | undefined>()
+
+  setSupplyCapSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.setSupplyCapSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setSupplyCapSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.setSupplyCapSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setSupplyCapSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.setSupplyCapSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.setSupplyCapSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.setSupplyCapSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useTransfer', () => {
+  const variables = {} as Actions.token.transfer.Parameters<typeof config>
+
+  const transfer = token.useTransfer({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.transfer.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.transfer.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.transfer.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.transfer.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.transfer.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.transfer.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.transfer.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.transfer.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(transfer.data).toEqualTypeOf<
+    Actions.token.transfer.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    transfer.error,
+  ).toEqualTypeOf<Actions.token.transfer.ErrorType | null>()
+  expectTypeOf(transfer.variables).toEqualTypeOf<
+    Actions.token.transfer.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(transfer.context).toEqualTypeOf<Context | undefined>()
+
+  transfer.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.transfer.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.transfer.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.transfer.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.transfer.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.transfer.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.transfer.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.transfer.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.transferSync.Parameters<
+    typeof config
+  >
+
+  const transferSync = token.useTransferSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.transferSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.transferSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.transferSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.transferSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.transferSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.transferSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.transferSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.transferSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(transferSync.data).toEqualTypeOf<
+    Actions.token.transferSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    transferSync.error,
+  ).toEqualTypeOf<Actions.token.transferSync.ErrorType | null>()
+  expectTypeOf(transferSync.variables).toEqualTypeOf<
+    Actions.token.transferSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(transferSync.context).toEqualTypeOf<Context | undefined>()
+
+  transferSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.transferSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.transferSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.transferSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.transferSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.transferSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.transferSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.transferSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useUnpause', () => {
+  const variables = {} as Actions.token.unpause.Parameters<typeof config>
+
+  const unpause = token.useUnpause({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpause.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.unpause.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpause.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.token.unpause.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpause.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.unpause.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.unpause.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpause.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(unpause.data).toEqualTypeOf<
+    Actions.token.unpause.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    unpause.error,
+  ).toEqualTypeOf<Actions.token.unpause.ErrorType | null>()
+  expectTypeOf(unpause.variables).toEqualTypeOf<
+    Actions.token.unpause.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(unpause.context).toEqualTypeOf<Context | undefined>()
+
+  unpause.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.unpause.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.unpause.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.unpause.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.unpause.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.unpause.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.unpause.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.unpause.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync = {} as Actions.token.unpauseSync.Parameters<
+    typeof config
+  >
+
+  const unpauseSync = token.useUnpauseSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpauseSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.token.unpauseSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpauseSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.unpauseSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpauseSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.unpauseSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.unpauseSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.unpauseSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(unpauseSync.data).toEqualTypeOf<
+    Actions.token.unpauseSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    unpauseSync.error,
+  ).toEqualTypeOf<Actions.token.unpauseSync.ErrorType | null>()
+  expectTypeOf(unpauseSync.variables).toEqualTypeOf<
+    Actions.token.unpauseSync.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(unpauseSync.context).toEqualTypeOf<Context | undefined>()
+
+  unpauseSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.token.unpauseSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.unpauseSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.token.unpauseSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.unpauseSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.unpauseSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.unpauseSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.unpauseSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('usePrepareUpdateQuoteToken', () => {
+  const variables = {} as Actions.token.prepareUpdateQuoteToken.Parameters<
+    typeof config
+  >
+
+  const prepareUpdateQuoteToken = token.usePrepareUpdateQuoteToken({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.prepareUpdateQuoteToken.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(prepareUpdateQuoteToken.data).toEqualTypeOf<
+    Actions.token.prepareUpdateQuoteToken.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    prepareUpdateQuoteToken.error,
+  ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ErrorType | null>()
+  expectTypeOf(prepareUpdateQuoteToken.variables).toEqualTypeOf<
+    Actions.token.prepareUpdateQuoteToken.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(prepareUpdateQuoteToken.context).toEqualTypeOf<
+    Context | undefined
+  >()
+
+  prepareUpdateQuoteToken.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.prepareUpdateQuoteToken.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.prepareUpdateQuoteToken.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.prepareUpdateQuoteToken.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+
+  const variablesSync =
+    {} as Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+
+  const prepareUpdateQuoteTokenSync = token.usePrepareUpdateQuoteTokenSync({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ErrorType>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(
+          data,
+        ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ReturnValue>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.token.prepareUpdateQuoteTokenSync.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ErrorType | null>()
+        expectTypeOf(variables).toExtend<
+          Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(prepareUpdateQuoteTokenSync.data).toEqualTypeOf<
+    Actions.token.prepareUpdateQuoteTokenSync.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    prepareUpdateQuoteTokenSync.error,
+  ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ErrorType | null>()
+  expectTypeOf(prepareUpdateQuoteTokenSync.variables).toEqualTypeOf<
+    | Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+    | undefined
+  >()
+  expectTypeOf(prepareUpdateQuoteTokenSync.context).toEqualTypeOf<
+    Context | undefined
+  >()
+
+  prepareUpdateQuoteTokenSync.mutate(variablesSync, {
+    onError(error, variables, context) {
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ErrorType>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(
+        data,
+      ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ReturnValue>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.token.prepareUpdateQuoteTokenSync.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.token.prepareUpdateQuoteTokenSync.ErrorType | null>()
+      expectTypeOf(variables).toExtend<
+        Actions.token.prepareUpdateQuoteTokenSync.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useWatchAdminRole', () => {
+  token.useWatchAdminRole({
+    config,
+    enabled: true,
+    onRoleAdminUpdated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchApprove', () => {
+  token.useWatchApprove({
+    config,
+    enabled: true,
+    onApproval(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchBurn', () => {
+  token.useWatchBurn({
+    config,
+    enabled: true,
+    onBurn(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchCreate', () => {
+  token.useWatchCreate({
+    config,
+    enabled: true,
+    onTokenCreated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchMint', () => {
+  token.useWatchMint({
+    config,
+    enabled: true,
+    onMint(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchRole', () => {
+  token.useWatchRole({
+    config,
+    enabled: true,
+    onRoleUpdated(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchTransfer', () => {
+  token.useWatchTransfer({
+    config,
+    enabled: true,
+    onTransfer(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})
+
+test('useWatchUpdateQuoteToken', () => {
+  token.useWatchUpdateQuoteToken({
+    config,
+    enabled: true,
+    onUpdateQuoteToken(args, log) {
+      expectTypeOf(args).toExtend<object>()
+      expectTypeOf(log).toExtend<object>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/wallet.test-d.ts
+++ b/packages/react/src/tempo/hooks/wallet.test-d.ts
@@ -1,0 +1,258 @@
+import { createConfig, http } from '@wagmi/core'
+import type { Actions } from '@wagmi/core/tempo'
+import { defineChain } from 'viem'
+import { tempoLocalnet } from 'viem/chains'
+import { expectTypeOf, test } from 'vitest'
+import * as wallet from './wallet.js'
+
+const tempo = defineChain({ ...tempoLocalnet, id: 1337 as number })
+const contextValue = { foo: 'bar' } as const
+
+const config = createConfig({
+  chains: [tempo],
+  transports: { [tempo.id]: http() },
+})
+
+type Context = typeof contextValue
+
+test('useTransfer', () => {
+  const variables = {} as Actions.wallet.transfer.Parameters<typeof config>
+
+  const transfer = wallet.useTransfer({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.transfer.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.wallet.transfer.ErrorType>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.transfer.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.wallet.transfer.ReturnValue>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.transfer.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.wallet.transfer.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.wallet.transfer.ErrorType | null>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.transfer.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(transfer.data).toEqualTypeOf<
+    Actions.wallet.transfer.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    transfer.error,
+  ).toEqualTypeOf<Actions.wallet.transfer.ErrorType | null>()
+  expectTypeOf(transfer.variables).toEqualTypeOf<
+    Actions.wallet.transfer.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(transfer.context).toEqualTypeOf<Context | undefined>()
+
+  transfer.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.wallet.transfer.ErrorType>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.transfer.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.wallet.transfer.ReturnValue>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.transfer.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.wallet.transfer.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.wallet.transfer.ErrorType | null>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.transfer.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useSwap', () => {
+  const variables = {} as Actions.wallet.swap.Parameters<typeof config>
+
+  const swap = wallet.useSwap({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.swap.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.wallet.swap.ErrorType>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.swap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.wallet.swap.ReturnValue>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.swap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.wallet.swap.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.wallet.swap.ErrorType | null>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.swap.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(swap.data).toEqualTypeOf<
+    Actions.wallet.swap.ReturnValue | undefined
+  >()
+  expectTypeOf(swap.error).toEqualTypeOf<Actions.wallet.swap.ErrorType | null>()
+  expectTypeOf(swap.variables).toEqualTypeOf<
+    Actions.wallet.swap.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(swap.context).toEqualTypeOf<Context | undefined>()
+
+  swap.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.wallet.swap.ErrorType>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.swap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.wallet.swap.ReturnValue>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.swap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.wallet.swap.ReturnValue | undefined
+      >()
+      expectTypeOf(error).toEqualTypeOf<Actions.wallet.swap.ErrorType | null>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.swap.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})
+
+test('useDeposit', () => {
+  const variables = {} as Actions.wallet.deposit.Parameters<typeof config>
+
+  const deposit = wallet.useDeposit({
+    config,
+    mutation: {
+      onMutate(variables) {
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.deposit.Parameters<typeof config>
+        >()
+        return contextValue
+      },
+      onError(error, variables, context) {
+        expectTypeOf(error).toEqualTypeOf<Actions.wallet.deposit.ErrorType>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.deposit.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+      onSuccess(data, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<Actions.wallet.deposit.ReturnValue>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.deposit.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context>()
+      },
+      onSettled(data, error, variables, context) {
+        expectTypeOf(data).toEqualTypeOf<
+          Actions.wallet.deposit.ReturnValue | undefined
+        >()
+        expectTypeOf(
+          error,
+        ).toEqualTypeOf<Actions.wallet.deposit.ErrorType | null>()
+        expectTypeOf(variables).toEqualTypeOf<
+          Actions.wallet.deposit.Parameters<typeof config>
+        >()
+        expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+      },
+    },
+  })
+
+  expectTypeOf(deposit.data).toEqualTypeOf<
+    Actions.wallet.deposit.ReturnValue | undefined
+  >()
+  expectTypeOf(
+    deposit.error,
+  ).toEqualTypeOf<Actions.wallet.deposit.ErrorType | null>()
+  expectTypeOf(deposit.variables).toEqualTypeOf<
+    Actions.wallet.deposit.Parameters<typeof config> | undefined
+  >()
+  expectTypeOf(deposit.context).toEqualTypeOf<Context | undefined>()
+
+  deposit.mutate(variables, {
+    onError(error, variables, context) {
+      expectTypeOf(error).toEqualTypeOf<Actions.wallet.deposit.ErrorType>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.deposit.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+    onSuccess(data, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<Actions.wallet.deposit.ReturnValue>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.deposit.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context>()
+    },
+    onSettled(data, error, variables, context) {
+      expectTypeOf(data).toEqualTypeOf<
+        Actions.wallet.deposit.ReturnValue | undefined
+      >()
+      expectTypeOf(
+        error,
+      ).toEqualTypeOf<Actions.wallet.deposit.ErrorType | null>()
+      expectTypeOf(variables).toEqualTypeOf<
+        Actions.wallet.deposit.Parameters<typeof config>
+      >()
+      expectTypeOf(context).toEqualTypeOf<Context | undefined>()
+    },
+  })
+})

--- a/packages/react/src/tempo/hooks/zone.test-d.ts
+++ b/packages/react/src/tempo/hooks/zone.test-d.ts
@@ -36,7 +36,7 @@ test('deposit variables', () => {
     zoneId: 7,
   })
 
-  expectTypeOf(deposit.variables).toMatchTypeOf<
+  expectTypeOf(deposit.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -58,7 +58,7 @@ test('depositSync variables', () => {
     zoneId: 7,
   })
 
-  expectTypeOf(deposit.variables).toMatchTypeOf<
+  expectTypeOf(deposit.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -80,7 +80,7 @@ test('encryptedDeposit variables', () => {
     zoneId: 7,
   })
 
-  expectTypeOf(deposit.variables).toMatchTypeOf<
+  expectTypeOf(deposit.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -102,7 +102,7 @@ test('encryptedDepositSync variables', () => {
     zoneId: 7,
   })
 
-  expectTypeOf(deposit.variables).toMatchTypeOf<
+  expectTypeOf(deposit.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -123,7 +123,7 @@ test('requestWithdrawal variables', () => {
     token,
   })
 
-  expectTypeOf(withdraw.variables).toMatchTypeOf<
+  expectTypeOf(withdraw.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -143,7 +143,7 @@ test('requestWithdrawalSync variables', () => {
     token,
   })
 
-  expectTypeOf(withdraw.variables).toMatchTypeOf<
+  expectTypeOf(withdraw.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -164,7 +164,7 @@ test('requestVerifiableWithdrawal variables', () => {
     token,
   })
 
-  expectTypeOf(withdraw.variables).toMatchTypeOf<
+  expectTypeOf(withdraw.variables).toExtend<
     | {
         account?: unknown
         amount: bigint
@@ -186,7 +186,7 @@ test('requestVerifiableWithdrawalSync variables', () => {
     token,
   })
 
-  expectTypeOf(withdraw.variables).toMatchTypeOf<
+  expectTypeOf(withdraw.variables).toExtend<
     | {
         account?: unknown
         amount: bigint


### PR DESCRIPTION
Makes Tempo action and hook transaction override parameters optional at the Wagmi layer, since wallet clients supply those values by default. Adds type coverage across Tempo core actions and React hooks to guard optional overrides, callback inference, query select inference, and required parameter regressions.