### PR TITLE
fix(tempo): support then-only dynamic imports

### DIFF
--- a/.changeset/tempo-metro-dynamic-import.md
+++ b/.changeset/tempo-metro-dynamic-import.md
@@ -2,4 +2,4 @@
 "@wagmi/core": patch
 ---
 
-Fixed Tempo connectors crashing when dynamic `import()` returns a thenable without `.catch`, such as with Metro.
+Fixed Tempo connectors crashing with Metro

--- a/.changeset/tempo-metro-dynamic-import.md
+++ b/.changeset/tempo-metro-dynamic-import.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed Tempo connectors crashing when dynamic `import()` returns a thenable without `.catch`, such as with Metro.

--- a/packages/core/src/tempo/Connectors.test.ts
+++ b/packages/core/src/tempo/Connectors.test.ts
@@ -106,6 +106,38 @@ describe('tempoWallet', () => {
   })
 })
 
+describe('getProvider', () => {
+  test('resolves when dynamic import returns a then-only thenable', async () => {
+    const config = createConfig({
+      chains: [tempoLocal],
+      connectors: [],
+      storage: null,
+      transports: {
+        [tempoLocal.id]: http(),
+      },
+    })
+
+    const address = accounts[0]!.address
+    const dialog = createTempoWalletDialog(address)
+    const storage = AccountsStorage.memory({ key: 'tempo-metro-test' })
+
+    const originalCatch = Promise.prototype.catch
+    let provider: Promise<unknown>
+    // @ts-expect-error Simulate Metro's then-only dynamic import result.
+    Promise.prototype.catch = undefined
+    try {
+      const connector = config._internal.connectors.setup(
+        tempoWallet({ dialog, storage }),
+      )
+      provider = connector.getProvider()
+    } finally {
+      Promise.prototype.catch = originalCatch
+    }
+
+    await expect(provider).resolves.toBeDefined()
+  })
+})
+
 describe('webAuthn', () => {
   describe('register with authorizeAccessKey', () => {
     test('passes chainId to signKeyAuthorization', async (context) => {

--- a/packages/core/src/tempo/Connectors.ts
+++ b/packages/core/src/tempo/Connectors.ts
@@ -188,12 +188,14 @@ function _setup(parameters: setup.Parameters) {
     let disconnect: ((error?: Error | undefined) => void) | undefined
 
     async function getAccountsModule() {
-      return await import(
-        /* turbopackOptional: true */
-        'accounts'
-      ).catch(() => {
+      try {
+        return await import(
+          /* turbopackOptional: true */
+          'accounts'
+        )
+      } catch {
         throw new Error('dependency "accounts" not found')
-      })
+      }
     }
 
     async function getProvider() {


### PR DESCRIPTION
Closes #5201 and supersedes #5202 by awaiting the optional `accounts` import inside `try`/`catch` for Metro compatibility.