### PR TITLE
docs: fix wallet client return type imports

### DIFF
--- a/site/core/api/actions/getConnectorClient.md
+++ b/site/core/api/actions/getConnectorClient.md
@@ -92,7 +92,7 @@ const client = await getConnectorClient(config, {
 ## Return Type
 
 ```ts
-import { type GetChainIdReturnType } from '@wagmi/core'
+import { type GetConnectorClientReturnType } from '@wagmi/core'
 ```
 
 `Client`

--- a/site/core/api/actions/getWalletClient.md
+++ b/site/core/api/actions/getWalletClient.md
@@ -96,7 +96,7 @@ const client = getWalletClient(config, {
 ## Return Type
 
 ```ts
-import { type GetChainIdReturnType } from '@wagmi/core'
+import { type GetWalletClientReturnType } from '@wagmi/core'
 ```
 
 `WalletClient`


### PR DESCRIPTION
## Summary
- Replace stale `GetChainIdReturnType` snippets in `getConnectorClient` and `getWalletClient` docs
- Point each Return Type import example at the action's exported return type

## Test Plan
- `git diff --check`
- `python3 - <<'PY'\nfrom pathlib import Path\nrepo = Path('/home/hermes/work/web3-pr-sprints/wagmi')\nfiles = [repo/'site/core/api/actions/getConnectorClient.md', repo/'site/core/api/actions/getWalletClient.md']\nexpected = ['GetConnectorClientReturnType', 'GetWalletClientReturnType']\nfor file, symbol in zip(files, expected):\n    text = file.read_text()\n    assert f'import {{ type {symbol} }} from' in text, (file, symbol)\n    src = repo/'packages/core/src/actions'/(file.stem + '.ts')\n    assert f'export type {symbol}' in src.read_text(), (src, symbol)\nprint('docs return type imports match exported action return types')\nPY`
- `pnpm --filter site build`