### PR TITLE
fix(cli): support named Foundry deployments sharing one artifact ABI

### DIFF
--- a/.changeset/foundry-alias-deployments.md
+++ b/.changeset/foundry-alias-deployments.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/cli": patch
+---
+
+Added support for named Foundry deployments that share one artifact's ABI, via `deployments: { <name>: { artifact, address } }` in the `foundry` plugin. This fixes multiple contract addresses (e.g. different ERC20 tokens) that reuse the same ABI only generating one config.

--- a/packages/cli/src/plugins/foundry.test.ts
+++ b/packages/cli/src/plugins/foundry.test.ts
@@ -349,6 +349,99 @@ test('broadcast deployments filters CALL transactions', async () => {
   })
 })
 
+test('deployments support multiple named contracts sharing one artifact ABI', async () => {
+  const dir = await createTempDir()
+  const spy = vi.spyOn(process, 'cwd')
+  spy.mockImplementation(() => dir)
+
+  const artifactsDir = resolve(dir, 'out')
+  await fs.mkdir(artifactsDir, { recursive: true })
+  const erc20Artifact = {
+    abi: [
+      {
+        inputs: [],
+        name: 'totalSupply',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ],
+  }
+  await fs.writeFile(
+    resolve(artifactsDir, 'ERC20.json'),
+    JSON.stringify(erc20Artifact, null, 2),
+  )
+
+  const result = await foundry({
+    deployments: {
+      DAI: {
+        artifact: 'ERC20',
+        address: { 1: '0x6b175474e89094c44da98b954eedeac495271d0' },
+      },
+      WETH: {
+        artifact: 'ERC20',
+        address: { 1: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' },
+      },
+    },
+  }).contracts?.()
+
+  const dai = result?.find((c) => c.name === 'DAI')
+  expect(dai?.address).toEqual({
+    '1': '0x6b175474e89094c44da98b954eedeac495271d0',
+  })
+  expect(dai?.abi).toEqual(erc20Artifact.abi)
+
+  const weth = result?.find((c) => c.name === 'WETH')
+  expect(weth?.address).toEqual({
+    '1': '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  })
+  expect(weth?.abi).toEqual(erc20Artifact.abi)
+
+  // base artifact-named contract is still emitted (no address, since `ERC20` key
+  // wasn't given its own plain-address entry in `deployments`)
+  const erc20 = result?.find((c) => c.name === 'ERC20')
+  expect(erc20?.address).toBeUndefined()
+  expect(erc20?.abi).toEqual(erc20Artifact.abi)
+})
+
+test('deployments still support a plain address for the artifact itself', async () => {
+  const dir = await createTempDir()
+  const spy = vi.spyOn(process, 'cwd')
+  spy.mockImplementation(() => dir)
+
+  const artifactsDir = resolve(dir, 'out')
+  await fs.mkdir(artifactsDir, { recursive: true })
+  const counterArtifact = {
+    abi: [
+      {
+        inputs: [],
+        name: 'increment',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ],
+  }
+  await fs.writeFile(
+    resolve(artifactsDir, 'Counter.json'),
+    JSON.stringify(counterArtifact, null, 2),
+  )
+
+  const result = await foundry({
+    deployments: {
+      Counter: '0x1234567890123456789012345678901234567890',
+    },
+  }).contracts?.()
+
+  expect(result).toEqual([
+    {
+      abi: counterArtifact.abi,
+      address: '0x1234567890123456789012345678901234567890',
+      name: 'Counter',
+    },
+  ])
+})
+
 test('watch callbacks use broadcast deployments', async () => {
   const dir = await createTempDir()
   const spy = vi.spyOn(process, 'cwd')

--- a/packages/cli/src/plugins/foundry.ts
+++ b/packages/cli/src/plugins/foundry.ts
@@ -60,8 +60,24 @@ export type FoundryConfig = {
    * @default false
    */
   includeBroadcasts?: boolean | undefined
-  /** Mapping of addresses to attach to artifacts. */
-  deployments?: { [key: string]: ContractConfig['address'] } | undefined
+  /**
+   * Mapping of addresses to attach to artifacts.
+   *
+   * A key can either resolve to an address (or `{ [chainId]: address }` map) for the
+   * artifact of the same name, or to `{ artifact, address }` to generate an additional,
+   * separately named contract that shares another artifact's ABI. The latter is useful
+   * when multiple deployments (e.g. different ERC20 tokens) share one ABI.
+   *
+   * @example
+   * {
+   *   // `ERC20.json` artifact's own address
+   *   ERC20: '0x314159265dd8dbb310642f98f50c066173c1259b',
+   *   // additional named contracts sharing the `ERC20.json` artifact's ABI
+   *   DAI: { artifact: 'ERC20', address: '0x6b175474e89094c44da98b954eedeac495271d0' },
+   *   WETH: { artifact: 'ERC20', address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' },
+   * }
+   */
+  deployments?: { [key: string]: FoundryDeployment } | undefined
   /** Artifact files to exclude. */
   exclude?: string[] | undefined
   /** [Forge](https://book.getfoundry.sh/forge) configuration */
@@ -105,6 +121,33 @@ type FoundryResult = Compute<
   RequiredBy<Plugin, 'contracts' | 'validate' | 'watch'>
 >
 
+/** A named deployment that reuses another artifact's ABI (see {@link FoundryConfig.deployments}). */
+export type FoundryAliasDeployment = {
+  /** Address (or `{ [chainId]: address }` map) for this named deployment. */
+  address: ContractConfig['address']
+  /** Name of the artifact (e.g. `'ERC20'`) whose ABI this deployment reuses. */
+  artifact: string
+}
+
+type FoundryDeployment = ContractConfig['address'] | FoundryAliasDeployment
+
+function isAliasDeployment(
+  deployment: FoundryDeployment | undefined,
+): deployment is FoundryAliasDeployment {
+  return (
+    typeof deployment === 'object' &&
+    deployment !== null &&
+    'artifact' in deployment
+  )
+}
+
+function resolveAddress(
+  deployment: FoundryDeployment | undefined,
+): ContractConfig['address'] {
+  if (isAliasDeployment(deployment)) return deployment.address
+  return deployment
+}
+
 const FoundryConfigSchema = z.object({
   out: z.string().default('out'),
   src: z.string().default('src'),
@@ -138,15 +181,35 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
   async function getContract(
     artifactPath: string,
     contractDeployments: {
-      [key: string]: ContractConfig['address']
+      [key: string]: FoundryDeployment
     } = allDeployments,
   ) {
     const artifact = await JSON.parse(await readFile(artifactPath, 'utf8'))
     return {
       abi: artifact.abi,
-      address: contractDeployments[getContractName(artifactPath, false)],
+      address: resolveAddress(
+        contractDeployments[getContractName(artifactPath, false)],
+      ),
       name: getContractName(artifactPath),
     }
+  }
+
+  /**
+   * Additional contracts declared via `deployments` that alias another artifact's ABI
+   * (`{ artifact, address }`), scoped to a single artifact's name.
+   */
+  function getAliasContracts(artifactName: string, abi: unknown) {
+    const aliasContracts: ContractConfig[] = []
+    for (const [name, deployment] of Object.entries(allDeployments)) {
+      if (!isAliasDeployment(deployment)) continue
+      if (deployment.artifact !== artifactName) continue
+      aliasContracts.push({
+        abi: abi as ContractConfig['abi'],
+        address: deployment.address,
+        name: `${namePrefix}${name}`,
+      })
+    }
+    return aliasContracts
   }
 
   function getArtifactPaths(artifactsDirectory: string) {
@@ -277,6 +340,12 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
         const contract = await getContract(artifactPath, allDeployments)
         if (!contract.abi?.length) continue
         contracts.push(contract)
+        contracts.push(
+          ...getAliasContracts(
+            getContractName(artifactPath, false),
+            contract.abi,
+          ),
+        )
       }
       return contracts
     },
@@ -329,6 +398,10 @@ export function foundry(config: FoundryConfig = {}): FoundryResult {
         ...include.map((x) => `${artifactsDirectory}/**/${x}`),
         ...exclude.map((x) => `!${artifactsDirectory}/**/${x}`),
       ],
+      // Note: alias deployments (`deployments: { X: { artifact, address } }`) are only
+      // resolved by `contracts()`. `onAdd`/`onChange` can only return one `ContractConfig`
+      // per changed file, so during `--watch` a rebuild (`wagmi generate`) is needed to
+      // pick up alias contracts for a changed artifact.
       async onAdd(path) {
         return getContract(path)
       },

--- a/site/cli/api/plugins/foundry.md
+++ b/site/cli/api/plugins/foundry.md
@@ -74,7 +74,7 @@ export default defineConfig({
 
 ### deployments
 
-`{ [key: string]: address?: Address | Record<chainId, Address> | undefined } | undefined`
+`{ [key: string]: Address | Record<chainId, Address> | { artifact: string, address: Address | Record<chainId, Address> } | undefined } | undefined`
 
 Mapping of addresses to attach to artifacts.
 
@@ -95,6 +95,34 @@ export default defineConfig({
   ],
 })
 ```
+
+A key can also resolve to `{ artifact, address }` to generate an additional, separately named contract that shares another artifact's ABI — useful when multiple deployments (e.g. different ERC20 tokens) share one ABI.
+
+```ts
+import { defineConfig } from '@wagmi/cli'
+import { foundry } from '@wagmi/cli/plugins'
+
+export default defineConfig({
+  plugins: [
+    foundry({
+      deployments: { // [!code focus]
+        DAI: { // [!code focus]
+          artifact: 'ERC20', // [!code focus]
+          address: '0x6b175474e89094c44da98b954eedeac495271d0', // [!code focus]
+        }, // [!code focus]
+        WETH: { // [!code focus]
+          artifact: 'ERC20', // [!code focus]
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // [!code focus]
+        }, // [!code focus]
+      }, // [!code focus]
+    }),
+  ],
+})
+```
+
+:::: warning
+Alias deployments are only resolved by a full `wagmi generate` run. During `wagmi generate --watch`, a changed artifact only re-emits its own artifact-named contract — rerun `wagmi generate` to pick up alias contracts.
+::::
 
 ### exclude
 


### PR DESCRIPTION
Closes #4396

The `foundry` plugin's `deployments` map is keyed by artifact name, so it can't express two named contracts (e.g. `DAI` and `WETH`) that share one artifact's ABI with different addresses — one entry silently overwrites the other, and only one of the two ends up generated.

## What changed

Added a second `deployments` value shape, `{ artifact, address }`, that generates an additional named contract reusing another artifact's ABI:

```ts
foundry({
  deployments: {
    DAI: { artifact: 'ERC20', address: { 1: '0x...' } },
    WETH: { artifact: 'ERC20', address: { 1: '0x...' } },
  },
})
```

The existing plain-address shape (`deployments: { ERC20: { 1: '0x...' } }`) is unchanged and fully backward compatible — covered by a new regression test.

## Scope / limitation

Alias contracts are resolved by `contracts()` (i.e. a full `wagmi generate` run). `watch.onAdd`/`watch.onChange` can only return a single `ContractConfig` per changed file (per the existing `Watch` type), so during `wagmi generate --watch` a changed artifact only re-emits its own artifact-named contract — picking up alias contracts needs a rerun of `wagmi generate`. This is called out in the docs. Happy to extend `onAdd`/`onChange` to return multiple contracts in a follow-up if that's preferred, but wanted to keep this PR's surface area (and the shared `Watch` type used by every plugin) small.

## Prior attempt

#5011 attempted this earlier but grew into a larger watch-mode rework across several follow-up commits and was closed without a merge or review comment. This PR re-approaches the same issue with a smaller, additive change to keep it easy to review.

## Testing

- Added `deployments support multiple named contracts sharing one artifact ABI` and `deployments still support a plain address for the artifact itself` to `foundry.test.ts`
- `pnpm --filter @wagmi/cli check:types` passes
- `biome check` passes on changed files
- Verified the new logic against real `out/` artifacts locally with `forge: { build: false }` (this dev environment doesn't have Foundry installed, so I couldn't exercise the existing `forge build`-dependent tests locally, only my scoped verification — CI has Foundry installed and should run the full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)