### PR TITLE
docs(react): fix EIP-5792 hook examples

### DIFF
--- a/site/react/api/hooks/useCallsStatus.md
+++ b/site/react/api/hooks/useCallsStatus.md
@@ -1,6 +1,6 @@
 ---
 title: useCallsStatus
-description: Hook for fetching the number of the most recent block seen.
+description: Hook for fetching the status and receipts of a call batch.
 ---
 
 <script setup>
@@ -94,13 +94,14 @@ function App() {
 Identifier of the call batch.
 
 ::: code-group
-```ts [index.ts]
-import { useCallsStatus } from '@wagmi/core'
-import { config } from './config'
+```tsx [index.tsx]
+import { useCallsStatus } from 'wagmi'
 
-const status = await useCallsStatus({
-  id: '0x1234567890abcdef', // [!code focus]
-})
+function App() {
+  const result = useCallsStatus({
+    id: '0x1234567890abcdef', // [!code focus]
+  })
+}
 ```
 <<< @/snippets/react/config.ts[config.ts]
 :::

--- a/site/react/api/hooks/useCapabilities.md
+++ b/site/react/api/hooks/useCapabilities.md
@@ -1,6 +1,6 @@
 ---
 title: useCapabilities
-description: Hook for fetching the number of the most recent block seen.
+description: Hook for fetching wallet capabilities.
 ---
 
 <script setup>
@@ -49,13 +49,14 @@ import { type UseCapabilitiesParameters } from 'wagmi'
 Fetch capabilities for the provided account.
 
 ::: code-group
-```ts [index.ts]
-import { useCapabilities } from '@wagmi/core'
-import { config } from './config'
+```tsx [index.tsx]
+import { useCapabilities } from 'wagmi'
 
-const status = await useCapabilities({
-  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', // [!code focus]
-})
+function App() {
+  const result = useCapabilities({
+    account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', // [!code focus]
+  })
+}
 ```
 <<< @/snippets/react/config.ts[config.ts]
 :::
@@ -84,7 +85,7 @@ function App() {
 
 `Connector | undefined`
 
-Connector to get call statuses with.
+Connector to get capabilities with.
 
 ::: code-group
 ```tsx [index.tsx]

--- a/site/react/api/hooks/useWaitForCallsStatus.md
+++ b/site/react/api/hooks/useWaitForCallsStatus.md
@@ -94,13 +94,14 @@ function App() {
 Identifier of the call batch.
 
 ::: code-group
-```ts [index.ts]
-import { useWaitForCallsStatus } from '@wagmi/core'
-import { config } from './config'
+```tsx [index.tsx]
+import { useWaitForCallsStatus } from 'wagmi'
 
-const status = await useWaitForCallsStatus({
-  id: '0x1234567890abcdef', // [!code focus]
-})
+function App() {
+  const result = useWaitForCallsStatus({
+    id: '0x1234567890abcdef', // [!code focus]
+  })
+}
 ```
 <<< @/snippets/react/config.ts[config.ts]
 :::
@@ -112,14 +113,15 @@ const status = await useWaitForCallsStatus({
 Polling interval in milliseconds.
 
 ::: code-group
-```ts [index.ts]
-import { useWaitForCallsStatus } from '@wagmi/core'
-import { config } from './config'
+```tsx [index.tsx]
+import { useWaitForCallsStatus } from 'wagmi'
 
-const status = await useWaitForCallsStatus({
-  id: '0x1234567890abcdef',
-  pollingInterval: 1_000, // [!code focus]
-})
+function App() {
+  const result = useWaitForCallsStatus({
+    id: '0x1234567890abcdef',
+    pollingInterval: 1_000, // [!code focus]
+  })
+}
 ```
 <<< @/snippets/react/config.ts[config.ts]
 :::
@@ -152,14 +154,15 @@ function App() {
 Timeout in milliseconds.
 
 ::: code-group
-```ts [index.ts]
-import { useWaitForCallsStatus } from '@wagmi/core'
-import { config } from './config'
+```tsx [index.tsx]
+import { useWaitForCallsStatus } from 'wagmi'
 
-const status = await useWaitForCallsStatus({
-  id: '0x1234567890abcdef',
-  timeout: 10_000, // [!code focus]
-})
+function App() {
+  const result = useWaitForCallsStatus({
+    id: '0x1234567890abcdef',
+    timeout: 10_000, // [!code focus]
+  })
+}
 ```
 <<< @/snippets/react/config.ts[config.ts]
 :::


### PR DESCRIPTION
## Summary

Fixes a few React EIP-5792 hook docs examples that were using core/action-style snippets:

- updates `useCapabilities`, `useCallsStatus`, and `useWaitForCallsStatus` parameter examples to import hooks from `wagmi`
- wraps those examples in React component usage instead of `await use...`
- fixes copied frontmatter descriptions for `useCapabilities` and `useCallsStatus`
- corrects the `useCapabilities` connector description

## Validation

- `git diff --check`
- `rg "import \\{ use[A-Za-z]+ \\} from '@wagmi/core'|const status = await use[A-Za-z]+\\(" site/react/api/hooks -n`
- `rg "most recent block seen" site/react/api/hooks/useCapabilities.md site/react/api/hooks/useCallsStatus.md -n`

Docs-only change; I did not run the full site build locally because dependencies were not installed in this checkout.
