### PR TITLE
docs: fix tempo policy index links

### DIFF
--- a/site/tempo/actions/index.md
+++ b/site/tempo/actions/index.md
@@ -21,16 +21,16 @@
 | [`nonce.getNonce`](/tempo/actions/nonce.getNonce) | Gets the nonce for an account and nonce key |
 | [`nonce.watchNonceIncremented`](/tempo/actions/nonce.watchNonceIncremented) | Watches for nonce incremented events |
 | **Policy Actions** | |
-| [`policy.create`](#TODO) | Creates a new transfer policy for token access control |
-| [`policy.getData`](#TODO) | Gets the data for a transfer policy, including its type and admin address |
-| [`policy.isAuthorized`](#TODO) | Checks if an address is authorized by a transfer policy |
-| [`policy.modifyBlacklist`](#TODO) | Modifies the blacklist for a blacklist-type transfer policy |
-| [`policy.modifyWhitelist`](#TODO) | Modifies the whitelist for a whitelist-type transfer policy |
-| [`policy.setAdmin`](#TODO) | Sets the admin for a transfer policy |
-| [`policy.watchAdminUpdated`](#TODO) | Watches for policy admin update events |
-| [`policy.watchBlacklistUpdated`](#TODO) | Watches for blacklist update events |
-| [`policy.watchCreate`](#TODO) | Watches for policy creation events |
-| [`policy.watchWhitelistUpdated`](#TODO) | Watches for whitelist update events |
+| [`policy.create`](/tempo/actions/policy.create) | Creates a new transfer policy for token access control |
+| [`policy.getData`](/tempo/actions/policy.getData) | Gets the data for a transfer policy, including its type and admin address |
+| [`policy.isAuthorized`](/tempo/actions/policy.isAuthorized) | Checks if an address is authorized by a transfer policy |
+| [`policy.modifyBlacklist`](/tempo/actions/policy.modifyBlacklist) | Modifies the blacklist for a blacklist-type transfer policy |
+| [`policy.modifyWhitelist`](/tempo/actions/policy.modifyWhitelist) | Modifies the whitelist for a whitelist-type transfer policy |
+| [`policy.setAdmin`](/tempo/actions/policy.setAdmin) | Sets the admin for a transfer policy |
+| [`policy.watchAdminUpdated`](/tempo/actions/policy.watchAdminUpdated) | Watches for policy admin update events |
+| [`policy.watchBlacklistUpdated`](/tempo/actions/policy.watchBlacklistUpdated) | Watches for blacklist update events |
+| [`policy.watchCreate`](/tempo/actions/policy.watchCreate) | Watches for policy creation events |
+| [`policy.watchWhitelistUpdated`](/tempo/actions/policy.watchWhitelistUpdated) | Watches for whitelist update events |
 | **Reward Actions** | |
 | [`reward.claim`](/tempo/actions/reward.claim) | Claims accumulated rewards for the caller |
 | [`reward.getUserRewardInfo`](/tempo/actions/reward.getUserRewardInfo) | Gets reward information for a specific account |

--- a/site/tempo/hooks/index.md
+++ b/site/tempo/hooks/index.md
@@ -21,16 +21,16 @@
 | [`nonce.useNonce`](/tempo/hooks/nonce.useNonce) | Hook for getting the nonce for an account and nonce key |
 | [`nonce.useWatchNonceIncremented`](/tempo/hooks/nonce.useWatchNonceIncremented) | Hook for watching nonce incremented events |
 | **Policy Hooks** | |
-| [`policy.useCreate`](#TODO) | Hook for creating a new transfer policy for token access control |
-| [`policy.useData`](#TODO) | Hook for getting the data for a transfer policy, including its type and admin address |
-| [`policy.useIsAuthorized`](#TODO) | Hook for checking if an address is authorized by a transfer policy |
-| [`policy.useModifyBlacklist`](#TODO) | Hook for modifying the blacklist for a blacklist-type transfer policy |
-| [`policy.useModifyWhitelist`](#TODO) | Hook for modifying the whitelist for a whitelist-type transfer policy |
-| [`policy.useSetAdmin`](#TODO) | Hook for setting the admin for a transfer policy |
-| [`policy.useWatchAdminUpdated`](#TODO) | Hook for watching policy admin update events |
-| [`policy.useWatchBlacklistUpdated`](#TODO) | Hook for watching blacklist update events |
-| [`policy.useWatchCreate`](#TODO) | Hook for watching policy creation events |
-| [`policy.useWatchWhitelistUpdated`](#TODO) | Hook for watching whitelist update events |
+| [`policy.useCreate`](/tempo/hooks/policy.useCreate) | Hook for creating a new transfer policy for token access control |
+| [`policy.useData`](/tempo/hooks/policy.useData) | Hook for getting the data for a transfer policy, including its type and admin address |
+| [`policy.useIsAuthorized`](/tempo/hooks/policy.useIsAuthorized) | Hook for checking if an address is authorized by a transfer policy |
+| [`policy.useModifyBlacklist`](/tempo/hooks/policy.useModifyBlacklist) | Hook for modifying the blacklist for a blacklist-type transfer policy |
+| [`policy.useModifyWhitelist`](/tempo/hooks/policy.useModifyWhitelist) | Hook for modifying the whitelist for a whitelist-type transfer policy |
+| [`policy.useSetAdmin`](/tempo/hooks/policy.useSetAdmin) | Hook for setting the admin for a transfer policy |
+| [`policy.useWatchAdminUpdated`](/tempo/hooks/policy.useWatchAdminUpdated) | Hook for watching policy admin update events |
+| [`policy.useWatchBlacklistUpdated`](/tempo/hooks/policy.useWatchBlacklistUpdated) | Hook for watching blacklist update events |
+| [`policy.useWatchCreate`](/tempo/hooks/policy.useWatchCreate) | Hook for watching policy creation events |
+| [`policy.useWatchWhitelistUpdated`](/tempo/hooks/policy.useWatchWhitelistUpdated) | Hook for watching whitelist update events |
 | **Reward Hooks** | |
 | [`reward.useClaim`](/tempo/hooks/reward.useClaim) | Hook for claiming accumulated rewards |
 | [`reward.useSetRecipient`](/tempo/hooks/reward.useSetRecipient) | Hook for setting or changing the reward recipient for a token holder |


### PR DESCRIPTION
## Summary
- Replace placeholder Tempo policy action links in the overview with their generated docs routes
- Replace placeholder Tempo policy hook links in the overview with their generated docs routes

## Test Plan
- `python3 - <<'PY'\nfrom pathlib import Path\nimport re, sys\nrepo = Path('/home/hermes/work/web3-pr-sprints/wagmi')\nmissing=[]\nfor file in [repo/'site/tempo/actions/index.md', repo/'site/tempo/hooks/index.md']:\n    text=file.read_text()\n    for link in re.findall(r'\]\((/tempo/(?:actions|hooks)/[^)]+)\)', text):\n        target = repo / 'site' / (link.removeprefix('/') + '.md')\n        if not target.exists():\n            missing.append((str(file.relative_to(repo)), link, str(target.relative_to(repo))))\nprint('checked tempo index links:', 'ok' if not missing else 'missing')\nfor item in missing:\n    print(item)\nif missing: sys.exit(1)\nPY`
- `git diff --check`
- `pnpm --filter site build`