### PR TITLE
fix(solid): preserve useInfiniteQuery queryKey

### DIFF
--- a/packages/solid/src/exports/query.test.ts
+++ b/packages/solid/src/exports/query.test.ts
@@ -1,3 +1,4 @@
+import { renderPrimitive } from '@wagmi/test/solid'
 import { expect, test } from 'vitest'
 
 import * as query from './query.js'
@@ -104,4 +105,19 @@ test('exports', () => {
       "writeContractSyncMutationOptions",
     ]
   `)
+})
+
+test('useInfiniteQuery exposes its query key', () => {
+  const queryKey = ['example', { page: 1 }] as const
+  const { result, cleanup } = renderPrimitive(() =>
+    query.useInfiniteQuery(() => ({
+      queryKey,
+      queryFn: async () => 'value',
+      initialPageParam: 0,
+      getNextPageParam: () => undefined,
+    })),
+  )
+
+  expect(result.queryKey).toEqual(queryKey)
+  cleanup()
 })

--- a/packages/solid/src/utils/query.ts
+++ b/packages/solid/src/utils/query.ts
@@ -164,8 +164,9 @@ export function useInfiniteQuery<
     ...(parameters() as any),
     queryKeyHashFn: hashFn, // for bigint support
   }))
-  return mergeProps(
-    result,
-    parameters().queryKey,
-  ) as unknown as UseInfiniteQueryReturnType<data, error>
+  return mergeProps(result, {
+    get queryKey() {
+      return parameters().queryKey
+    },
+  }) as unknown as UseInfiniteQueryReturnType<data, error>
 }


### PR DESCRIPTION
## Summary

- preserve `queryKey` on the Solid `useInfiniteQuery` return value
- add a focused regression test for the public return shape

`useInfiniteQuery` previously passed the query-key array as a positional `mergeProps` source, which spread array indexes onto the result instead of exposing `result.queryKey`. This keeps the wrapper consistent with Solid `useQuery` and the React/Vue infinite-query wrappers.

## Testing

- `pnpm --filter @wagmi/solid build`
- `pnpm exec vitest run --project solid packages/solid/src/exports/query.test.ts`