### PR TITLE
fix(tempo): await accounts import instead of chaining .catch()

### DIFF
--- a/.changeset/tempo-accounts-import-catch.md
+++ b/.changeset/tempo-accounts-import-catch.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed the Tempo connectors crashing with `TypeError: undefined is not a function` when lazily loading the `accounts` peer dependency under bundlers whose transformed `import()` does not return a spec-compliant `Promise` (e.g. Metro/React Native). The result of `import()` is now awaited instead of having `.catch()` chained onto it.

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -188,12 +188,14 @@ function _setup(parameters: setup.Parameters) {
     let disconnect: ((error?: Error | undefined) => void) | undefined
 
     async function getAccountsModule() {
-      return await import(
-        /* turbopackOptional: true */
-        'accounts'
-      ).catch(() => {
+      try {
+        return await import(
+          /* turbopackOptional: true */
+          'accounts'
+        )
+      } catch {
         throw new Error('dependency "accounts" not found')
-      })
+      }
     }
 
     async function getProvider() {


### PR DESCRIPTION
Fixes #5201.

### Problem

The Tempo connectors (`webAuthn` / `tempoWallet` / `dangerous_secp256k1`) in `@wagmi/core` lazily load the peer-installed `accounts` package with:

```ts
async function getAccountsModule() {
  return await import(
    /* turbopackOptional: true */
    'accounts'
  ).catch(() => {
    throw new Error('dependency "accounts" not found')
  })
}
```

Chaining `.catch()` directly on the result of `import()` assumes that value is always a spec-compliant native `Promise`. That isn't guaranteed in every bundling environment — notably under Metro (React Native's bundler), a transformed `import()` reliably exposes `.then()` but **not** `.catch()`. Evaluating `import('accounts').catch` then throws `TypeError: undefined is not a function` before the import settles and before the intended `'dependency "accounts" not found'` message can run, making the connectors unusable there with a misleading error.

### Fix

Await the dynamic import inside a `try`/`catch` instead of chaining `.catch()` on it. `await` only requires a thenable's `.then()`, so it works with Metro's non-spec import result while remaining identical for spec Promises. The `/* turbopackOptional: true */` magic comment and the rethrown error message are preserved.

### Verification

- `biome check` on the changed file — clean.
- `tsc --noEmit` (core) and the `build:esm+types` build — both pass.
- Mechanism reproduced standalone (a thenable with `.then` but no `.catch`, mirroring Metro):
  - old path `thenable.catch(...)` → `TypeError: ...catch is not a function`
  - new path `await thenable` → resolves normally

### Note for reviewers (tests)

The template asks for a test that fails without the fix. I was unable to add one that's meaningful in CI: under Node/Vitest, `import()` always returns a spec-compliant `Promise` (with `.catch`) and `accounts` is installed in the workspace, so both the old and new code behave identically in the test environment — the divergence only appears under Metro's non-spec `import()` transform, which the repo's test runner can't reproduce. The change is a behavior-preserving 3-line refactor for spec Promises; happy to add a test if you can suggest a way to simulate the Metro import shape within the existing suite.
