### PR TITLE
fix(core): query block 0 (genesis) when blockNumber is 0n in getBalance/getTransactionCount

### DIFF
--- a/.changeset/block-number-zero-genesis.md
+++ b/.changeset/block-number-zero-genesis.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `getBalance` and `getTransactionCount` querying the wrong block for `blockNumber: 0n` (genesis), which is a valid input but was treated as falsy and fell back to `blockTag: 'latest'`.

--- a/packages/core/src/actions/getBalance.test.ts
+++ b/packages/core/src/actions/getBalance.test.ts
@@ -41,6 +41,21 @@ test('default', async () => {
   `)
 })
 
+test('parameters: blockNumber 0 (genesis)', async () => {
+  // `blockNumber: 0n` is falsy but a valid block (genesis). Ensure it queries
+  // block 0 (where `address` has no balance) instead of falling back to
+  // `blockTag: 'latest'` (10000 ETH set in `beforeEach`).
+  await expect(
+    getBalance(config, { address, blockNumber: 0n }),
+  ).resolves.toMatchInlineSnapshot(`
+    {
+      "decimals": 18,
+      "symbol": "ETH",
+      "value": 0n,
+    }
+  `)
+})
+
 test('parameters: chainId', async () => {
   await expect(
     getBalance(config, { address, chainId: chain.mainnet2.id }),

--- a/packages/core/src/actions/getBalance.ts
+++ b/packages/core/src/actions/getBalance.ts
@@ -31,7 +31,9 @@ export async function getBalance<config extends Config>(
   const client = config.getClient({ chainId })
   const action = getAction(client, viem_getBalance, 'getBalance')
   const value = await action(
-    blockNumber ? { address, blockNumber } : { address, blockTag },
+    blockNumber !== undefined
+      ? { address, blockNumber }
+      : { address, blockTag },
   )
   const chain = config.chains.find((x) => x.id === chainId) ?? client.chain!
   return {

--- a/packages/core/src/actions/getTransactionCount.test.ts
+++ b/packages/core/src/actions/getTransactionCount.test.ts
@@ -28,6 +28,17 @@ test('parameters: blockNumber', async () => {
   ).resolves.toBeTypeOf('number')
 })
 
+test('parameters: blockNumber 0 (genesis)', async () => {
+  // `blockNumber: 0n` is falsy but a valid block (genesis). Ensure it queries
+  // block 0 (nonce 0) instead of falling back to `blockTag: 'latest'`.
+  await testClient.mainnet.restart()
+  await testClient.mainnet.setNonce({ address, nonce: 69 })
+  await testClient.mainnet.mine({ blocks: 1 })
+  await expect(
+    getTransactionCount(config, { address, blockNumber: 0n }),
+  ).resolves.toBe(0)
+})
+
 test.each([
   { blockTag: 'earliest' },
   { blockTag: 'finalized' },

--- a/packages/core/src/actions/getTransactionCount.ts
+++ b/packages/core/src/actions/getTransactionCount.ts
@@ -30,5 +30,9 @@ export async function getTransactionCount<config extends Config>(
     viem_getTransactionCount,
     'getTransactionCount',
   )
-  return action(blockNumber ? { address, blockNumber } : { address, blockTag })
+  return action(
+    blockNumber !== undefined
+      ? { address, blockNumber }
+      : { address, blockTag },
+  )
 }


### PR DESCRIPTION
## Summary

`getBalance` and `getTransactionCount` select the block with a falsy guard:

```ts
blockNumber ? { address, blockNumber } : { address, blockTag }
```

`0n` (the genesis block) is a valid `blockNumber` but is falsy in JS, so the ternary silently falls through to `blockTag` (default `'latest'`) and queries the **wrong** block. A user asking for the balance / transaction count at block `0` gets the latest value instead.

Fixed both actions by guarding with `blockNumber !== undefined` instead of truthiness.

## Affected actions

- `packages/core/src/actions/getBalance.ts`
- `packages/core/src/actions/getTransactionCount.ts`

## Example

```ts
// before: returns the latest balance, not genesis
await getBalance(config, { address, blockNumber: 0n })
```

## Notes

- Added regression tests asserting `blockNumber: 0n` queries block `0` (genesis) rather than `latest` — these fail on the old truthiness guard and pass with the fix.
- Added a changeset (`@wagmi/core` patch).
- This mirrors the already-merged #5197, which fixed the same falsy-guard class for `getTransaction`'s `index: 0` using the same `!== undefined` idiom.
