### PR TITLE
docs(react): mention SwapDK in third-party libraries ecosystem

### DIFF
--- a/site/react/why.md
+++ b/site/react/why.md
@@ -32,7 +32,7 @@ Wagmi supports the most popular and commonly-used Ethereum features out of the b
 
 If you need lower-level control, you can always drop down to [Wagmi Core](/core/getting-started) or [Viem](https://viem.sh), which Wagmi uses internally to perform blockchain operations. Wagmi also manages multi-chain support automatically so developers can focus on their applications instead of adding custom code.
 
-Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), and many more, so you can get started quickly without needing to build everything from scratch.
+Finally, Wagmi has a [CLI](/cli/getting-started) to manage ABIs as well as a robust ecosystem of third-party libraries, like [ConnectKit](https://docs.family.co/connectkit), [Dynamic](https://www.dynamic.xyz), [Privy](https://privy.io), [SwapDK](https://github.com/Swap-DK/wagmidk) for cross-chain swaps, and many more, so you can get started quickly without needing to build everything from scratch.
 
 ## Stability
 


### PR DESCRIPTION
Adds SwapDK (`@swapdk/wagmidk`) as an inline mention in the react/why.md "ecosystem of third-party libraries" paragraph.

- Category: cross-chain swap SDK (distinct from wallet-infrastructure libraries already listed)
- Public repo: https://github.com/Swap-DK/wagmidk
- npm: https://www.npmjs.com/package/@swapdk/wagmidk (v0.2.0-alpha.0)
- Peer deps: `wagmi` ^2, `viem` ^2, `@tanstack/react-query` ^5, `react` >=18

The library provides a headless React hooks surface (`useSwap`, `useSwapQuote`, `useSwapExecute`, `useSwapStatus`, `useSourceChain`) over the SwapDK swap-engine HTTP aggregator (THORChain / MAYAChain / Chainflip). Mainnet-validated on ARB→BTC (native + ERC-20 source), ARB→mainnet ETH, ARB→mainnet USDC as of 2026-07-02.

Only `react/why.md` is touched — `vue/why.md` and `core/why.md` intentionally left alone since the library ships React hooks only (no vue/core adapter yet).

Docs-only change, no changeset per CONTRIBUTING.