### PR TITLE
fix(react): forward includeTransactions and blockTag to useBlock watcher

### DIFF
--- a/.changeset/hungry-donuts-shave.md
+++ b/.changeset/hungry-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+"wagmi": patch
+---
+
+Forwarded `includeTransactions` and `blockTag` to the block watcher in `useBlock` so watched updates match the query parameters

--- a/packages/react/src/hooks/useBlock.test.ts
+++ b/packages/react/src/hooks/useBlock.test.ts
@@ -1,5 +1,6 @@
-import { testClient } from '@wagmi/test'
+import { accounts, testClient } from '@wagmi/test'
 import { renderHook } from '@wagmi/test/react'
+import { parseEther } from 'viem'
 import { expect, test, vi } from 'vitest'
 
 import { useBlock } from './useBlock.js'
@@ -64,4 +65,35 @@ test('parameters: watch', async () => {
   await vi.waitFor(() => {
     expect(result.current.data?.number).toEqual(block.number + 2n)
   })
+})
+
+test('parameters: watch (includeTransactions)', async () => {
+  await testClient.mainnet.mine({ blocks: 1 })
+
+  const { result } = await renderHook(() =>
+    useBlock({ includeTransactions: true, watch: true }),
+  )
+
+  await vi.waitUntil(() => result.current.isSuccess, { timeout: 10_000 })
+  const block = result.current.data!
+  expect(block).toBeDefined()
+
+  await testClient.mainnet.setBalance({
+    address: accounts[0],
+    value: parseEther('10'),
+  })
+  await testClient.mainnet.sendUnsignedTransaction({
+    from: accounts[0],
+    to: accounts[1],
+    value: parseEther('1'),
+  })
+  await testClient.mainnet.mine({ blocks: 1 })
+
+  await vi.waitFor(() => {
+    expect(result.current.data?.number).toEqual(block.number + 1n)
+  })
+
+  const transactions = result.current.data!.transactions
+  expect(transactions.length).toBeGreaterThan(0)
+  expect(typeof transactions[0]).not.toBe('string')
 })

--- a/packages/react/src/hooks/useBlock.ts
+++ b/packages/react/src/hooks/useBlock.ts
@@ -91,6 +91,8 @@ export function useBlock<
     ...({
       config: parameters.config,
       chainId: parameters.chainId!,
+      blockTag: parameters.blockTag,
+      includeTransactions: parameters.includeTransactions,
       ...(typeof parameters.watch === 'object' ? parameters.watch : {}),
     } as UseWatchBlocksParameters),
     enabled: Boolean(


### PR DESCRIPTION
### Problem

`useBlock` builds its query key with the caller's `includeTransactions` and `blockTag`, but only forwards `config` and `chainId` into `useWatchBlocks`:

```ts
const options = getBlockQueryOptions(config, {
  ...parameters,
  chainId: parameters.chainId ?? chainId,
})
useWatchBlocks({
  ...({
    config: parameters.config,
    chainId: parameters.chainId!,
    ...(typeof parameters.watch === 'object' ? parameters.watch : {}),
  } as UseWatchBlocksParameters),
  ...
  onBlock(block) {
    queryClient.setQueryData(options.queryKey, block)
  },
})
```

The watcher therefore fetches with viem's defaults (`includeTransactions: false`, `blockTag: 'latest'`) and writes that block straight into a query key that promised something else.

For `useBlock({ includeTransactions: true, watch: true })` this means the initial fetch returns full `Transaction` objects, and then the very next block silently replaces `data.transactions` with an array of hash strings — while the return type still says `Transaction[]`. The same mismatch applies to `blockTag: 'safe' | 'finalized'` combined with `watch`.

### Fix

Forward `blockTag` and `includeTransactions` into `useWatchBlocks`, placed before the `watch` object spread so an explicit `watch` object still takes precedence:

```ts
blockTag: parameters.blockTag,
includeTransactions: parameters.includeTransactions,
```

viem's `watchBlocks` resolves both defaults internally (`includeTransactions_ ?? false`, `blockTag = 'latest'`), so passing `undefined` keeps the current behaviour when the parameters are not set.

### Test

Added `parameters: watch (includeTransactions)` to `packages/react/src/hooks/useBlock.test.ts`. The existing `parameters: watch` test only covers `watch: true` without `includeTransactions`, so this case was not exercised.

On `main` the new test fails with:

```
AssertionError: expected 'string' not to be 'string'
 at packages/react/src/hooks/useBlock.test.ts:98:37
```

With the fix applied it passes.
