### PR TITLE
fix(core): allow getTransaction query for transaction index 0

### DIFF
--- a/.changeset/get-transaction-index-zero.md
+++ b/.changeset/get-transaction-index-zero.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `getTransaction` query being disabled for transaction `index: 0`, which is a valid input (the first transaction in a block) but was treated as falsy.

--- a/packages/core/src/query/getTransaction.test.ts
+++ b/packages/core/src/query/getTransaction.test.ts
@@ -32,3 +32,11 @@ test('parameters: chainId', () => {
     }
   `)
 })
+
+test('parameters: index 0 with blockNumber enables query', () => {
+  const options = getTransactionQueryOptions(config, {
+    blockNumber: 1n,
+    index: 0,
+  })
+  expect(options.enabled).toBe(true)
+})

--- a/packages/core/src/query/getTransaction.ts
+++ b/packages/core/src/query/getTransaction.ts
@@ -36,7 +36,7 @@ export function getTransactionQueryOptions<
     ...options.query,
     enabled: Boolean(
       (options.hash ||
-        (options.index &&
+        (options.index !== undefined &&
           (options.blockHash || options.blockNumber || options.blockTag))) &&
         (options.query?.enabled ?? true),
     ),
@@ -45,7 +45,7 @@ export function getTransactionQueryOptions<
       if (
         !(
           parameters.hash ||
-          (parameters.index &&
+          (parameters.index !== undefined &&
             (parameters.blockHash ||
               parameters.blockNumber ||
               parameters.blockTag))


### PR DESCRIPTION
## Bug

In `getTransactionQueryOptions` (`packages/core/src/query/getTransaction.ts`), both the `enabled` guard and the `queryFn` precondition test the block transaction `index` for **truthiness**:

```ts
enabled: Boolean(
  (options.hash ||
    (options.index && // <-- falsy for index 0
      (options.blockHash || options.blockNumber || options.blockTag))) &&
    (options.query?.enabled ?? true),
),
```

`index` is the 0-based transaction index within a block, so `index: 0` — the first transaction of any block — is a valid input but is falsy.

## Failing scenario

```ts
useTransaction({ blockNumber: 21_000_000n, index: 0 })
// or
getTransactionQueryOptions(config, { blockNumber: 21_000_000n, index: 0 })
```

This computes `enabled: false`, so the query never fetches. If the query is forced to run, the `queryFn` guard evaluates `!(undefined || (0 && …))` → `!0` → `true` and throws `"hash OR index AND blockHash, blockNumber, blockTag is required"`.

Any other index (`1`, `2`, …) works, which masks the bug. viem's `getTransaction` fully supports `index: 0`, so a legitimate request for the first transaction in a block is silently broken.

## Fix

Check `index !== undefined` instead of truthiness in both guards. `index` is typed `number | undefined`, so `!== undefined` correctly admits `0`. The patch is symmetric across the `enabled` guard and the `queryFn` precondition.

Adds a regression test asserting the query is enabled for `{ blockNumber, index: 0 }` (fails before the fix, passes after). Existing `default` / `chainId` snapshots (no `index`) remain `enabled: false` and are unchanged.