### PR TITLE
docs: fix type names in estimateMaxPriorityFeePerGas reference

### DIFF
--- a/site/core/api/actions/estimateMaxPriorityFeePerGas.md
+++ b/site/core/api/actions/estimateMaxPriorityFeePerGas.md
@@ -1,7 +1,7 @@
 <script setup>
 const packageName = '@wagmi/core'
 const actionName = 'estimateMaxPriorityFeePerGas'
-const typeName = 'EstimateFeesPerGas'
+const typeName = 'EstimateMaxPriorityFeePerGas'
 </script>
 
 # estimateMaxPriorityFeePerGas
@@ -29,7 +29,7 @@ const result = await estimateMaxPriorityFeePerGas(config)
 ## Parameters
 
 ```ts
-import { type EstimateFeesPerGasParameters } from '@wagmi/core'
+import { type EstimateMaxPriorityFeePerGasParameters } from '@wagmi/core'
 ```
 
 ### chainId
@@ -54,7 +54,7 @@ const result = await estimateMaxPriorityFeePerGas(config, {
 ## Return Type
 
 ```ts
-import { type EstimateFeesPerGasReturnType } from '@wagmi/core'
+import { type EstimateMaxPriorityFeePerGasReturnType } from '@wagmi/core'
 ```
 
 `bigint`
@@ -64,7 +64,7 @@ An estimate (in wei) for the max priority fee per gas.
 ## Error
 
 ```ts
-import { type EstimateFeesPerGasErrorType } from '@wagmi/core'
+import { type EstimateMaxPriorityFeePerGasErrorType } from '@wagmi/core'
 ```
 
 <!--@include: @shared/query-imports.md-->


### PR DESCRIPTION
The `estimateMaxPriorityFeePerGas` reference page was copy-pasted from `estimateFeesPerGas` and the type names were never updated, so the `typeName` and the three import examples reference `EstimateFeesPerGas*` types that do not exist for this action. The core action exports `EstimateMaxPriorityFeePerGas{Parameters,ReturnType,ErrorType}`. Updated all four to the correct type names.
