### PR TITLE
fix(core): enable getTransaction query for blockNumber 0 (genesis)

### DIFF
--- a/.changeset/get-transaction-block-number-zero.md
+++ b/.changeset/get-transaction-block-number-zero.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/core": patch
+---
+
+Fixed `getTransaction` query being disabled for `blockNumber: 0n` (genesis), which is a valid input but was treated as falsy alongside a valid `index`.

--- a/packages/core/src/query/getTransaction.test.ts
+++ b/packages/core/src/query/getTransaction.test.ts
@@ -40,3 +40,19 @@ test('parameters: index 0 with blockNumber enables query', () => {
   })
   expect(options.enabled).toBe(true)
 })
+
+test('parameters: blockNumber 0 (genesis) with index 0 enables query', () => {
+  const options = getTransactionQueryOptions(config, {
+    blockNumber: 0n,
+    index: 0,
+  })
+  expect(options.enabled).toBe(true)
+})
+
+test('parameters: blockNumber 0 (genesis) with index enables query', () => {
+  const options = getTransactionQueryOptions(config, {
+    blockNumber: 0n,
+    index: 1,
+  })
+  expect(options.enabled).toBe(true)
+})

--- a/packages/core/src/query/getTransaction.ts
+++ b/packages/core/src/query/getTransaction.ts
@@ -37,7 +37,9 @@ export function getTransactionQueryOptions<
     enabled: Boolean(
       (options.hash ||
         (options.index !== undefined &&
-          (options.blockHash || options.blockNumber || options.blockTag))) &&
+          (options.blockHash ||
+            options.blockNumber !== undefined ||
+            options.blockTag))) &&
         (options.query?.enabled ?? true),
     ),
     queryFn: async (context) => {
@@ -47,7 +49,7 @@ export function getTransactionQueryOptions<
           parameters.hash ||
           (parameters.index !== undefined &&
             (parameters.blockHash ||
-              parameters.blockNumber ||
+              parameters.blockNumber !== undefined ||
               parameters.blockTag))
         )
       )


### PR DESCRIPTION
`getTransactionQueryOptions` tests `blockNumber` for truthiness in both the `enabled` guard and the `queryFn` precondition, so the genesis block `0n` is treated as absent:

```ts
enabled: Boolean(
  (options.hash ||
    (options.index !== undefined &&
      (options.blockHash || options.blockNumber || options.blockTag))) &&
    (options.query?.enabled ?? true),
)
```

With `{ blockNumber: 0n, index: 0 }` the inner group evaluates to `undefined`, so `enabled` is `false` and the query never fetches. The user cannot override it either, since `query.enabled` is ANDed with the same expression, so `useTransaction({ blockNumber: 0n, index: 0 })` sits permanently idle with no error. If the `queryFn` is invoked directly it throws the misleading `hash OR index AND blockHash, blockNumber, blockTag is required`. Any other block number works, which masks the bug.

This is the remaining half of the same falsy check: #5197 corrected `index` on this exact expression but left `blockNumber`, and #5203 corrected `blockNumber: 0n` in `getBalance` / `getTransactionCount` for the same reason.

Nothing downstream blocks the value: viem's `getTransaction` accepts `blockNumber: 0n`, and `filterQueryOptions` uses rest destructuring so `0n` is preserved in the query key.

### Change

Compare `blockNumber` against `undefined` instead of testing truthiness, in both the `enabled` guard and the `queryFn` precondition, matching the treatment `index` already received. `blockHash` and `blockTag` are left as-is since they are non-empty strings when present.

### Tests

Added two cases to `packages/core/src/query/getTransaction.test.ts` covering `blockNumber: 0n` with `index: 0` and with a non-zero index, so the assertion isolates `blockNumber` rather than `index`.

Both fail on `main` and pass with this change:

```
# with the fix reverted
 × parameters: blockNumber 0 (genesis) with index 0 enables query
 × parameters: blockNumber 0 (genesis) with index enables query
 Tests  2 failed | 3 passed (5)

# with the fix
 Tests  5 passed (5)
```

The full `packages/core/src/query` suite passes: 54 files, 123 tests. `biome check` is clean on both changed files.
