### PR TITLE
fix(connectors): preserve optional dependency tree-shaking

### DIFF
--- a/.changeset/calm-chains-shake.md
+++ b/.changeset/calm-chains-shake.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fixed optional connector SDK imports retaining unused dependency exports in application bundles.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build
         run: pnpm clean && pnpm build
 
-      - name: Publint
+      - name: Publint and engine tests
         run: pnpm test:build
 
       - name: Check for unused files, dependencies, and exports

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm test:build
 
       - name: Engine tests
-        run: pnpm --filter engine-tests test:build
+        run: pnpm --filter engine-tests test
 
       - name: Check for unused files, dependencies, and exports
         run: pnpm knip --production

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,8 +66,11 @@ jobs:
       - name: Build
         run: pnpm clean && pnpm build
 
-      - name: Publint and engine tests
+      - name: Publint
         run: pnpm test:build
+
+      - name: Engine tests
+        run: pnpm --filter engine-tests test:build
 
       - name: Check for unused files, dependencies, and exports
         run: pnpm knip --production

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "changeset:publish": "pnpm changeset:prepublish && changeset publish",
     "changeset:version": "changeset version && pnpm version:update && pnpm format",
     "check": "biome check --write",
-    "check:repo": "sherif -i viem",
+    "check:repo": "sherif -i viem -p engine-tests",
     "check:types": "pnpm run --r --parallel check:types && tsgo --noEmit",
     "check:types:typescript": "pnpm -r --parallel --filter './packages/*' --filter './packages/register-tests/*' exec tsc --noEmit && tsc --noEmit",
     "check:unused": "pnpm clean && knip",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "preinstall": "pnpx only-allow pnpm",
     "prepare": "pnpm simple-git-hooks",
     "test": "vitest",
-    "test:build": "node scripts/generateConnectorExports.ts && node scripts/generateProxyPackages.ts && pnpm run --r --parallel --filter '!engine-tests' test:build",
+    "test:build": "node scripts/generateConnectorExports.ts && node scripts/generateProxyPackages.ts && pnpm run --r --parallel test:build",
     "test:cov": "vitest run --coverage",
     "test:update": "vitest --update",
     "version:update": "node scripts/updateVersion.ts",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
       "scripts/**"
     ],
     "ignoreWorkspaces": [
+      "packages/engine-tests",
       "packages/register-tests/**",
       "packages/test",
       "playgrounds/**",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "preinstall": "pnpx only-allow pnpm",
     "prepare": "pnpm simple-git-hooks",
     "test": "vitest",
-    "test:build": "node scripts/generateConnectorExports.ts && node scripts/generateProxyPackages.ts && pnpm run --r --parallel test:build",
+    "test:build": "node scripts/generateConnectorExports.ts && node scripts/generateProxyPackages.ts && pnpm run --r --parallel --filter '!engine-tests' test:build && pnpm --filter engine-tests test:build",
     "test:cov": "vitest run --coverage",
     "test:update": "vitest --update",
     "version:update": "node scripts/updateVersion.ts",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "preinstall": "pnpx only-allow pnpm",
     "prepare": "pnpm simple-git-hooks",
     "test": "vitest",
-    "test:build": "node scripts/generateConnectorExports.ts && node scripts/generateProxyPackages.ts && pnpm run --r --parallel --filter '!engine-tests' test:build && pnpm --filter engine-tests test:build",
+    "test:build": "node scripts/generateConnectorExports.ts && node scripts/generateProxyPackages.ts && pnpm run --r --parallel --filter '!engine-tests' test:build",
     "test:cov": "vitest run --coverage",
     "test:update": "vitest --update",
     "version:update": "node scripts/updateVersion.ts",

--- a/packages/connectors/src/baseAccount.ts
+++ b/packages/connectors/src/baseAccount.ts
@@ -217,24 +217,23 @@ export function baseAccount(parameters: BaseAccountParameters = {}) {
           }
         })()
 
