### PR TITLE
Fix async injected provider cleanup

### DIFF
--- a/.changeset/calm-ravens-listen.md
+++ b/.changeset/calm-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed async injected provider detection retaining its initialization listener and timeout after authorization settled.

--- a/packages/core/src/connectors/injected.test.ts
+++ b/packages/core/src/connectors/injected.test.ts
@@ -1,7 +1,12 @@
 import { config } from '@wagmi/test'
-import { expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 
 import { injected } from './injected.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
 
 test('setup', () => {
   const connectorFn = injected()
@@ -22,4 +27,65 @@ test.each([
   const connectorFn = injected({ target: wallet })
   const connector = config._internal.connectors.setup(connectorFn)
   expect(connector.name).toEqual(expected)
+})
+
+test('cleans up async injection listener after timeout', async () => {
+  vi.useFakeTimers()
+  const addEventListener = vi.spyOn(window, 'addEventListener')
+  const removeEventListener = vi.spyOn(window, 'removeEventListener')
+  const connector = config._internal.connectors.setup(
+    injected({
+      target: {
+        id: 'test',
+        name: 'Test',
+        provider: () => undefined,
+      },
+      unstable_shimAsyncInject: 100,
+    }),
+  )
+  const getProvider = vi.spyOn(connector, 'getProvider')
+
+  const isAuthorized = connector.isAuthorized()
+  await vi.advanceTimersByTimeAsync(0)
+  const listener = addEventListener.mock.calls.find(
+    ([type]) => type === 'ethereum#initialized',
+  )?.[1]
+
+  await vi.advanceTimersByTimeAsync(100)
+  await expect(isAuthorized).resolves.toBe(false)
+  expect(removeEventListener).toHaveBeenCalledWith(
+    'ethereum#initialized',
+    listener,
+  )
+
+  const calls = getProvider.mock.calls.length
+  window.dispatchEvent(new Event('ethereum#initialized'))
+  await vi.advanceTimersByTimeAsync(0)
+  expect(getProvider).toHaveBeenCalledTimes(calls)
+})
+
+test('cancels async injection timeout after event', async () => {
+  vi.useFakeTimers()
+  let provider: object | undefined
+  const connector = config._internal.connectors.setup(
+    injected({
+      target: {
+        id: 'test',
+        name: 'Test',
+        provider: () => provider as never,
+      },
+      unstable_shimAsyncInject: 100,
+    }),
+  )
+  const getProvider = vi.spyOn(connector, 'getProvider')
+
+  const isAuthorized = connector.isAuthorized()
+  await vi.advanceTimersByTimeAsync(0)
+  provider = {}
+  window.dispatchEvent(new Event('ethereum#initialized'))
+
+  await expect(isAuthorized).resolves.toBe(true)
+  const calls = getProvider.mock.calls.length
+  await vi.advanceTimersByTimeAsync(100)
+  expect(getProvider).toHaveBeenCalledTimes(calls)
 })

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -307,35 +307,39 @@ export function injected(parameters: InjectedParameters = {}) {
             // If no provider is found, check for async injection
             // https://github.com/wevm/references/issues/167
             // https://github.com/MetaMask/detect-provider
-            const handleEthereum = async () => {
-              if (typeof window !== 'undefined')
-                window.removeEventListener(
-                  'ethereum#initialized',
-                  handleEthereum,
-                )
-              const provider = await this.getProvider()
-              return !!provider
-            }
             const timeout =
               typeof unstable_shimAsyncInject === 'number'
                 ? unstable_shimAsyncInject
                 : 1_000
-            const res = await Promise.race([
-              ...(typeof window !== 'undefined'
-                ? [
-                    new Promise<boolean>((resolve) =>
-                      window.addEventListener(
-                        'ethereum#initialized',
-                        () => resolve(handleEthereum()),
-                        { once: true },
-                      ),
-                    ),
-                  ]
-                : []),
-              new Promise<boolean>((resolve) =>
-                setTimeout(() => resolve(handleEthereum()), timeout),
-              ),
-            ])
+            const res = await new Promise<boolean>((resolve) => {
+              let settled = false
+
+              const finish = async () => {
+                if (settled) return
+                settled = true
+
+                clearTimeout(timer)
+                if (typeof window !== 'undefined')
+                  window.removeEventListener('ethereum#initialized', onEthereum)
+
+                try {
+                  resolve(!!(await this.getProvider()))
+                } catch {
+                  resolve(false)
+                }
+              }
+              const onEthereum = () => {
+                void finish()
+              }
+              const timer = setTimeout(() => {
+                void finish()
+              }, timeout)
+
+              if (typeof window !== 'undefined')
+                window.addEventListener('ethereum#initialized', onEthereum, {
+                  once: true,
+                })
+            })
             if (res) return true
           }
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://wagmi.sh/dev/contributing
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Wagmi!
----------------------------------------------------------------------->

## Summary

- consolidate the async injected provider event and timeout paths into a single settlement path
- remove the exact `ethereum#initialized` listener and clear the timeout once detection settles
- prevent the losing path from querying the provider after authorization has already completed
- add regression tests for both timeout-first and event-first behavior

Previously, the listener registered for `ethereum#initialized` was an anonymous wrapper, while cleanup attempted to remove a different function reference. If the timeout settled first and the event was never emitted, the listener remained attached. If the event settled first, the uncancelled timeout could later perform another provider lookup.

The new settlement path cleans up the listener and timeout before querying the provider and guards against concurrent settlement.


I have tested by the following cmd:

- `pnpm vitest run packages/core/src/connectors/injected.test.ts --project core`
- `pnpm --filter @wagmi/core check:types`
- `pnpm biome check packages/core/src/connectors/injected.ts packages/core/src/connectors/injected.test.ts .changeset/calm-ravens-listen.md`
- `pnpm changeset status`
