### PR TITLE
fix(core): catch connector.isAuthorized() rejection in reconnect and revalidate

### DIFF
--- a/packages/core/src/actions/reconnect.test.ts
+++ b/packages/core/src/actions/reconnect.test.ts
@@ -72,6 +72,31 @@ test("behavior: doesn't reconnect if already reconnecting", async () => {
   config.setState((x) => ({ ...x, status: previousStatus }))
 })
 
+test('behavior: connector.isAuthorized() rejects', async () => {
+  const rejectingConnector = config._internal.connectors.setup(
+    mock({
+      accounts,
+      features: {
+        reconnect: true,
+        defaultConnected: true,
+      },
+    }),
+  )
+  rejectingConnector.isAuthorized = async () => {
+    throw new Error('stale session')
+  }
+
+  await expect(
+    reconnect(config, { connectors: [rejectingConnector] }),
+  ).resolves.toStrictEqual([])
+  expect(config.state.status).toEqual('disconnected')
+
+  // subsequent reconnect should still be able to run
+  await expect(
+    reconnect(config, { connectors: [connector] }),
+  ).resolves.toStrictEqual([])
+})
+
 test('behavior: recovers from invalid state', async () => {
   const state = {
     'wagmi.store': JSON.stringify({

--- a/packages/core/src/actions/reconnect.ts
+++ b/packages/core/src/actions/reconnect.ts
@@ -25,103 +25,106 @@ export async function reconnect(
   if (isReconnecting) return []
   isReconnecting = true
 
-  config.setState((x) => ({
-    ...x,
-    status: x.current ? 'reconnecting' : 'connecting',
-  }))
-
-  const connectors: Connector[] = []
-  if (parameters.connectors?.length) {
-    for (const connector_ of parameters.connectors) {
-      let connector: Connector
-      // "Register" connector if not already created
-      if (typeof connector_ === 'function')
-        connector = config._internal.connectors.setup(connector_)
-      else connector = connector_
-      connectors.push(connector)
-    }
-  } else connectors.push(...config.connectors)
-
-  // Try recently-used connectors first
-  let recentConnectorId: string | null | undefined
   try {
-    recentConnectorId = await config.storage?.getItem('recentConnectorId')
-  } catch {}
-  const scores: Record<string, number> = {}
-  for (const [, connection] of config.state.connections) {
-    scores[connection.connector.id] = 1
-  }
-  if (recentConnectorId) scores[recentConnectorId] = 0
-  const sorted =
-    Object.keys(scores).length > 0
-      ? // .toSorted()
-        [...connectors].sort(
-          (a, b) => (scores[a.id] ?? 10) - (scores[b.id] ?? 10),
-        )
-      : connectors
+    config.setState((x) => ({
+      ...x,
+      status: x.current ? 'reconnecting' : 'connecting',
+    }))
 
-  // Iterate through each connector and try to connect
-  let connected = false
-  const connections: Connection[] = []
-  const providers: unknown[] = []
-  for (const connector of sorted) {
-    const provider = await connector.getProvider().catch(() => undefined)
-    if (!provider) continue
-
-    // If we already have an instance of this connector's provider,
-    // then we have already checked it (ie. injected connectors can
-    // share the same `window.ethereum` instance, so we don't want to
-    // connect to it again).
-    if (providers.some((x) => x === provider)) continue
-
-    const isAuthorized = await connector.isAuthorized()
-    if (!isAuthorized) continue
-
-    const data = await connector
-      .connect({ isReconnecting: true })
-      .catch(() => null)
-    if (!data) continue
-
-    connector.emitter.off('connect', config._internal.events.connect)
-    connector.emitter.on('change', config._internal.events.change)
-    connector.emitter.on('disconnect', config._internal.events.disconnect)
-
-    config.setState((x) => {
-      const connections = new Map(connected ? x.connections : new Map()).set(
-        connector.uid,
-        { accounts: data.accounts, chainId: data.chainId, connector },
-      )
-      return {
-        ...x,
-        current: connected ? x.current : connector.uid,
-        connections,
+    const connectors: Connector[] = []
+    if (parameters.connectors?.length) {
+      for (const connector_ of parameters.connectors) {
+        let connector: Connector
+        // "Register" connector if not already created
+        if (typeof connector_ === 'function')
+          connector = config._internal.connectors.setup(connector_)
+        else connector = connector_
+        connectors.push(connector)
       }
-    })
-    connections.push({
-      accounts: data.accounts as readonly [Address, ...Address[]],
-      chainId: data.chainId,
-      connector,
-    })
-    providers.push(provider)
-    connected = true
-  }
+    } else connectors.push(...config.connectors)
 
-  // Prevent overwriting connected status from race condition
-  if (
-    config.state.status === 'reconnecting' ||
-    config.state.status === 'connecting'
-  ) {
-    // If connecting didn't succeed, set to disconnected
-    if (!connected)
-      config.setState((x) => ({
-        ...x,
-        connections: new Map(),
-        current: null,
-        status: 'disconnected',
-      }))
-    else config.setState((x) => ({ ...x, status: 'connected' }))
-  }
+    // Try recently-used connectors first
+    let recentConnectorId: string | null | undefined
+    try {
+      recentConnectorId = await config.storage?.getItem('recentConnectorId')
+    } catch {}
+    const scores: Record<string, number> = {}
+    for (const [, connection] of config.state.connections) {
+      scores[connection.connector.id] = 1
+    }
+    if (recentConnectorId) scores[recentConnectorId] = 0
+    const sorted =
+      Object.keys(scores).length > 0
+        ? // .toSorted()
+          [...connectors].sort(
+            (a, b) => (scores[a.id] ?? 10) - (scores[b.id] ?? 10),
+          )
+        : connectors
 
-  isReconnecting = false
-  return connections
+    // Iterate through each connector and try to connect
+    let connected = false
+    const connections: Connection[] = []
+    const providers: unknown[] = []
+    for (const connector of sorted) {
+      const provider = await connector.getProvider().catch(() => undefined)
+      if (!provider) continue
+
+      // If we already have an instance of this connector's provider,
+      // then we have already checked it (ie. injected connectors can
+      // share the same `window.ethereum` instance, so we don't want to
+      // connect to it again).
+      if (providers.some((x) => x === provider)) continue
+
+      const isAuthorized = await connector.isAuthorized().catch(() => false)
+      if (!isAuthorized) continue
+
+      const data = await connector
+        .connect({ isReconnecting: true })
+        .catch(() => null)
+      if (!data) continue
+
+      connector.emitter.off('connect', config._internal.events.connect)
+      connector.emitter.on('change', config._internal.events.change)
+      connector.emitter.on('disconnect', config._internal.events.disconnect)
+
+      config.setState((x) => {
+        const connections = new Map(connected ? x.connections : new Map()).set(
+          connector.uid,
+          { accounts: data.accounts, chainId: data.chainId, connector },
+        )
+        return {
+          ...x,
+          current: connected ? x.current : connector.uid,
+          connections,
+        }
+      })
+      connections.push({
+        accounts: data.accounts as readonly [Address, ...Address[]],
+        chainId: data.chainId,
+        connector,
+      })
+      providers.push(provider)
+      connected = true
+    }
+
+    // Prevent overwriting connected status from race condition
+    if (
+      config.state.status === 'reconnecting' ||
+      config.state.status === 'connecting'
+    ) {
+      // If connecting didn't succeed, set to disconnected
+      if (!connected)
+        config.setState((x) => ({
+          ...x,
+          connections: new Map(),
+          current: null,
+          status: 'disconnected',
+        }))
+      else config.setState((x) => ({ ...x, status: 'connected' }))
+    }
+
+    return connections
+  } finally {
+    isReconnecting = false
+  }
 }

--- a/packages/core/src/createConfig.test.ts
+++ b/packages/core/src/createConfig.test.ts
@@ -483,6 +483,32 @@ test('behavior: revalidate connections', async () => {
   expect([...config.state.connections.keys()]).toEqual([c2.uid])
 })
 
+test('behavior: revalidate handles connector.isAuthorized() rejection', async () => {
+  const config = createConfig({
+    chains: [mainnet],
+    connectors: [
+      mock({ accounts, features: { defaultConnected: true, reconnect: true } }),
+    ],
+    storage: null,
+    transports: {
+      [mainnet.id]: http(),
+    },
+  })
+
+  const c1 = config.connectors.at(0)!
+  c1.isAuthorized = async () => {
+    throw new Error('revalidation error')
+  }
+
+  const connections = new Map<string, Connection>()
+  connections.set(c1.uid, { accounts: ['0x'], chainId: 1, connector: c1 })
+  config.setState((state) => ({ ...state, connections, current: c1.uid }))
+
+  await expect(config._internal.revalidate()).resolves.toBeUndefined()
+  expect(config.state.connections.size).toEqual(0)
+  expect(config.state.current).toBeNull()
+})
+
 function getProviderDetail(
   info: Pick<EIP6963ProviderDetail['info'], 'name' | 'rdns'>,
 ): EIP6963ProviderDetail {

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -466,14 +466,14 @@ export function createConfig<
       async revalidate() {
         // Check connections to see if they are still active
         const state = store.getState()
-        const connections = state.connections
+        const connections = new Map(state.connections)
         let current = state.current
-        for (const [, connection] of connections) {
+        for (const [, connection] of state.connections) {
           const connector = connection.connector
           // check if `connect.isAuthorized` exists
           // partial connectors in storage do not have it
           const isAuthorized = connector.isAuthorized
-            ? await connector.isAuthorized()
+            ? await connector.isAuthorized().catch(() => false)
             : false
           if (isAuthorized) continue
           // Remove stale connection


### PR DESCRIPTION
## Problem

When a connector's `isAuthorized()` method throws or rejects (e.g. stale WalletConnect session, unreachable relay, or transport network failure), `reconnect()` and `createConfig`'s `revalidate()` fail unhandled. This left the config state permanently stranded in the `reconnecting` status and kept the internal `isReconnecting` lock flag `true`, preventing all subsequent reconnection attempts from running.

## Cause

`reconnect()` and `createConfig.revalidate()` awaited `connector.isAuthorized()` without a `.catch()` handler, unlike neighboring `connector.getProvider()` and `connector.connect()`. A thrown rejection propagated out of the function before `isReconnecting` could be reset and before `config.setState` could update the status to `disconnected`.

## Fix

- Added `.catch(() => false)` to `connector.isAuthorized()` in `packages/core/src/actions/reconnect.ts` and `packages/core/src/createConfig.ts`.
- Wrapped the body of `reconnect` in a `try ... finally` block to guarantee `isReconnecting` is reset to `false` even if unexpected errors occur.
- Replaced in-place mutation of `state.connections` during `revalidate()` with a fresh `Map` copy so state subscribers receive proper updates.

## Testing

- Added unit tests in `packages/core/src/actions/reconnect.test.ts` and `packages/core/src/createConfig.test.ts` verifying that `reconnect` and `revalidate` recover gracefully when `isAuthorized` rejects and allow subsequent reconnect calls to succeed.