-        const { createBaseAccountSDK } = await (() => {
-          // safe webpack optional peer dependency dynamic import
-          try {
-            return import(
-              /* turbopackOptional: true */
-              '@base-org/account'
-            )
-          } catch {
-            throw new Error('dependency "@base-org/account" not found')
-          }
-        })()
-        const sdk = createBaseAccountSDK({
-          ...parameters,
-          appChainIds: config.chains.map((x) => x.id),
-          preference,
-        })
+        // safe webpack optional peer dependency dynamic import
+        try {
+          const { createBaseAccountSDK } = await import(
+            /* turbopackOptional: true */
+            '@base-org/account'
+          )
+          const sdk = createBaseAccountSDK({
+            ...parameters,
+            appChainIds: config.chains.map((x) => x.id),
+            preference,
+          })
 
-        walletProvider = sdk.getProvider()
+          walletProvider = sdk.getProvider()
+        } catch (error) {
+          // biome-ignore lint/complexity/noUselessCatch: try block marks dependency as optional for webpack
+          throw error
+        }
       }
 
       return walletProvider

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -151,27 +151,26 @@ export function coinbaseWallet(
     },
     async getProvider() {
       if (!walletProvider) {
-        const { createCoinbaseWalletSDK } = await (() => {
-          // safe webpack optional peer dependency dynamic import
-          try {
-            return import(
-              /* turbopackOptional: true */
-              '@coinbase/wallet-sdk'
-            )
-          } catch {
-            throw new Error('dependency "@coinbase/wallet-sdk" not found')
-          }
-        })()
-        const sdk = createCoinbaseWalletSDK({
-          ...parameters,
-          appChainIds: config.chains.map((x) => x.id),
-          preference: {
-            options: 'all',
-            ...(parameters.preference ?? {}),
-          },
-        })
+        // safe webpack optional peer dependency dynamic import
+        try {
+          const { createCoinbaseWalletSDK } = await import(
+            /* turbopackOptional: true */
+            '@coinbase/wallet-sdk'
+          )
+          const sdk = createCoinbaseWalletSDK({
+            ...parameters,
+            appChainIds: config.chains.map((x) => x.id),
+            preference: {
+              options: 'all',
+              ...(parameters.preference ?? {}),
+            },
+          })
 
-        walletProvider = sdk.getProvider()
+          walletProvider = sdk.getProvider()
+        } catch (error) {
+          // biome-ignore lint/complexity/noUselessCatch: try block marks dependency as optional for webpack
+          throw error
+        }
       }
 
       return walletProvider

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -322,55 +322,55 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
     async getInstance() {
       if (!metamask) {
         if (!metamaskPromise) {
-          const { createEVMClient } = await (async () => {
-            try {
-              return import(
-                /* turbopackOptional: true */
-                '@metamask/connect-evm'
-              )
-            } catch {
-              throw new Error('dependency "@metamask/connect-evm" not found')
-            }
-          })()
-          const defaultDappParams =
-            typeof window === 'undefined'
-              ? { name: 'wagmi' }
-              : { name: window.location.hostname, url: window.location.href }
+          // safe webpack optional peer dependency dynamic import
+          try {
+            const { createEVMClient } = await import(
+              /* turbopackOptional: true */
+              '@metamask/connect-evm'
+            )
+            const defaultDappParams =
+              typeof window === 'undefined'
+                ? { name: 'wagmi' }
+                : { name: window.location.hostname, url: window.location.href }
 
-          metamaskPromise = createEVMClient({
-            ...parameters,
-            skipAutoAnnounce: true,
-            api: {
-              supportedNetworks: Object.fromEntries(
-                config.chains.map((chain) => [
-                  numberToHex(chain.id),
-                  chain.rpcUrls.default?.http[0] ?? '',
-                ]),
-              ),
-            },
-            dapp: parameters.dapp ?? {
-              ...defaultDappParams,
-              ...parameters.dappMetadata,
-            },
-            debug: parameters.debug ?? parameters.logging?.sdk,
-            eventHandlers: {
-              accountsChanged: this.onAccountsChanged.bind(this),
-              chainChanged: this.onChainChanged.bind(this),
-              connect: this.onConnect.bind(this),
-              disconnect: this.onDisconnect.bind(this),
-              displayUri: this.onDisplayUri.bind(this),
-            },
-            analytics: {
-              integrationType: 'wagmi',
-            },
-            ui: {
-              ...parameters.ui,
-              ...(parameters.headless != null && {
-                headless: parameters.headless,
-              }),
-            },
-            ...(parameters.mobile && { mobile: parameters.mobile }),
-          })
+            metamaskPromise = createEVMClient({
+              ...parameters,
+              skipAutoAnnounce: true,
+              api: {
+                supportedNetworks: Object.fromEntries(
+                  config.chains.map((chain) => [
+                    numberToHex(chain.id),
+                    chain.rpcUrls.default?.http[0] ?? '',
+                  ]),
+                ),
+              },
+              dapp: parameters.dapp ?? {
+                ...defaultDappParams,
+                ...parameters.dappMetadata,
+              },
+              debug: parameters.debug ?? parameters.logging?.sdk,
+              eventHandlers: {
+                accountsChanged: this.onAccountsChanged.bind(this),
+                chainChanged: this.onChainChanged.bind(this),
+                connect: this.onConnect.bind(this),
+                disconnect: this.onDisconnect.bind(this),
+                displayUri: this.onDisplayUri.bind(this),
+              },
+              analytics: {
+                integrationType: 'wagmi',
+              },
+              ui: {
+                ...parameters.ui,
+                ...(parameters.headless != null && {
+                  headless: parameters.headless,
+                }),
+              },
+              ...(parameters.mobile && { mobile: parameters.mobile }),
+            })
+          } catch (error) {
+            // biome-ignore lint/complexity/noUselessCatch: try block marks dependency as optional for webpack
+            throw error
+          }
         }
         metamask = await metamaskPromise
       }

--- a/packages/connectors/src/porto.ts
+++ b/packages/connectors/src/porto.ts
@@ -102,28 +102,14 @@ export function porto(parameters: PortoParameters = {}) {
 
         try {
           if (!accounts?.length && !isReconnecting) {
-            const { RpcSchema } = await (() => {
-              // safe webpack optional peer dependency dynamic import
-              try {
-                return import(
-                  /* turbopackOptional: true */
-                  'porto'
-                )
-              } catch {
-                throw new Error('dependency "porto" not found')
-              }
-            })()
-            const { z } = await (() => {
-              // safe webpack optional peer dependency dynamic import
-              try {
-                return import(
-                  /* turbopackOptional: true */
-                  'porto/internal'
-                )
-              } catch {
-                throw new Error('dependency "porto/internal" not found')
-              }
-            })()
+            const { RpcSchema } = await import(
+              /* turbopackOptional: true */
+              'porto'
+            )
+            const { z } = await import(
+              /* turbopackOptional: true */
+              'porto/internal'
+            )
             const res = await provider.request({
               method: 'wallet_connect',
               params: [
@@ -227,26 +213,25 @@ export function porto(parameters: PortoParameters = {}) {
       },
       async getPortoInstance() {
         porto_promise ??= (async () => {
-          const { Porto } = await (() => {
-            // safe webpack optional peer dependency dynamic import
-            try {
-              return import(
-                /* turbopackOptional: true */
-                'porto'
-              )
-            } catch {
-              throw new Error('dependency "porto" not found')
-            }
-          })()
-          // @ts-ignore
-          return Porto.create({
-            ...parameters,
-            announceProvider: false,
+          // safe webpack optional peer dependency dynamic import
+          try {
+            const { Porto } = await import(
+              /* turbopackOptional: true */
+              'porto'
+            )
             // @ts-ignore
-            chains,
-            // @ts-ignore
-            transports,
-          })
+            return Porto.create({
+              ...parameters,
+              announceProvider: false,
+              // @ts-ignore
+              chains,
+              // @ts-ignore
+              transports,
+            })
+          } catch (error) {
+            // biome-ignore lint/complexity/noUselessCatch: try block marks dependency as optional for webpack
+            throw error
+          }
         })()
         return await porto_promise
       },

--- a/packages/connectors/src/safe.ts
+++ b/packages/connectors/src/safe.ts
@@ -95,49 +95,39 @@ export function safe(parameters: SafeParameters = {}) {
       if (!isIframe) return
 
       if (!provider_) {
-        const { default: SDK } = await (() => {
-          // safe webpack optional peer dependency dynamic import
-          try {
-            return import(
-              /* turbopackOptional: true */
-              '@safe-global/safe-apps-sdk'
-            )
-          } catch {
-            throw new Error('dependency "@safe-global/safe-apps-sdk" not found')
-          }
-        })()
-        const sdk = new SDK(parameters)
-
-        // `getInfo` hangs when not used in Safe App iFrame
-        // https://github.com/safe-global/safe-apps-sdk/issues/263#issuecomment-1029835840
-        const safe = await withTimeout(() => sdk.safe.getInfo(), {
-          timeout: parameters.unstable_getInfoTimeout ?? 10,
-        })
-        if (!safe) throw new Error('Could not load Safe information')
-        // Unwrapping import for Vite compatibility.
-        // See: https://github.com/vitejs/vite/issues/9703
-        const SafeAppProvider = await (async () => {
-          const Provider = await (() => {
-            // safe webpack optional peer dependency dynamic import
-            try {
-              return import(
-                /* turbopackOptional: true */
-                '@safe-global/safe-apps-provider'
-              )
-            } catch {
-              throw new Error(
-                'dependency "@safe-global/safe-apps-provider" not found',
-              )
-            }
-          })()
-          if (
-            typeof Provider.SafeAppProvider !== 'function' &&
-            typeof Provider.default.SafeAppProvider === 'function'
+        // safe webpack optional peer dependency dynamic imports
+        try {
+          const { default: SDK } = await import(
+            /* turbopackOptional: true */
+            '@safe-global/safe-apps-sdk'
           )
-            return Provider.default.SafeAppProvider
-          return Provider.SafeAppProvider
-        })()
-        provider_ = new SafeAppProvider(safe, sdk)
+          const sdk = new SDK(parameters)
+
+          // `getInfo` hangs when not used in Safe App iFrame
+          // https://github.com/safe-global/safe-apps-sdk/issues/263#issuecomment-1029835840
+          const safe = await withTimeout(() => sdk.safe.getInfo(), {
+            timeout: parameters.unstable_getInfoTimeout ?? 10,
+          })
+          if (!safe) throw new Error('Could not load Safe information')
+          // Unwrapping import for Vite compatibility.
+          // See: https://github.com/vitejs/vite/issues/9703
+          const Provider = await import(
+            /* turbopackOptional: true */
+            '@safe-global/safe-apps-provider'
+          )
+          const SafeAppProvider = (() => {
+            if (
+              typeof Provider.SafeAppProvider !== 'function' &&
+              typeof Provider.default.SafeAppProvider === 'function'
+            )
+              return Provider.default.SafeAppProvider
+            return Provider.SafeAppProvider
+          })()
+          provider_ = new SafeAppProvider(safe, sdk)
+        } catch (error) {
+          // biome-ignore lint/complexity/noUselessCatch: try block marks dependencies as optional for webpack
+          throw error
+        }
       }
       return provider_
     },

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -270,35 +270,32 @@ export function walletConnect(parameters: WalletConnectParameters) {
       async function initProvider() {
         const optionalChains = config.chains.map((x) => x.id) as [number]
         if (!optionalChains.length) return
-        const { EthereumProvider } = await (() => {
-          // safe webpack optional peer dependency dynamic import
-          try {
-            return import(
-              /* turbopackOptional: true */
-              '@walletconnect/ethereum-provider'
-            )
-          } catch {
-            throw new Error(
-              'dependency "@walletconnect/ethereum-provider" not found',
-            )
-          }
-        })()
-        return await EthereumProvider.init({
-          ...parameters,
-          disableProviderPing: true,
-          optionalChains,
-          projectId: parameters.projectId,
-          rpcMap: Object.fromEntries(
-            config.chains.map((chain) => {
-              const [url] = extractRpcUrls({
-                chain,
-                transports: config.transports,
-              })
-              return [chain.id, url]
-            }),
-          ),
-          showQrModal: parameters.showQrModal ?? true,
-        })
+        // safe webpack optional peer dependency dynamic import
+        try {
+          const { EthereumProvider } = await import(
+            /* turbopackOptional: true */
+            '@walletconnect/ethereum-provider'
+          )
+          return await EthereumProvider.init({
+            ...parameters,
+            disableProviderPing: true,
+            optionalChains,
+            projectId: parameters.projectId,
+            rpcMap: Object.fromEntries(
+              config.chains.map((chain) => {
+                const [url] = extractRpcUrls({
+                  chain,
+                  transports: config.transports,
+                })
+                return [chain.id, url]
+              }),
+            ),
+            showQrModal: parameters.showQrModal ?? true,
+          })
+        } catch (error) {
+          // biome-ignore lint/complexity/noUselessCatch: try block marks dependency as optional for webpack
+          throw error
+        }
       }
 
       if (!provider_) {

--- a/packages/engine-tests/next/.gitignore
+++ b/packages/engine-tests/next/.gitignore
@@ -1,0 +1,1 @@
+next-env.d.ts

--- a/packages/engine-tests/next/app/layout.tsx
+++ b/packages/engine-tests/next/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Layout(props: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{props.children}</body>
+    </html>
+  )
+}

--- a/packages/engine-tests/next/app/page.tsx
+++ b/packages/engine-tests/next/app/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { createConfig, http } from 'wagmi'
+import { mainnet } from 'wagmi/chains'
+import { baseAccount } from 'wagmi/connectors'
+
+const config = createConfig({
+  chains: [mainnet],
+  connectors: [baseAccount()],
+  transports: { [mainnet.id]: http() },
+})
+
+export default function Page() {
+  return <div>{config.connectors[0]?.name}</div>
+}

--- a/packages/engine-tests/next/tsconfig.json
+++ b/packages/engine-tests/next/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "plugins": [{ "name": "next" }]
+  }
+}

--- a/packages/engine-tests/package.json
+++ b/packages/engine-tests/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "engine-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf next/.next vite/dist tsconfig.tsbuildinfo",
+    "test:build": "node test.ts"
+  },
+  "dependencies": {
+    "@base-org/account": "catalog:",
+    "next": "16.3.0-canary.96",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "viem": "2.*",
+    "vite": "catalog:",
+    "wagmi": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/packages/engine-tests/package.json
+++ b/packages/engine-tests/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "clean": "rm -rf next/.next vite/dist tsconfig.tsbuildinfo",
-    "test:build": "node test.ts"
+    "test": "node test.ts"
   },
   "dependencies": {
     "@base-org/account": "catalog:",

--- a/packages/engine-tests/test.ts
+++ b/packages/engine-tests/test.ts
@@ -1,0 +1,78 @@
+import { spawnSync } from 'node:child_process'
+import { readdir, readFile, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = fileURLToPath(new URL('.', import.meta.url))
+const nextRoot = path.join(root, 'next')
+const viteRoot = path.join(root, 'vite')
+
+const targets = [
+  {
+    name: 'Next.js (Turbopack)',
+    command: 'next',
+    args: ['build', nextRoot, '--turbopack'],
+    output: path.join(nextRoot, '.next/static/chunks'),
+    clean: path.join(nextRoot, '.next'),
+  },
+  {
+    name: 'Next.js (Webpack)',
+    command: 'next',
+    args: ['build', nextRoot, '--webpack'],
+    output: path.join(nextRoot, '.next/static/chunks'),
+    clean: path.join(nextRoot, '.next'),
+  },
+  {
+    name: 'Vite',
+    command: 'vite',
+    args: ['build', viteRoot],
+    output: path.join(viteRoot, 'dist/assets'),
+    clean: path.join(viteRoot, 'dist'),
+  },
+] as const
+
+const unusedChainMarkers = [
+  'Artela Testnet',
+  'Bitkub Testnet',
+  'WorldLand Mainnet',
+  'Zora Goerli Testnet',
+]
+
+for (const target of targets) {
+  console.log(`\nBuilding ${target.name}.`)
+  await rm(target.clean, { force: true, recursive: true })
+
+  const result = spawnSync(target.command, target.args, {
+    cwd: root,
+    env: { ...process.env, NEXT_TELEMETRY_DISABLED: '1' },
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0)
+    throw new Error(`${target.name} build exited with code ${result.status}.`)
+
+  const files = await getJavaScriptFiles(target.output)
+  if (files.length === 0)
+    throw new Error(`${target.name} build did not emit client JavaScript.`)
+
+  for (const file of files) {
+    const source = await readFile(file, 'utf8')
+    const marker = unusedChainMarkers.find((marker) => source.includes(marker))
+    if (marker)
+      throw new Error(
+        `${target.name} included unused Viem chain "${marker}" in ${path.relative(root, file)}.`,
+      )
+  }
+}
+
+async function getJavaScriptFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const file = path.join(directory, entry.name)
+      if (entry.isDirectory()) return getJavaScriptFiles(file)
+      return /\.[cm]?js$/.test(entry.name) ? [file] : []
+    }),
+  )
+  return files.flat()
+}

--- a/packages/engine-tests/tsconfig.json
+++ b/packages/engine-tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["next/.next", "vite/dist"],
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "target": "ESNext"
+  }
+}

--- a/packages/engine-tests/vite/index.html
+++ b/packages/engine-tests/vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wagmi Engine Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src.ts"></script>
+  </body>
+</html>

--- a/packages/engine-tests/vite/src.ts
+++ b/packages/engine-tests/vite/src.ts
@@ -1,0 +1,12 @@
+import { createConfig, http } from 'wagmi'
+import { mainnet } from 'wagmi/chains'
+import { baseAccount } from 'wagmi/connectors'
+
+const config = createConfig({
+  chains: [mainnet],
+  connectors: [baseAccount()],
+  transports: { [mainnet.id]: http() },
+})
+
+document.querySelector<HTMLDivElement>('#app')!.textContent =
+  config.connectors[0]?.name ?? ''

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,37 @@ importers:
         specifier: ^2.4.9
         version: 2.4.9
 
+  packages/engine-tests:
+    dependencies:
+      '@base-org/account':
+        specifier: 'catalog:'
+        version: 2.4.0(@types/react@19.2.3)(bufferutil@4.0.8)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@4.3.6)
+      next:
+        specifier: 16.3.0-canary.96
+        version: 16.3.0-canary.96(@types/node@24.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.0(react@19.2.0)
+      viem:
+        specifier: 2.*
+        version: 2.55.7(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.31.0)(tsx@4.21.0)(yaml@2.9.0)
+      wagmi:
+        specifier: workspace:*
+        version: link:../react
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.3
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.2(@types/react@19.2.3)
+
   packages/react:
     dependencies:
       '@wagmi/connectors':
@@ -2293,8 +2324,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.35.0':
     resolution: {integrity: sha512-c1z9LFpKB0slQW3RchwBE8iSVzGp70TNjUUO9k4BZwwW4HH7JBGHeIy4b+kk4n/kcBASb9evKCE3/7Slmslgiw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
@@ -2304,8 +2347,18 @@ packages:
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.3.0':
     resolution: {integrity: sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2314,8 +2367,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.3.0':
     resolution: {integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2326,8 +2390,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.3.0':
     resolution: {integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -2338,8 +2414,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.3.0':
     resolution: {integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -2350,8 +2438,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
     resolution: {integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -2362,8 +2462,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linux-arm64@0.35.0':
     resolution: {integrity: sha512-4+4XHLNT5wDT0roYlHTEmH9lDKt0acf9Tv+3hM3iceOirkxrR404/3WjAYZ9F9CkHrxeRcGLJXbi4vluMZ9O+A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
@@ -2376,8 +2489,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-ppc64@0.35.0':
     resolution: {integrity: sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
@@ -2390,8 +2517,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-s390x@0.35.0':
     resolution: {integrity: sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
@@ -2404,8 +2545,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linuxmusl-arm64@0.35.0':
     resolution: {integrity: sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
@@ -2418,8 +2573,19 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-wasm32@0.35.0':
     resolution: {integrity: sha512-9woLIFORERCr+6cWu87dQ22J34EExkhc73U1kZW0c+RclQqWetoodByp4dWZ/hN8/KVmTRAx2HOnUwib8AwZdA==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
     engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.0':
@@ -2427,8 +2593,19 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.35.0':
     resolution: {integrity: sha512-M5eKxug0dabbaWgFKvPa3odNs2OpaP+81NASfGKkt4GcYXpNhSu7CaeYxWkLNV6vHmUp4hnCxnxrUyhUJhXbKA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
@@ -2439,8 +2616,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.35.0':
     resolution: {integrity: sha512-feNnlz5ZHKr0MY1LPHvZQyJeBkbo4ctsn0D8FvA53VTw5TC63rfEL2UrWbkSBR19htSE7Mw78xYVwdJqoMWVHw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -2609,8 +2798,17 @@ packages:
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
+  '@next/env@16.3.0-canary.96':
+    resolution: {integrity: sha512-lHzmW1VFrxv+2fY9I5MXsC8b3D7IRQWt4n9kVvG8e+rEy9iGI4XLCAu04uzu1U+zFgjrKldIZlOjpNhL/OVsAg==}
+
   '@next/swc-darwin-arm64@16.2.6':
     resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.3.0-canary.96':
+    resolution: {integrity: sha512-LKxGOKepzVg+sUjKQ8nA7MipNEdrpybKyBd2dXtYNW56arZaI3rPIcK8luXUhg/qEkjr51vU5uNWep3d+qhG5A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2621,8 +2819,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.3.0-canary.96':
+    resolution: {integrity: sha512-Y7DPh+g0Q/JsDh3vKlMNUQpFQ0PHKxd8+KhFpPJFVvokqzK8tW+V3YjeS9MCeT7FX6/kY3bGWKZtwdZl/B0gVA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@16.2.6':
     resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.96':
+    resolution: {integrity: sha512-rJBT7hyd80QtOZPKELFN4q+GlJ1mJK6MPT/pTj2/Y8K/y4h2oERf1X/AXcRJkwrNJaGEbl62OoRSRXqcTIoF6A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2635,8 +2846,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@16.3.0-canary.96':
+    resolution: {integrity: sha512-mGb0eP8ITV7MLnnW+jkwtAhXtaDaBlGpcYuTLMo4d3lbrPSdEa7PpGBAG54ZPoSZiLB/ftEczBozM5Ud3Qm/Mg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.3.0-canary.96':
+    resolution: {integrity: sha512-ZuRXJs9hALl2NmaLXbOZcBeqbqO58snbhx/1EAj6w84mLXLUfCbT5Get/SSG/39E5f7It1YxxXtSfsJld+Wz9A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2649,14 +2874,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@16.3.0-canary.96':
+    resolution: {integrity: sha512-ko9/c6bf2bZuPdOADp1b5Loka44wOXSv4T+ApieUGhy6mMFbPYMp9z1stv997vMLD5+80epwtxCSpdYq04CBuQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.96':
+    resolution: {integrity: sha512-nERQottR+QHh2toL2PeYQ1oja0DZtXJapma570jh8g85G9q3chR2BZZVBrGXcsOQRQtyifvqfRbDSnB3B3COeg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@16.2.6':
     resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.3.0-canary.96':
+    resolution: {integrity: sha512-D+uu6EvuzO+W1vs/ZZkTnVgybTZ841MJ93IruiRxEa6s13bc/npSsYxDxF24mvMXfkioGn+IIfFkfqhURxpjPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8596,6 +8840,27 @@ packages:
       sass:
         optional: true
 
+  next@16.3.0-canary.96:
+    resolution: {integrity: sha512-BeUWaEnbEfuqI9XOtkQJpvDtX2hZilLmML3NQ1uef/cZnf/4T/Me/L7eUcU9XrVzX303S2oA+8RdqZYa3HcelQ==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   nitropack@2.13.4:
     resolution: {integrity: sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9883,6 +10148,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -9945,6 +10215,15 @@ packages:
   sharp@0.35.0:
     resolution: {integrity: sha512-BqvG5XbwPZ4NV0DK90d86leEECMsoa8bO0nqnKWlBDYxri4GJ7c4EDInaF6q20lTh/mATmnDIKWJFfXnoVfH5g==}
     engines: {node: '>=20.9.0'}
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -12089,6 +12368,32 @@ snapshots:
       - ws
       - zod
 
+  '@base-org/account@2.4.0(@types/react@19.2.3)(bufferutil@4.0.8)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@4.3.6)':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      preact: 10.24.2
+      viem: 2.55.7(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.3(@types/react@19.2.3)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - react
+      - supports-color
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+      - zod
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.2.4':
@@ -12894,9 +13199,19 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.3.0
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
   '@img/sharp-darwin-x64@0.35.0':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
   '@img/sharp-freebsd-wasm32@0.35.0':
@@ -12904,34 +13219,69 @@ snapshots:
       '@img/sharp-wasm32': 0.35.0
     optional: true
 
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.3.0':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.3.0':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.3.0':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.3.0':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     optional: true
 
   '@img/sharp-linux-arm64@0.35.0':
@@ -12939,9 +13289,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.3.0
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
   '@img/sharp-linux-arm@0.35.0':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
   '@img/sharp-linux-ppc64@0.35.0':
@@ -12949,9 +13309,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.3.0
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
   '@img/sharp-linux-riscv64@0.35.0':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
   '@img/sharp-linux-s390x@0.35.0':
@@ -12959,9 +13329,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.3.0
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
   '@img/sharp-linux-x64@0.35.0':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.35.0':
@@ -12969,12 +13349,27 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.35.0':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.0
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
   '@img/sharp-wasm32@0.35.0':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
@@ -12984,13 +13379,27 @@ snapshots:
       '@img/sharp-wasm32': 0.35.0
     optional: true
 
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
   '@img/sharp-win32-arm64@0.35.0':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
   '@img/sharp-win32-ia32@0.35.0':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
   '@img/sharp-win32-x64@0.35.0':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@inquirer/confirm@3.1.6':
@@ -13113,7 +13522,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.8.4
+      semver: 7.8.5
       tar: 7.5.19
     transitivePeerDependencies:
       - encoding
@@ -13221,7 +13630,7 @@ snapshots:
       '@types/debug': 4.1.7
       debug: 4.4.3
       pony-cause: 2.1.11
-      semver: 7.8.4
+      semver: 7.8.5
       uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13257,28 +13666,54 @@ snapshots:
 
   '@next/env@16.2.6': {}
 
+  '@next/env@16.3.0-canary.96': {}
+
   '@next/swc-darwin-arm64@16.2.6':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.3.0-canary.96':
     optional: true
 
   '@next/swc-darwin-x64@16.2.6':
     optional: true
 
+  '@next/swc-darwin-x64@16.3.0-canary.96':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.96':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
+  '@next/swc-linux-arm64-musl@16.3.0-canary.96':
+    optional: true
+
   '@next/swc-linux-x64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.3.0-canary.96':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
+  '@next/swc-linux-x64-musl@16.3.0-canary.96':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.96':
+    optional: true
+
   '@next/swc-win32-x64-msvc@16.2.6':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.3.0-canary.96':
     optional: true
 
   '@noble/ciphers@1.2.1': {}
@@ -13520,7 +13955,7 @@ snapshots:
       magicast: 0.5.3
       pathe: 2.0.3
       pkg-types: 2.3.1
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@nuxt/devtools@3.2.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)(vite@8.0.16(@types/node@24.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.31.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
@@ -18798,7 +19233,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.7
-      semver: 7.8.4
+      semver: 7.8.5
 
   ee-first@1.1.1: {}
 
@@ -19960,7 +20395,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   make-synchronized@0.8.0: {}
 
@@ -20525,6 +20960,31 @@ snapshots:
       sharp: 0.35.0
     transitivePeerDependencies:
       - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.3.0-canary.96(@types/node@24.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 16.3.0-canary.96
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      postcss: 8.5.10
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      styled-jsx: 5.1.6(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.3.0-canary.96
+      '@next/swc-darwin-x64': 16.3.0-canary.96
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.96
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.96
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.96
+      '@next/swc-linux-x64-musl': 16.3.0-canary.96
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.96
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.96
+      sharp: 0.35.3(@types/node@24.6.2)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   nitropack@2.13.4(idb-keyval@6.2.2)(oxc-parser@0.132.0)(rolldown@1.0.3):
@@ -21275,6 +21735,20 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.6.9(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -22393,6 +22867,8 @@ snapshots:
 
   semver@7.8.4: {}
 
+  semver@7.8.5: {}
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -22481,7 +22957,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.35.0
       '@img/sharp-darwin-x64': 0.35.0
@@ -22508,6 +22984,40 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.0
       '@img/sharp-win32-ia32': 0.35.0
       '@img/sharp-win32-x64': 0.35.0
+
+  sharp@0.35.3(@types/node@24.6.2):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 24.6.2
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
The optional dependency imports were wrapped in IIFEs that hid named export usage from bundler analysis, causing unrelated dependency exports such as Viem chains to be retained in application bundles. Their synchronous `try` blocks also did not catch rejected dynamic import promises.

The imports now remain directly inside `try` blocks, preserving optional dependency resolution while allowing bundlers to infer the exports each connector uses.

The Turbopack fixture pins Next.js 16.3.0-canary.96 because it is the first release containing vercel/next.js#95989. Stable Next.js 16.2 still retains the unrelated exports due to that upstream re-export propagation issue.

Closes #5206