### PR TITLE
docs: clarify writeContracts call id status

### DIFF
--- a/site/core/api/actions/writeContracts.md
+++ b/site/core/api/actions/writeContracts.md
@@ -304,6 +304,8 @@ import { type WriteContractsReturnType } from '@wagmi/core/experimental'
 
 Identifier of the call batch.
 
+The `id` is not a transaction hash. Use [`getCallsStatus`](/core/api/actions/getCallsStatus) or [`waitForCallsStatus`](/core/api/actions/waitForCallsStatus) to check inclusion and retrieve receipts. Do not pass this value to `waitForTransactionReceipt`.
+
 ## Error
 
 ```ts

--- a/site/react/api/hooks/useWriteContracts.md
+++ b/site/react/api/hooks/useWriteContracts.md
@@ -110,6 +110,8 @@ function App() {
 import { type UseWriteContractsReturnType } from 'wagmi/experimental'
 ```
 
+The mutation data contains the call batch `id`, not a transaction hash. Use [`useCallsStatus`](/react/api/hooks/useCallsStatus) or [`useWaitForCallsStatus`](/react/api/hooks/useWaitForCallsStatus) to check inclusion and retrieve receipts. Do not pass this value to `useWaitForTransactionReceipt`.
+
 <!--@include: @shared/mutation-result.md-->
 
 <!--@include: @shared/mutation-imports.md-->


### PR DESCRIPTION
## Summary
- Clarify that `writeContracts` returns a call batch id, not a transaction hash
- Point core users to `getCallsStatus` / `waitForCallsStatus`
- Point React users to `useCallsStatus` / `useWaitForCallsStatus`

Refs #4626

## Test Plan
- `test -f site/core/api/actions/getCallsStatus.md && test -f site/core/api/actions/waitForCallsStatus.md && test -f site/react/api/hooks/useCallsStatus.md && test -f site/react/api/hooks/useWaitForCallsStatus.md && git diff --check`
- `pnpm --filter site build`

Note: `pnpm exec biome check site/core/api/actions/writeContracts.md site/react/api/hooks/useWriteContracts.md` reported no files processed because Markdown docs are ignored by Biome.