### PR TITLE
fix(tempo): don't chain .catch() on optional accounts import

### DIFF
--- a/.changeset/tempo-metro-dynamic-import.md
+++ b/.changeset/tempo-metro-dynamic-import.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed Tempo connectors crashing with `TypeError: undefined is not a function` on bundlers where dynamic `import()` does not return a spec-compliant `Promise` (e.g. Metro/React Native).

--- a/packages/core/src/tempo/Connectors.test.ts
+++ b/packages/core/src/tempo/Connectors.test.ts
@@ -106,6 +106,41 @@ describe('tempoWallet', () => {
   })
 })
 
+describe('getProvider', () => {
+  test('resolves when dynamic import returns a then-only thenable', async () => {
+    const config = createConfig({
+      chains: [tempoLocal],
+      connectors: [],
+      storage: null,
+      transports: {
+        [tempoLocal.id]: http(),
+      },
+    })
+
+    const address = accounts[0]!.address
+    const dialog = createTempoWalletDialog(address)
+    const storage = AccountsStorage.memory({ key: 'tempo-metro-test' })
+
+    // Metro's transformed `import()` returns a thenable without `.catch`.
+    // Simulate by removing `Promise.prototype.catch` while the connector
+    // evaluates the dynamic import synchronously.
+    const originalCatch = Promise.prototype.catch
+    let provider: Promise<unknown>
+    // @ts-expect-error simulating Metro's then-only thenable
+    Promise.prototype.catch = undefined
+    try {
+      const connector = config._internal.connectors.setup(
+        tempoWallet({ dialog, storage }),
+      )
+      provider = connector.getProvider()
+    } finally {
+      Promise.prototype.catch = originalCatch
+    }
+
+    await expect(provider).resolves.toBeDefined()
+  })
+})
+
 describe('webAuthn', () => {
   describe('register with authorizeAccessKey', () => {
     test('passes chainId to signKeyAuthorization', async (context) => {

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -188,12 +188,16 @@ function _setup(parameters: setup.Parameters) {
     let disconnect: ((error?: Error | undefined) => void) | undefined
 
     async function getAccountsModule() {
-      return await import(
-        /* turbopackOptional: true */
-        'accounts'
-      ).catch(() => {
+      // `try`/`catch` instead of chaining `.catch()` since some bundlers
+      // (e.g. Metro) transform `import()` into a thenable without `.catch`.
+      try {
+        return await import(
+          /* turbopackOptional: true */
+          'accounts'
+        )
+      } catch {
         throw new Error('dependency "accounts" not found')
-      })
+      }
     }
 
     async function getProvider() {


### PR DESCRIPTION
Fixes #5201

Metro (React Native) transforms dynamic `import()` into a thenable that has `.then` but no `.catch`, so `import('accounts').catch(...)` in the Tempo connectors throws `TypeError: undefined is not a function` on `setup()` even when `accounts` is installed. Replaced the chain with `try`/`await`/`catch` — behavior is identical where `import()` returns a real `Promise`. The `turbopackOptional` comment from #5165 is preserved.

The test simulates Metro by removing `Promise.prototype.catch` while the connector evaluates the import synchronously; it fails on the previous code with the same `TypeError`.

Not covered: the `dependency "accounts" not found` message path — an unresolvable module can't be simulated in the browser-mode suite; that behavior is unchanged.