### PR TITLE
docs: clarify paymaster receipt identifiers

### DIFF
--- a/site/core/api/actions/waitForTransactionReceipt.md
+++ b/site/core/api/actions/waitForTransactionReceipt.md
@@ -8,6 +8,10 @@ const typeName = 'WaitForTransactionReceipt'
 
 Action that waits for the transaction to be included on a block, and then returns the transaction receipt. If the transaction reverts, then the action will throw an error. Replacement detection (e.g. sped up transactions) is also supported.
 
+::: warning
+This action expects an on-chain transaction hash. It does not accept an EIP-5792 call bundle ID or a UserOperation hash returned by `writeContracts`, including calls submitted with a paymaster. For batched calls, use [`waitForCallsStatus`](/core/api/actions/waitForCallsStatus) with the returned ID. Its `receipts` field contains the on-chain transaction receipts.
+:::
+
 ## Import
 
 ```ts

--- a/site/react/api/hooks/useWaitForTransactionReceipt.md
+++ b/site/react/api/hooks/useWaitForTransactionReceipt.md
@@ -15,6 +15,10 @@ const TError = 'WaitForTransactionReceiptErrorType'
 
 Hook that waits for the transaction to be included on a block, and then returns the transaction receipt. If the transaction reverts, then the action will throw an error. Replacement detection (e.g. sped up transactions) is also supported.
 
+::: warning
+This hook expects an on-chain transaction hash. It does not accept an EIP-5792 call bundle ID or a UserOperation hash returned by `writeContracts`, including calls submitted with a paymaster. For batched calls, use [`useWaitForCallsStatus`](/react/api/hooks/useWaitForCallsStatus) with the returned ID. Its `receipts` field contains the on-chain transaction receipts.
+:::
+
 ## Import
 
 ```ts


### PR DESCRIPTION
Fixes #4626

## What is this PR solving?

`useWaitForTransactionReceipt` and `waitForTransactionReceipt` expect an on-chain transaction hash. EIP-5792 `writeContracts` returns a call bundle identifier, and paymaster-backed flows may return a UserOperation identifier. Passing either identifier to the transaction receipt APIs leads to repeated `null` results because the identifier is not an L1 or L2 transaction hash.

This PR adds matching warnings to the React hook and core action documentation. The warning directs users to `useWaitForCallsStatus` or `waitForCallsStatus`, whose `receipts` field exposes the on-chain transaction receipts for batched calls.

## Scope

The change is documentation-only. It does not change receipt polling behavior or runtime APIs. It records the supported distinction between transaction hashes and call bundle or UserOperation identifiers.

## Validation

- `git diff --check` passes.
- - The two documentation pages use the repository’s existing warning admonition syntax.
- - The commit is GPG verified.
- 