### PR TITLE
docs: clarify writeContracts status tracking

### DIFF
--- a/site/core/api/actions/getCallsStatus.md
+++ b/site/core/api/actions/getCallsStatus.md
@@ -6,7 +6,7 @@ const typeName = 'GetCallsStatus'
 
 # getCallsStatus
 
-Action to fetch the status and receipts of a call batch that was sent via [`sendCalls`](/core/api/actions/sendCalls).
+Action to fetch the status and receipts of a call batch that was sent via [`sendCalls`](/core/api/actions/sendCalls) or [`writeContracts`](/core/api/actions/writeContracts).
 
 [Read more.](https://github.com/ethereum/EIPs/blob/1663ea2e7a683285f977eda51c32cec86553f585/EIPS/eip-5792.md#wallet_getcallsstatus)
 

--- a/site/core/api/actions/writeContracts.md
+++ b/site/core/api/actions/writeContracts.md
@@ -58,6 +58,31 @@ const id = await writeContracts(config, {
 <<< @/snippets/core/config.ts[config.ts]
 :::
 
+## Track call status
+
+The returned `id` is a call batch identifier, not a transaction hash. Use
+[`getCallsStatus`](/core/api/actions/getCallsStatus) to fetch receipts for the
+batch. Do not pass the `id` to
+[`waitForTransactionReceipt`](/core/api/actions/waitForTransactionReceipt),
+which expects an on-chain transaction hash.
+
+::: code-group
+```ts [index.ts]
+import { getCallsStatus } from '@wagmi/core'
+import { writeContracts } from '@wagmi/core/experimental'
+import { config } from './config'
+
+const { id } = await writeContracts(config, {
+  contracts: [
+    /* ... */
+  ],
+})
+
+const status = await getCallsStatus(config, { id })
+```
+<<< @/snippets/core/config.ts[config.ts]
+:::
+
 ## Parameters
 
 ```ts

--- a/site/react/api/hooks/useCallsStatus.md
+++ b/site/react/api/hooks/useCallsStatus.md
@@ -13,7 +13,7 @@ const TError = 'GetCallsStatusErrorType'
 
 # useCallsStatus
 
-Hook to fetch the status and receipts of a call batch that was sent via [`useSendCalls`](/react/api/hooks/useSendCalls).
+Hook to fetch the status and receipts of a call batch that was sent via [`useSendCalls`](/react/api/hooks/useSendCalls) or [`useWriteContracts`](/react/api/hooks/useWriteContracts).
 
  
 

--- a/site/react/api/hooks/useWriteContracts.md
+++ b/site/react/api/hooks/useWriteContracts.md
@@ -76,6 +76,44 @@ function App() {
 <<< @/snippets/react/config.ts[config.ts]
 :::
 
+## Track call status
+
+`useWriteContracts` returns an `id` for the call batch, not a transaction hash.
+Use [`useCallsStatus`](/react/api/hooks/useCallsStatus) to fetch receipts for the
+batch. Do not pass the `id` to
+[`useWaitForTransactionReceipt`](/react/api/hooks/useWaitForTransactionReceipt),
+which expects an on-chain transaction hash.
+
+::: code-group
+```tsx [index.tsx]
+import { useCallsStatus } from 'wagmi'
+import { useWriteContracts } from 'wagmi/experimental'
+
+function App() {
+  const { data, writeContracts } = useWriteContracts()
+  const status = useCallsStatus({
+    id: data?.id ?? '',
+    query: { enabled: Boolean(data?.id) },
+  })
+
+  return (
+    <button
+      onClick={() =>
+        writeContracts({
+          contracts: [
+            /* ... */
+          ],
+        })
+      }
+    >
+      Send calls
+    </button>
+  )
+}
+```
+<<< @/snippets/react/config.ts[config.ts]
+:::
+
 ## Parameters
 
 ```ts


### PR DESCRIPTION
## Summary
- Clarifies that writeContracts/useWriteContracts return a call batch id, not an on-chain transaction hash
- Points users to getCallsStatus/useCallsStatus for receipts instead of waitForTransactionReceipt/useWaitForTransactionReceipt
- Notes getCallsStatus/useCallsStatus also apply to writeContracts batches

Refs #4626

## Test Plan
- pnpm --filter site build
- git diff --check