### PR TITLE
docs(vue): add Nuxt SSR cookie hydration guide

### DIFF
--- a/site/vue/api/utilities/cookieToInitialState.md
+++ b/site/vue/api/utilities/cookieToInitialState.md
@@ -1,0 +1,9 @@
+---
+title: cookieToInitialState
+---
+
+<script setup>
+const packageName = '@wagmi/vue'
+</script>
+
+<!--@include: @shared/utilities/cookieToInitialState.md-->

--- a/site/vue/guides/ssr.md
+++ b/site/vue/guides/ssr.md
@@ -66,12 +66,29 @@ Next, we will need to add some mechanisms to hydrate the stored cookie in Wagmi.
 
 #### Nuxt.js
 
-Would you like to contribute this content? Feel free to [open a Pull Request](https://github.com/wevm/wagmi/pulls)!
-<!-- TODO -->
+In a Nuxt plugin, read the request's `cookie` header on the server and pass the result of [`cookieToInitialState`](/vue/api/utilities/cookieToInitialState) to [`WagmiPlugin`](/vue/api/WagmiPlugin) as `initialState`.
+
+::: code-group
+```ts [plugins/wagmi.ts]
+import { useRequestHeaders } from '#imports'
+import { cookieToInitialState, WagmiPlugin } from '@wagmi/vue'
+
+import { config } from '~/config'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const cookie = useRequestHeaders(['cookie']).cookie
+  const initialState = cookieToInitialState(config, cookie)
+
+  nuxtApp.vueApp.use(WagmiPlugin, {
+    config,
+    initialState,
+  })
+})
+```
+:::
 
 #### Vanilla SSR
 
 Would you like to contribute this content? Feel free to [open a Pull Request](https://github.com/wevm/wagmi/pulls)!
 <!-- TODO -->
-
 


### PR DESCRIPTION
## Summary
- add the missing Vue `cookieToInitialState` API page
- replace the Nuxt.js SSR TODO with a minimal `useRequestHeaders` + `WagmiPlugin` hydration example

## Validation
- `git diff --check`
- `pnpm --filter site build` could not start because Corepack failed to download pnpm 10.22.0 (`ECONNRESET`).